### PR TITLE
feat(sw): add a compile time env var to always fetch the root key

### DIFF
--- a/apps/sw-cert/README.md
+++ b/apps/sw-cert/README.md
@@ -2,8 +2,15 @@
 Certified fun guaranteed.
 
 ## Build
-From the root of this repo, `npm i && npm build --workspaces --if-present`. The output should be in a `dist/`
+From the root of this repo, `npm ci && npm build --workspaces --if-present`. The output should be in a `dist/`
 folder next to this file.
+
+### Build With FETCH_ROOT_KEY
+By setting the `FORCE_FETCH_ROOT_KEY` environment variable prior to building, the service worker will
+always fetch the root key of the network before doing the validation.
+
+**THIS SHOULD ONLY BE USED ON A TEST OR LOCAL NETWORK.** The IC mainnet public key is hard coded in
+the agent and, for security reasons, should not be fetched by the agent.
 
 ## Develop
 You will need to build the rest of the repo first (see Build section above) so that the agent packages are available when building this app.

--- a/apps/sw-cert/src/sw/http_request.ts
+++ b/apps/sw-cert/src/sw/http_request.ts
@@ -15,6 +15,8 @@ const hostnameCanisterIdMap: Record<string, [string, string]> = {
   'nns.ic0.app': ['qoctq-giaaa-aaaaa-aaaea-cai', 'ic0.app'],
 };
 
+const shouldFetchRootKey: boolean = !!(process?.env?.FORCE_FETCH_ROOT_KEY) || false;
+
 const swLocation = new URL(self.location.toString());
 const [_swCanisterId, swDomains] = (() => {
   const maybeSplit = splitHostnameForCanisterId(swLocation.hostname);
@@ -276,7 +278,7 @@ export async function handleRequest(request: Request): Promise<Response> {
           certificate,
           tree,
           agent,
-          isLocal,
+          shouldFetchRootKey,
         );
 
         if (!bodyValid) {

--- a/apps/sw-cert/src/sw/validation.ts
+++ b/apps/sw-cert/src/sw/validation.ts
@@ -7,7 +7,7 @@ import {
   HttpAgent,
   lookupPathEx,
   reconstruct,
-  Principal, hashTreeToString,
+  Principal,
 } from "@dfinity/agent";
 
 /**
@@ -18,7 +18,7 @@ import {
  * @param certificate The certificate to validate the .
  * @param tree The merkle tree returned by the canister.
  * @param agent A JavaScript agent that can validate certificates.
- * @param isLocal Whether we're running in a local mode.
+ * @param shouldFetchRootKey Whether should fetch the root key if it isn't available.
  * @returns True if the body is valid.
  */
 export async function validateBody(
@@ -28,12 +28,12 @@ export async function validateBody(
   certificate: ArrayBuffer,
   tree: ArrayBuffer,
   agent: HttpAgent,
-  isLocal = false,
+  shouldFetchRootKey = false,
 ): Promise<boolean> {
   const cert = new Certificate({ certificate: blobFromUint8Array(new Uint8Array(certificate)) }, agent);
 
   // If we're running locally, update the key manually.
-  if (isLocal) {
+  if (shouldFetchRootKey) {
     await cert.fetchRootKey();
   }
 

--- a/apps/sw-cert/webpack.config.js
+++ b/apps/sw-cert/webpack.config.js
@@ -75,5 +75,8 @@ module.exports = {
       Buffer: [require.resolve('buffer/'), 'Buffer'],
       process: require.resolve('process/browser'),
     }),
+    new webpack.EnvironmentPlugin({
+      FORCE_FETCH_ROOT_KEY: false,
+    }),
   ],
 };

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -104,6 +104,7 @@ export class HttpAgent implements Agent {
   private readonly _fetch: typeof fetch;
   private readonly _host: URL;
   private readonly _credentials: string | undefined;
+  private _rootKeyFetched = false;
   public rootKey = blobFromHex(IC_ROOT_KEY);
 
   constructor(options: HttpAgentOptions = {}) {
@@ -350,8 +351,11 @@ export class HttpAgent implements Agent {
   }
 
   public async fetchRootKey(): Promise<BinaryBlob> {
-    // Hex-encoded version of the replica root key
-    this.rootKey = blobFromUint8Array(((await this.status()) as any).root_key);
+    if (!this._rootKeyFetched) {
+      // Hex-encoded version of the replica root key
+      this.rootKey = blobFromUint8Array(((await this.status()) as any).root_key);
+      this._rootKeyFetched = true;
+    }
     return this.rootKey;
   }
 


### PR DESCRIPTION
The environment variable is `FORCE_FETCH_ROOT_KEY` which should be set prior to
building the service worker. It will force the service worker to fetch the root
key on every queries.

An optimization in the HttpAgent has been added to reduce the amount of fetch;
if the root key was fetched once we do not fetch it again. This is safe because
the Agent can only point to a single Host URL, and the key should not change
with the same backend replica.