### PR TITLE
fix: return false when path cannot be found (and thus not validated)

### DIFF
--- a/apps/sw-cert/package.json
+++ b/apps/sw-cert/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "webpack",
     "develop": "webpack-dev-server",
-    "start": "npm run build; http-server dist --proxy http://localhost:8000/",
+    "start": "npm run build; http-server dist --proxy https://ic0.app/",
     "lint:fix": "npm run lint -- --fix",
     "make:docs/reference": "",
     "publish:release": "",

--- a/apps/sw-cert/src/sw/validation.ts
+++ b/apps/sw-cert/src/sw/validation.ts
@@ -65,6 +65,13 @@ export async function validateBody(
     treeSha = lookupPathEx(["http_assets", "/index.html"], hashTree);
   }
 
+  if (!treeSha) {
+    // The tree returned in the certification header is wrong. Return false.
+    // We don't throw here, just invalidate the request.
+    console.error(`Invalid Tree in the header. Does not contain path ${JSON.stringify(path)}`);
+    return false;
+  }
+
   return !!treeSha && equal(sha, treeSha);
 }
 


### PR DESCRIPTION
And put back the mainnet as backend for SW local development.