### PR TITLE
fix: Various fixes related to the Service Worker validation

### DIFF
--- a/apps/sw-cert/package.json
+++ b/apps/sw-cert/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "webpack",
     "develop": "webpack-dev-server",
-    "start": "npm run build; http-server dist --proxy https://ic0.page/",
+    "start": "npm run build; http-server dist --proxy http://localhost:8000/",
     "lint:fix": "npm run lint -- --fix",
     "make:docs/reference": "",
     "publish:release": "",

--- a/apps/sw-cert/src/sw/http_request.ts
+++ b/apps/sw-cert/src/sw/http_request.ts
@@ -77,7 +77,7 @@ function maybeResolveCanisterIdFromSearchParam(
   isLocal: boolean,
 ): Principal | null {
   // Skip this if we're not on localhost.
-  if (isLocal) {
+  if (!isLocal) {
     return null;
   }
 
@@ -165,6 +165,22 @@ const canisterIdlFactory: IDL.InterfaceFactory = ({ IDL }) => {
 }
 
 /**
+ * Decode a body (ie. deflate or gunzip it) based on its content-encoding.
+ * @param body The body to decode.
+ * @param encoding Its content-encoding associated header.
+ */
+function decodeBody(body: Uint8Array, encoding: string): Uint8Array {
+  switch (encoding) {
+    case 'identity':
+    case '':
+      return body;
+    case 'gzip': return pako.ungzip(body);
+    case 'deflate': return pako.inflate(body);
+    default: throw new Error(`Unsupported encoding: "${encoding}"`);
+  }
+}
+
+/**
  * Box a request, send it to the canister, and handle its response, creating a Response
  * object.
  * @param request The request received from the browser.
@@ -202,7 +218,12 @@ export async function handleRequest(request: Request): Promise<Response> {
         canisterId: maybeCanisterId,
       });
       const requestHeaders: [string, string][] = [];
-      request.headers.forEach((key, value) => requestHeaders.push([key, value]));
+      request.headers.forEach((value, key) => requestHeaders.push([key, value]));
+
+      // If the accept encoding isn't given, add it because we want to save bandwidth.
+      if (!request.headers.has("Accept-Encoding")) {
+        requestHeaders.push(["Accept-Encoding", "gzip, deflate, identity"]);
+      }
 
       const httpRequest = {
         method: request.method,
@@ -212,10 +233,7 @@ export async function handleRequest(request: Request): Promise<Response> {
       };
 
       const httpResponse: any = await actor.http_request(httpRequest);
-      const body = new Uint8Array(httpResponse.body);
-      const response = new Response(body.buffer, {
-        status: httpResponse.status_code,
-      });
+      const headers = new Headers();
 
       let certificate: ArrayBuffer | undefined;
       let tree: ArrayBuffer | undefined;
@@ -242,11 +260,15 @@ export async function handleRequest(request: Request): Promise<Response> {
             break;
         }
 
-        response.headers.append(key, value);
+        headers.append(key, value);
       }
+
+      const body = new Uint8Array(httpResponse.body);
+      const identity = decodeBody(body, encoding);
 
       let bodyValid = false;
       if (certificate && tree) {
+        // Try to validate the body as is.
         bodyValid = await validateBody(
           maybeCanisterId,
           url.pathname,
@@ -254,15 +276,28 @@ export async function handleRequest(request: Request): Promise<Response> {
           certificate,
           tree,
           agent,
+          isLocal,
         );
+
+        if (!bodyValid) {
+          // If that didn't work, try to validate its identity version. This is for
+          // backward compatibility.
+          bodyValid = await validateBody(
+            maybeCanisterId,
+            url.pathname,
+            identity.buffer,
+            certificate,
+            tree,
+            agent,
+            isLocal,
+          )
+        }
       }
       if (bodyValid) {
-        switch (encoding) {
-          case '': return response;
-          case 'gzip': return new Response(pako.ungzip(body), response);
-          case 'deflate': return new Response(pako.inflate(body), response);
-          default: throw new Error(`Unsupported encoding: "${encoding}"`);
-        }
+        return new Response(identity.buffer, {
+          status: httpResponse.status_code,
+          headers,
+        });
       } else {
         console.error('BODY DOES NOT PASS VERIFICATION');
         return new Response("Body does not pass verification", { status: 500 });

--- a/apps/sw-cert/src/sw/validation.ts
+++ b/apps/sw-cert/src/sw/validation.ts
@@ -18,6 +18,7 @@ import {
  * @param certificate The certificate to validate the .
  * @param tree The merkle tree returned by the canister.
  * @param agent A JavaScript agent that can validate certificates.
+ * @param isLocal Whether we're running in a local mode.
  * @returns True if the body is valid.
  */
 export async function validateBody(
@@ -27,8 +28,15 @@ export async function validateBody(
   certificate: ArrayBuffer,
   tree: ArrayBuffer,
   agent: HttpAgent,
+  isLocal = false,
 ): Promise<boolean> {
   const cert = new Certificate({ certificate: blobFromUint8Array(new Uint8Array(certificate)) }, agent);
+
+  // If we're running locally, update the key manually.
+  if (isLocal) {
+    await cert.fetchRootKey();
+  }
+
   // Make sure the certificate is valid.
   if (!(await cert.verify())) {
     return false;
@@ -50,13 +58,11 @@ export async function validateBody(
 
   // Next, calculate the SHA of the content.
   const sha = await crypto.subtle.digest("SHA-256", body);
-  const treeSha = lookupPathEx(["http_assets", path], hashTree);
+  let treeSha = lookupPathEx(["http_assets", path], hashTree);
 
-  // First check if treeSha is not undefined.
   if (!treeSha) {
-    console.log('treeSha undefined??');
-    console.log(hashTreeToString(hashTree));
-    console.log(path);
+    // Allow fallback to `index.html`.
+    treeSha = lookupPathEx(["http_assets", "/index.html"], hashTree);
   }
 
   return !!treeSha && equal(sha, treeSha);


### PR DESCRIPTION
The new asset canister allows users to have multiple asset encodings, but only one certification (for now). It means that if the asset canister returns a `Content-Encoding: gzip` file the certification might be for the unzipped content. Thus, we need to refactor a bit how content is used in the validation code.

Now the algorithm is basically; decode the body (because we need to return the decoded body anyway to the browser), check that its encoded content is certified (because that's what NNS and Identity do), if not, use the same certificate/tree to check if its identity content is certified.

Also added a new check for `/index.html` if the SHA isn't found. If both aren't found, we invalidate the response (with an error message for debugging).

Also, with the latest agent and using localhost, we cannot use the hard coded mainnet public key, and fetch it. This only works if the SW was installed from `localhost`.