### PR TITLE
chore: v0.6.26-beta.1

### DIFF
--- a/apps/bootstrap/package-lock.json
+++ b/apps/bootstrap/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/bootstrap",
-	"version": "0.6.26-beta.0",
+	"version": "0.6.26-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/bootstrap",
-			"version": "0.6.26-beta.0",
+			"version": "0.6.26-beta.1",
 			"dependencies": {
 				"bignumber.js": "^9.0.0",
 				"buffer": "5.6.0",

--- a/apps/bootstrap/package.json
+++ b/apps/bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/bootstrap",
-  "version": "0.6.26-beta.0",
+  "version": "0.6.26-beta.1",
   "private": true,
   "main": "ts-out/packages/bootstrap/src",
   "scripts": {
@@ -51,8 +51,8 @@
     "worker-plugin": "^4.0.3"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.6.26-beta.0",
-    "@dfinity/authentication": "^0.6.26-beta.0",
+    "@dfinity/agent": "^0.6.26-beta.1",
+    "@dfinity/authentication": "^0.6.26-beta.1",
     "bignumber.js": "^9.0.0",
     "buffer": "5.6.0",
     "css-loader": "^3.4.2",

--- a/e2e/node/package-lock.json
+++ b/e2e/node/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@do-not-publish/ic-node-e2e-tests",
-	"version": "0.6.26-beta.0",
+	"version": "0.6.26-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@do-not-publish/ic-node-e2e-tests",
-			"version": "0.6.26-beta.0",
+			"version": "0.6.26-beta.1",
 			"dependencies": {
 				"@trust/webcrypto": "^0.9.2",
 				"@types/base64-js": "^1.2.5",

--- a/e2e/node/package.json
+++ b/e2e/node/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@do-not-publish/ic-node-e2e-tests",
-  "version": "0.6.26-beta.0",
+  "version": "0.6.26-beta.1",
   "scripts": {
     "ci": "npm run e2e",
     "e2e": "jest --verbose",
@@ -11,8 +11,8 @@
     "mitm": "jest -i basic/mitm.test.ts"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.6.26-beta.0",
-    "@dfinity/authentication": "^0.6.26-beta.0",
+    "@dfinity/agent": "^0.6.26-beta.1",
+    "@dfinity/authentication": "^0.6.26-beta.1",
     "@trust/webcrypto": "^0.9.2",
     "@types/base64-js": "^1.2.5",
     "@types/jest": "^24.0.18",

--- a/lerna.json
+++ b/lerna.json
@@ -15,5 +15,5 @@
     "eslint-plugin-jsdoc",
     "typescript"
   ],
-  "version": "0.6.26-beta.0"
+  "version": "0.6.26-beta.1"
 }

--- a/packages/agent/.npmignore
+++ b/packages/agent/.npmignore
@@ -2,15 +2,10 @@
 # that are.
 **
 
-!src/**/*.d.ts
-!src/**/*.js
+!lib/**
 !types/**/*.d.ts
 !package.json
 !README.md
-!src/utils/bls*
-
-# bls.ts should not be included in the npm package.
-src/utils/bls.ts
 
 # The following line further removes all test files (which matches .js and .d.ts).
-src/**/*.test.*
+lib/**/*.test.*

--- a/packages/agent/package-lock.json
+++ b/packages/agent/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/agent",
-	"version": "0.6.26-beta.0",
+	"version": "0.6.26-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/agent",
-			"version": "0.6.26-beta.0",
+			"version": "0.6.26-beta.1",
 			"dependencies": {
 				"@types/crc": "^3.4.0",
 				"base64-arraybuffer": "^0.2.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/agent",
-  "version": "0.6.26-beta.0",
+  "version": "0.6.26-beta.1",
   "main": "./lib/cjs/index",
   "module": "./lib/esm/index",
   "scripts": {

--- a/packages/authentication/.npmignore
+++ b/packages/authentication/.npmignore
@@ -2,12 +2,10 @@
 # that are.
 **
 
-!src/**/*.d.ts
-!src/**/*.js
-!.tsc-out/**/*
+!lib/**
 !types/**/*.d.ts
 !package.json
 !README.md
 
 # The following line further removes all test files (which matches .js and .d.ts).
-src/**/*.test.*
+lib/**/*.test.*

--- a/packages/authentication/package-lock.json
+++ b/packages/authentication/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/authentication",
-	"version": "0.6.26-beta.0",
+	"version": "0.6.26-beta.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/authentication",
-			"version": "0.6.26-beta.0",
+			"version": "0.6.26-beta.1",
 			"dependencies": {
 				"@types/crc": "^3.4.0",
 				"bignumber.js": "^9.0.0",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/authentication",
-  "version": "0.6.26-beta.0",
+  "version": "0.6.26-beta.1",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "scripts": {
@@ -14,7 +14,7 @@
     "test": "jest --verbose --detectOpenHandles"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.6.26-beta.0",
+    "@dfinity/agent": "^0.6.26-beta.1",
     "@types/crc": "^3.4.0",
     "@types/jest": "^24.0.18",
     "bignumber.js": "^9.0.0",


### PR DESCRIPTION
This also includes a change to `.npmignore` in our packages as the build was changed to output to `lib/` and not next to the source files.