### PR TITLE
fix: idp logic error in createSendResponseUri where resulting encoded AuthenticationResponse was not toOAuth

### DIFF
--- a/packages/authentication/src/idp-protocol/oauth2.ts
+++ b/packages/authentication/src/idp-protocol/oauth2.ts
@@ -3,7 +3,7 @@
  */
 
 // https://tools.ietf.org/html/rfc6749#section-4.2.2
-export interface OAuth2AccessTokenResponse {
+export type OAuth2AccessTokenResponse = {
   access_token: string; // REQUIRED.  The access token issued by the authorization server.
   token_type: 'bearer'; // default 'bearer' REQUIRED.  The type of the token issued as described in Section 7.1.
   expires_in: number; // The lifetime in seconds of the access token.

--- a/packages/authentication/src/idp-protocol/response.test.ts
+++ b/packages/authentication/src/idp-protocol/response.test.ts
@@ -96,7 +96,7 @@ test('ic-id-protocol/response createSendResponseUri', async () => {
   const responseUri = icidResponse.createSendResponseUri(new URL(redirectUri), authenticationResponse);
   expect(responseUri).toBeTruthy();
   expect(typeof responseUri).toEqual('string')
-  expect(responseUri).toEqual(`${redirectUri}#accessToken=accessTokenValue&expiresIn=2099000000&scope=a+b&tokenType=bearer&type=AuthenticationResponse`)
+  expect(responseUri).toEqual(`${redirectUri}#access_token=accessTokenValue&expires_in=2099000000&scope=a+b&token_type=bearer`)
 });
 
 describe('ic-id-protocol parseScopeString', () => {

--- a/packages/authentication/src/idp-protocol/response.ts
+++ b/packages/authentication/src/idp-protocol/response.ts
@@ -159,7 +159,7 @@ export function createSendResponseUri(redirectUri: URL, authenticationResponse: 
   }
   const responseUri = (() => {
     const _responseUrl = new URL(redirectUri.toString());
-    _responseUrl.hash = `#${queryStringify(authenticationResponse, true)}`
+    _responseUrl.hash = `#${queryStringify(toOauth(authenticationResponse), true)}`
     return _responseUrl.toString();
   })();
   return responseUri;


### PR DESCRIPTION
, leading to ?accessToken not ?access_token

Motivation: https://github.com/dfinity/agent-js/issues/257