### PR TITLE
chore: use CI flag for lerna bootstrap

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
 
-    - run: npx lerna bootstrap
+    - run: npx lerna bootstrap --ci
     - run: npx lerna run lint
 
     # build monorepo incl. each subpackage


### PR DESCRIPTION
So it respects the package-lock.json.