### PR TITLE
chore: set package-lock.json as binary files in git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-package-lock.json   -text
+package-lock.json binary !text


### PR DESCRIPTION
If we should not look at them, they should not show up in diffs.