### PR TITLE
ci: fix setup-haskell step

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -35,12 +35,10 @@ jobs:
           ~/.cabal/store
         key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-store
 
-    - uses: actions/setup-haskell@v1.1
+    - uses: actions/setup-haskell@v1.1.3
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: '3.2'
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     - name: Cargo cache
       uses: actions/cache@v2


### PR DESCRIPTION
See https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/

The setup-haskell step, previous of versions 1.1.3, was not updated properly for the change. Just using a sliding `v1.1` was apparently not enough to get the latest, so we force it.