### PR TITLE
fix: yubi key auth on chrome

### DIFF
--- a/packages/authentication/src/identity/webauthn.ts
+++ b/packages/authentication/src/identity/webauthn.ts
@@ -95,6 +95,7 @@ async function _createCredential(): Promise<PublicKeyCredential | null> {
       authenticatorSelection: {
         userVerification: 'preferred',
       },
+      attestation: 'direct',
       challenge: _createChallengeBuffer(),
       pubKeyCredParams: [{ type: 'public-key', alg: PubKeyCoseAlgo.ECDSA_WITH_SHA256 }],
       rp: {


### PR DESCRIPTION
Both of these options were added from official Safari documentation on how to get touch id working. They are both too perscriptive on telling the browser to authenticate with touch id, which ended up breaking yubi key auth on chrome. The `authenticatorAttachment` field was telling the browser to prefer a platform-specific vs cross-platform auth device, which was breaking the yubi flow with chrome (it was asking for a password along with the yubi key). The `transports` field was similar in that it was telling the browser the preferred way to find credentials, in which case chrome wouldn't look for the yubi key (which would be the `usb` transport, instead trying to find a touch id. 

I believe the Safari docs that said to use these options were for an earlier version of safari where they may have been required, but after testing the removal of these options on Safari with Big Sur, both touch id and yubi keys work fine.

Tested touch id and yubi key on: Safari, Big Sur, Chrome@latest, Firefox@latest (Firefox latest doesn't have touch id implemented yet)