### PR TITLE
Update the OpenChat canisterId as it has been moved to its own subnet

### DIFF
--- a/apps/sw-cert/src/sw/http_request.ts
+++ b/apps/sw-cert/src/sw/http_request.ts
@@ -13,8 +13,8 @@ const hostnameCanisterIdMap: Record<string, [string, string]> = {
   'identity.ic0.app': ['rdmx6-jaaaa-aaaaa-aaadq-cai', 'ic0.app'],
   'nns.ic0.page': ['qoctq-giaaa-aaaaa-aaaea-cai', 'ic0.page'],
   'nns.ic0.app': ['qoctq-giaaa-aaaaa-aaaea-cai', 'ic0.app'],
-  'chat.ic0.page': ['l4kjv-xyaaa-aaaae-qaaba-cai', 'ic0.page'],
-  'chat.ic0.app': ['l4kjv-xyaaa-aaaae-qaaba-cai', 'ic0.app'],
+  'chat.ic0.page': ['7rzzy-aaaaa-aaaaf-aaaaq-cai', 'ic0.page'],
+  'chat.ic0.app': ['7rzzy-aaaaa-aaaaf-aaaaq-cai', 'ic0.app'],
   'dscvr.ic0.page': ['h5aet-waaaa-aaaab-qaamq-cai', 'ic0.page'],
   'dscvr.ic0.app': ['h5aet-waaaa-aaaab-qaamq-cai', 'ic0.app'],
 };


### PR DESCRIPTION
OpenChat has been assigned a different canisterId now as it has been decided that it should run on its own subnet.