### PR TITLE
fix: add default values for ingress_expiry

### DIFF
--- a/packages/agent/src/actor.test.ts
+++ b/packages/agent/src/actor.test.ts
@@ -158,6 +158,7 @@ test('makeActor', async () => {
         content: {
           request_type: 'request_status',
           request_id: expectedCallRequestId,
+          ingress_expiry: new Expiry(300000),
         },
         sender_pubkey: senderPubKey,
         sender_sig: senderSig,
@@ -175,6 +176,7 @@ test('makeActor', async () => {
       content: {
         request_type: 'request_status',
         request_id: expectedCallRequestId,
+        ingress_expiry: new Expiry(300000),
       },
       sender_pubkey: senderPubKey,
       sender_sig: senderSig,
@@ -191,6 +193,7 @@ test('makeActor', async () => {
       content: {
         request_type: 'request_status',
         request_id: expectedCallRequestId,
+        ingress_expiry: new Expiry(300000),
       },
       sender_pubkey: senderPubKey,
       sender_sig: senderSig,
@@ -207,6 +210,7 @@ test('makeActor', async () => {
       content: {
         request_type: 'request_status',
         request_id: expectedCallRequestId,
+        ingress_expiry: new Expiry(300000),
       },
       sender_pubkey: senderPubKey,
       sender_sig: senderSig,

--- a/packages/agent/src/agent/http.ts
+++ b/packages/agent/src/agent/http.ts
@@ -30,6 +30,9 @@ import { BinaryBlob, blobFromHex, JsonObject } from '../types';
 
 const API_VERSION = 'v1';
 
+// Default delta for ingress expiry is 5 minutes.
+const DEFAULT_INGRESS_EXPIRY_DELTA_IN_MSECS = 5 * 60 * 1000;
+
 // HttpAgent options that can be used at construction.
 export interface HttpAgentOptions {
   // Another HttpAgent to inherit configuration (pipeline and fetch) of. This
@@ -150,7 +153,7 @@ export class HttpAgent implements Agent {
       method_name: fields.methodName,
       arg: fields.arg,
       sender: p.toBlob(),
-      ingress_expiry: new Expiry(300000),
+      ingress_expiry: new Expiry(DEFAULT_INGRESS_EXPIRY_DELTA_IN_MSECS),
     });
   }
 
@@ -174,7 +177,7 @@ export class HttpAgent implements Agent {
       module: fields.module,
       arg: fields.arg || blobFromHex(''),
       sender: p.toBlob(),
-      ingress_expiry: new Expiry(300000),
+      ingress_expiry: new Expiry(DEFAULT_INGRESS_EXPIRY_DELTA_IN_MSECS),
     });
   }
 
@@ -188,7 +191,7 @@ export class HttpAgent implements Agent {
     return this.submit({
       request_type: SubmitRequestType.CreateCanister,
       sender: p.toBlob(),
-      ingress_expiry: new Expiry(300000),
+      ingress_expiry: new Expiry(DEFAULT_INGRESS_EXPIRY_DELTA_IN_MSECS),
     });
   }
 
@@ -209,7 +212,7 @@ export class HttpAgent implements Agent {
       method_name: fields.methodName,
       arg: fields.arg,
       sender: p.toBlob(),
-      ingress_expiry: new Expiry(300000),
+      ingress_expiry: new Expiry(DEFAULT_INGRESS_EXPIRY_DELTA_IN_MSECS),
     }) as Promise<QueryResponse>;
   }
 
@@ -226,6 +229,7 @@ export class HttpAgent implements Agent {
     return this.read({
       request_type: ReadRequestType.RequestStatus,
       request_id: fields.requestId,
+      ingress_expiry: new Expiry(DEFAULT_INGRESS_EXPIRY_DELTA_IN_MSECS),
     }) as Promise<RequestStatusResponse>;
   }
 

--- a/packages/agent/src/http_agent.test.ts
+++ b/packages/agent/src/http_agent.test.ts
@@ -150,6 +150,7 @@ test('requestStatus', async () => {
     content: {
       request_type: ReadRequestType.RequestStatus,
       request_id: requestId,
+      ingress_expiry: new Expiry(300000),
     },
     sender_pubkey: senderPubKey,
     sender_sig: Buffer.from([0]) as SenderSig,

--- a/packages/agent/src/http_agent_transforms.ts
+++ b/packages/agent/src/http_agent_transforms.ts
@@ -21,6 +21,7 @@ export class Expiry {
   }
 
   public toCBOR(): cbor.CborValue {
+    // TODO: change this to take the minimum amount of space (it always takes 8 bytes now).
     return cbor.value.u64(this._value.toString(16), 16);
   }
 

--- a/packages/agent/src/http_agent_types.ts
+++ b/packages/agent/src/http_agent_types.ts
@@ -154,6 +154,7 @@ export interface QueryRequest extends Record<string, any> {
 export interface RequestStatusRequest extends Record<string, any> {
   request_type: ReadRequestType.RequestStatus;
   request_id: RequestId;
+  ingress_expiry: Expiry;
 }
 
 // An ADT that represents responses to a "request_status" read request.


### PR DESCRIPTION
It was set when using the transform, but you shouldn't require the transform to work (there should be a sensible default).