### PR TITLE
fix: dont use typescript 'as string' override in idp-protocol/request

### DIFF
--- a/packages/authentication/src/idp-protocol/request.ts
+++ b/packages/authentication/src/idp-protocol/request.ts
@@ -73,7 +73,7 @@ export function fromQueryString(params: URLSearchParams): AuthenticationRequest 
     },
     redirectUri: oauth2Request.redirect_uri,
     state: oauth2Request.state,
-    scope: oauth2Request.scope as string,
+    scope: oauth2Request.scope ?? '',
   };
   return authenticationRequest;
 }


### PR DESCRIPTION
I think this might be safer because it's not overriding the type inference

Motivation:
* https://github.com/dfinity/agent-js/pull/272/files#r591928099