### PR TITLE
build: split chunks on webpack to have smaller TTI

### DIFF
--- a/apps/identity-provider/src/design-phase-1/index.tsx
+++ b/apps/identity-provider/src/design-phase-1/index.tsx
@@ -1,1 +1,2 @@
-export { default as Route } from './ui/route';
+import Route from './ui/route';
+export default Route;

--- a/apps/identity-provider/src/index.html
+++ b/apps/identity-provider/src/index.html
@@ -1,21 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <script src="http://localhost:8097"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Identity Provider</title>
-    <style>
-      .ic_progress {
-        display: block;
-        margin: 50vh auto;
-        width: 25vw;
-      }
-    </style>
   </head>
   <body>
-    <app id="identity-provider">
-      <progress class="ic_progress" id="ic-progress">Loading...</progress>
-    </app>
+    <app id="identity-provider"></app>
   </body>
 </html>

--- a/apps/identity-provider/src/index.tsx
+++ b/apps/identity-provider/src/index.tsx
@@ -8,9 +8,7 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { IDPRootErrorBoundary } from './ErrorBoundary';
 import theme from './theme';
 import NotFound from './routes/NotFound';
-import RelyingPartyDemoRoute from './relying-party-demo/routes';
 import { RelyingPartyDemoIdentityChangedEventIdentifier } from './relying-party-demo/events';
-import { Route as DesignPhase1Route } from './design-phase-1';
 import { WebAuthnIdentity } from '@dfinity/authentication';
 
 const NotFoundRoute = () => {
@@ -18,6 +16,9 @@ const NotFoundRoute = () => {
 };
 
 const App = () => {
+  const RelyingPartyDemoRoute = React.lazy(() => import('./relying-party-demo/routes'));
+  const DesignPhase1Route = React.lazy(() => import('./design-phase-1'));
+
   return (
     <IDPRootErrorBoundary>
       <ThemeProvider theme={theme}>

--- a/apps/identity-provider/webpack.config.js
+++ b/apps/identity-provider/webpack.config.js
@@ -82,14 +82,30 @@ const productionConfig = {
         },
       }),
     ],
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        dfinity: {
+          test: /[\\/]packages[\\/](agent|authentication)[\\/]/,
+          name: 'dfinity',
+          chunks: 'initial',
+        },
+        react: {
+          test: /[\\/]node_modules[\\/]react(-dom)?[\\/]/,
+          name: 'react',
+          chunks: 'initial',
+        },
+        commons: {
+          test: /[\\/]node_modules[\\/]/,
+          name: "vendor",
+          chunks: "initial",
+        },
+      },
+    },
   },
 };
 
 const developmentConfig = {
-  optimization: {
-    minimize: false,
-    minimizer: undefined,
-  },
   mode: 'development',
   devServer: {
     contentBase: './dist',
@@ -109,6 +125,9 @@ module.exports = (env) => {
   if (env === "development") {
     return merge(commonConfig, developmentConfig);
   } else if (env === "production") {
+    return merge(commonConfig, productionConfig);
+  } else if (env === undefined) {
+    console.error("No environment specified, defaulting to prod.")
     return merge(commonConfig, productionConfig);
   } else {
     throw new Error(`Invalid environment name: "${JSON.stringify(env)}"`);


### PR DESCRIPTION
Also removed the script in index.html which is not needed.

Also added a default if `--env` arg isn't passed to webpack. Happens to the best of us.