### PR TITLE
fix: add Buffer import to principal

### DIFF
--- a/packages/agent/src/principal.ts
+++ b/packages/agent/src/principal.ts
@@ -1,4 +1,5 @@
 import base32 from 'base32.js';
+import { Buffer } from 'buffer/';
 import { BinaryBlob, blobFromHex, blobFromUint8Array, blobToHex } from './types';
 import { getCrc32 } from './utils/getCrc';
 import { sha224 } from './utils/sha224';


### PR DESCRIPTION
Otherwise toText() wont work in browsers that import agent directly.