### PR TITLE
fix: Changes redirect to occur after authentication complete

### DIFF
--- a/apps/identity-provider/src/design-phase-1/ui/route.tsx
+++ b/apps/identity-provider/src/design-phase-1/ui/route.tsx
@@ -162,13 +162,14 @@ export default function FlowRoute(props: {
               exact
               path={urls.session.consent}
               component={() => {
-                const authenticationRequestHasConsent = React.useMemo(() => {
-                  const { request, consent } = state.authentication;
+                const authenticationRequestHasConsentAndResponse = React.useMemo(() => {
+                  const { request, consent, response } = state.authentication;
                   if (!consent) return false;
-                  return JSON.stringify(request) === JSON.stringify(consent.proposal.request);
+                  const consentMatch = JSON.stringify(request) === JSON.stringify(consent.proposal.request);
+                  return consentMatch && !!response
                 }, [state.authentication]);
                 /** If the we've already consented to this request, redirect to next screen. */
-                if (authenticationRequestHasConsent) {
+                if (authenticationRequestHasConsentAndResponse) {
                   return <Redirect to={urls.response.confirmation} />;
                 }
                 return (


### PR DESCRIPTION
This is a simple design fix so you only redirect to the confirm page after you've authenticated with touch id or key. Previously you would redirect to page as you were authenticated and would see a authentication error in the background.

Working towards https://github.com/dfinity/agent-js/issues/275