### PR TITLE
feat: add the canister ID to the window.ic object

### DIFF
--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -332,7 +332,7 @@ async function _requestStatusAndLoop<T>(
       // we don't know the result and cannot decode it.
       throw new Error(
         `Call was marked as done but we never saw the reply:\n` +
-        `  Request ID: ${requestIdToHex(requestId)}\n`
+        `  Request ID: ${requestIdToHex(requestId)}\n`,
       );
   }
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,3 +1,5 @@
+import { ActorSubclass } from './actor';
+
 export * from './actor';
 export * from './agent';
 export {
@@ -26,12 +28,20 @@ import * as UICore from './candid/candid-core';
 import * as UI from './candid/candid-ui';
 export { UICore, UI };
 
-import { Principal } from './principal';
 export interface GlobalInternetComputer {
   ic: {
     agent: Agent;
     HttpAgent: typeof HttpAgent;
     IDL: typeof IDL;
-    canisterId: Principal | undefined,
+
+    /**
+     * The Actor for the canister being used for the frontend. Normally should correspond to the
+     * canister represented by the canister id in the URL.
+     *
+     * It does not have any functions configured.
+     *
+     * If a canister ID could not be found, no actor were created and this is undefined.
+     */
+    canister: ActorSubclass<{}> | undefined,
   };
 }

--- a/packages/bootstrap/src/index.ts
+++ b/packages/bootstrap/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  Actor,
   createAssetCanisterActor,
   GlobalInternetComputer,
   HttpAgent,
@@ -48,9 +49,14 @@ async function _main() {
   const site = await SiteInfo.fromWindow();
   const agent = await createAgent(site);
 
-  // Find the canister ID. Allow override from the url with 'canister_id=1234..'
+  // Find the canister ID. Allow override from the url with 'canister_id=1234..'.
   const canisterId = site.principal;
-  window.ic = { agent, HttpAgent, IDL, canisterId };
+  window.ic = {
+    agent,
+    canister: canisterId && Actor.createActor(({ IDL: IDL_ }) => IDL_.Service({}), { canisterId }),
+    HttpAgent,
+    IDL,
+  };
 
   if (!canisterId) {
     // Show an error.


### PR DESCRIPTION
This can be useful to know the canister ID of the current frontend.