### PR TITLE
fix: set the service worker public path to be always root

### DIFF
--- a/apps/sw-cert/webpack.config.js
+++ b/apps/sw-cert/webpack.config.js
@@ -11,7 +11,8 @@ module.exports = {
   devtool: 'source-map',
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: '[id]-[contenthash].js'
+    filename: '[id]-[contenthash].js',
+    publicPath: '/'
   },
   optimization: {
     splitChunks: {


### PR DESCRIPTION
When a user accesses a frontend with a regular browser router, it will
download the index.html as it is, but not the service worker. That means
that someone accessing "/some/path/to/route" would download the
index.html content, but then use relative paths to the JS and Service
Worker (ie. "/some/path/to/sw.js"). This obviously doesn't resolve to
any known file and returns a 404.

With this fix we always refer to absolute paths for every resources, and
the absolute path is "/" which is the right file.