### PR TITLE
feat(identity-provider): ic-id-protocol updates: response has no redirectUri. request.state is echoed back in response.state

### DIFF
--- a/packages/identity-provider/src/authorization/components/SessionAuthorization.tsx
+++ b/packages/identity-provider/src/authorization/components/SessionAuthorization.tsx
@@ -41,7 +41,7 @@ export default function SessionAuthorization(props: PropsWithoutRef<SessionAutho
       const options = {
         previous,
       };
-      const tomorrow = new Date(Date.now() + 15 * 60 * 1000);
+      const tomorrow = new Date(Date.now() + (1000 * 60 * 60 * 24))
       const sessionChain = await DelegationChain.create(from, to, tomorrow, options);
       auth.setSessionDelegationChain(sessionChain);
     }

--- a/packages/identity-provider/src/authorization/routes/Authorization.tsx
+++ b/packages/identity-provider/src/authorization/routes/Authorization.tsx
@@ -1,8 +1,9 @@
-import { PublicKey } from '@dfinity/agent';
+import { PublicKey, blobFromHex } from '@dfinity/agent';
 import {
   Bip39Ed25519KeyIdentity,
   DelegationChain,
   Ed25519KeyIdentity,
+  Ed25519PublicKey,
 } from '@dfinity/authentication';
 import Typography from '@material-ui/core/Typography';
 import Stepper from '@material-ui/core/Stepper';
