### PR TITLE
fix: Fix an IDL bug in using FixedNat with BigInt

### DIFF
--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -611,7 +611,7 @@ export class FixedNatClass extends PrimitiveType<bigint | number> {
 
   public covariant(x: any): x is bigint {
     const max = BigInt(2) ** BigInt(this.bits);
-    if (typeof x === 'bigint' && x > BigInt(0)) {
+    if (typeof x === 'bigint' && x >= BigInt(0)) {
       return x < max;
     } else if (Number.isInteger(x) && x >= 0) {
       const v = BigInt(x);


### PR DESCRIPTION
The bug was `IDL.Nat64.covariant(0n) == false`, but it should be true.