@@ -37,13 +38,12 @@ import * as icid from '../../protocol/ic-id-protocol';
 export function AuthorizationRoute() {
   const auth = useAuth();
   const location = useLocation();
-
-  const [redirectURI, setRedirectURI] = React.useState('');
+  const [authenticationRequest, setAuthenticationRequest] = React.useState<icid.IDPAuthenticationRequest>()
   const [activeStep, setActiveStep] = React.useState(0);
 
   // Redirect to relying party with proper query parameters
   function handleRedirect() {
-    if (auth && auth.sessionDelegationChain) {
+    if (auth && auth.sessionDelegationChain && authenticationRequest) {
       // @TODO(bengo) - make this a hex(cborEncode(ICAuthenticationResponse))
       // where ICAuthenticationResponse({ sender_delegation, ... })
       const accessToken = icid.createBearerToken({ delegationChain: auth.sessionDelegationChain });
@@ -53,17 +53,19 @@ export function AuthorizationRoute() {
       const icAuthResponse: icid.ICAuthenticationResponse = {
         accessToken,
         expiresIn,
-        redirectURI,
         tokenType,
+        ...(authenticationRequest?.state && {
+          state: authenticationRequest.state,
+        }),
       };
       const oauth2AcessTokenResponse = icid.toOAuth2(icAuthResponse);
 
       console.debug('new AccessTokenResponse: ', JSON.stringify(oauth2AcessTokenResponse, null, 2));
 
       const finalRedirectUri = (() => {
-        const _finalRedirectUri = new URL(redirectURI);
+        const _finalRedirectUri = new URL(authenticationRequest.redirectUri.toString());
         for (const [key, value] of Object.entries(oauth2AcessTokenResponse)) {
-          _finalRedirectUri.searchParams.append(key, value);
+          _finalRedirectUri.searchParams.set(key, value);
         }
         return _finalRedirectUri;
       })();
@@ -72,14 +74,27 @@ export function AuthorizationRoute() {
   }
 
   // every time our query parameters change, we should try to get login hint and redirect from them
-  React.useEffect(() => {
-    try {
-      const params = getRequiredQueryParams(location.search);
-      setRedirectURI(params.redirectURI);
-    } catch (error) {
-      console.error(error);
-    }
-  }, [location.search]);
+  React.useEffect(
+    () => {
+      const searchParams = new URLSearchParams(location.search);
+      const redirectUriString = searchParams.get('redirect_uri');
+      const redirectUri = redirectUriString && new URL(redirectUriString)
+      const loginHintString = searchParams.get('login_hint');
+      const sessionIdentity = loginHintString && Ed25519PublicKey.fromDer(blobFromHex(loginHintString))
+      const state = searchParams.get('state');
+      if (redirectUri && sessionIdentity) {
+        const authenticationRequest: icid.IDPAuthenticationRequest = {
+          redirectUri,
+          sessionIdentity,
+          ...(state && { state }),
+        }
+        setAuthenticationRequest(authenticationRequest)
+      } else {
+        setAuthenticationRequest(undefined);
+      }
+    },
+    [location.search]
+  )
 
   React.useEffect(() => {
     if (auth.rootIdentity) {
@@ -99,7 +114,11 @@ export function AuthorizationRoute() {
   function handleDecline() {
     // handle declining authorization at any step
     // @todo(andrew): handle different scenarios with different descriptions
-    const redirect = new URL(redirectURI);
+    if ( ! authenticationRequest) {
+      console.warn('handleDecline called without an authenticationRequest. Returning early.')
+      return;
+    }
+    const redirect = new URL(authenticationRequest.redirectUri.toString());
     redirect.searchParams.append('error', 'access_denied');
     redirect.searchParams.append('error_description', 'User denied authorization');
     window.location.assign(redirect.href);

--- a/packages/identity-provider/src/protocol/ic-id-protocol.test.ts
+++ b/packages/identity-provider/src/protocol/ic-id-protocol.test.ts
@@ -40,9 +40,6 @@ describe('ic-id-protocol', () => {
     );
     expect(authenticationResponse.accessToken).toStrictEqual('accessTokenValue');
     expect(authenticationResponse.tokenType).toStrictEqual('bearer');
-    expect(authenticationResponse.redirectURI).toStrictEqual(
-      'http://localhost:8080/relying-party-demo/oauth/redirect_uri',
-    );
     expect(authenticationResponse.expiresIn).toStrictEqual(2099000000);
   });
   it('can create a bearer token', () => {

--- a/packages/identity-provider/src/protocol/ic-id-protocol.ts
+++ b/packages/identity-provider/src/protocol/ic-id-protocol.ts
@@ -9,7 +9,6 @@ import { hexEncodeUintArray, hexToBytes } from '../bytes';
 import { DelegationChain } from '@dfinity/authentication';
 
 export interface ICAuthenticationResponse {
-  redirectURI: string;
   accessToken: string;
   tokenType: 'bearer';
   expiresIn: number;
@@ -25,6 +24,7 @@ export interface ICAuthenticationResponse {
 export interface IDPAuthenticationRequest {
   sessionIdentity: PublicKey;
   redirectUri: URL;
+  state?: string;
 }
 
 /**
@@ -36,13 +36,13 @@ export function toOAuth2(message: ICAuthenticationResponse) {
     accessToken: access_token,
     expiresIn: expires_in,
     tokenType: token_type,
-    redirectURI: redirect_uri,
+    state,
   } = message;
   const oauth2AccessTokenResponse: OAuth2AccessTokenResponse = {
     access_token,
     expires_in,
     token_type,
-    redirect_uri,
+    state,
   };
   return oauth2AccessTokenResponse;
 }
@@ -60,7 +60,6 @@ export function fromOAuth2(message: OAuth2AccessTokenResponse) {
     accessToken: message.access_token,
     expiresIn: message.expires_in,
     tokenType: message.token_type,
-    redirectURI: message.redirect_uri,
   };
   return authenticationResponse;
 }

--- a/packages/identity-provider/src/protocol/oauth2.test.ts
+++ b/packages/identity-provider/src/protocol/oauth2.test.ts
@@ -9,9 +9,6 @@ describe('oauth2', () => {
     );
     expect(accessTokenResponse.access_token).toStrictEqual('accessTokenValue');
     expect(accessTokenResponse.token_type).toStrictEqual('bearer');
-    expect(accessTokenResponse.redirect_uri).toStrictEqual(
-      'http://localhost:8080/relying-party-demo/oauth/redirect_uri',
-    );
     expect(accessTokenResponse.expires_in).toStrictEqual(2099000000);
   });
 });

--- a/packages/identity-provider/src/protocol/oauth2.ts
+++ b/packages/identity-provider/src/protocol/oauth2.ts
@@ -2,7 +2,6 @@ import * as assert from 'assert';
 
 // https://tools.ietf.org/html/rfc6749#section-4.2.2
 export interface OAuth2AccessTokenResponse {
-  redirect_uri: string;
   access_token: string; // REQUIRED.  The access token issued by the authorization server.
   token_type: 'bearer' | 'mac'; // default 'bearer' REQUIRED.  The type of the token issued as described in Section 7.1.
   expires_in: number; // The lifetime in seconds of the access token.
@@ -43,7 +42,6 @@ export function fromQueryString(searchParams: URLSearchParams): OAuth2AccessToke
     access_token,
     expires_in,
     token_type,
-    redirect_uri,
   };
   return response;
 }


### PR DESCRIPTION
* `state` via https://tools.ietf.org/html/rfc6749#section-4.1.1