### PR TITLE
refactor: move ledgerhq identity to using webhid

### DIFF
--- a/demos/ledgerhq/src/main.js
+++ b/demos/ledgerhq/src/main.js
@@ -53,7 +53,7 @@ let identity = undefined;
 
 document.getElementById('connectLedgerBtn').addEventListener('click', async () => {
   const { LedgerIdentity } = await import('@dfinity/identity-ledgerhq');
-  identity = await LedgerIdentity.fromWebUsb();
+  identity = await LedgerIdentity.create();
 
   document.getElementById('ledgerPrincipal').innerText = `${identity.getPrincipal().toText()}`;
   for (const el of document.getElementsByClassName('connected-only')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2042,22 +2042,14 @@
       }
     },
     "node_modules/@ledgerhq/devices": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.51.0.tgz",
-      "integrity": "sha512-7lajbkvlSItBYcWj+A2FzEm457cFGMYU4Bs61TfFzIA8LP8bWNoVOhQ22+mvZ3HIls27hHupj/d2qEavtNaRHQ==",
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.51.1.tgz",
+      "integrity": "sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==",
       "dependencies": {
         "@ledgerhq/errors": "^5.50.0",
         "@ledgerhq/logs": "^5.50.0",
-        "rxjs": "^7.0.0",
+        "rxjs": "6",
         "semver": "^7.3.5"
-      }
-    },
-    "node_modules/@ledgerhq/devices/node_modules/rxjs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.0.0.tgz",
-      "integrity": "sha512-I1V/ArAtGJg4kmCfms8fULm0SwYgEsAf2d5WPCBGzTYm2qTjO3Tx4EDFaGjbOox8CeEsC69jQK22mnmfyA26sw==",
-      "dependencies": {
-        "tslib": "~2.1.0"
       }
     },
     "node_modules/@ledgerhq/devices/node_modules/semver": {
@@ -2074,34 +2066,29 @@
         "node": ">=10"
       }
     },
-    "node_modules/@ledgerhq/devices/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-    },
     "node_modules/@ledgerhq/errors": {
       "version": "5.50.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.50.0.tgz",
       "integrity": "sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow=="
     },
     "node_modules/@ledgerhq/hw-transport": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.51.0.tgz",
-      "integrity": "sha512-Tr7W2YDCIOqoEmmbn+1ZmqMUgds04e6ZYGIxY5g2NJXG2K0IITH2vi3vl4tP9zlLzUucrNWPOWQqivhX+OlrEQ==",
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz",
+      "integrity": "sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==",
       "dependencies": {
-        "@ledgerhq/devices": "^5.51.0",
+        "@ledgerhq/devices": "^5.51.1",
         "@ledgerhq/errors": "^5.50.0",
         "events": "^3.3.0"
       }
     },
-    "node_modules/@ledgerhq/hw-transport-webusb": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-5.51.0.tgz",
-      "integrity": "sha512-q/NnAm6/bYGetKbp6GxlPuSOG+qHEkTGOM5evhAL6uLGsZQHK0Jg19KOxzyVcEACNb0fxX92X0+ND6Ygo2SPLg==",
+    "node_modules/@ledgerhq/hw-transport-webhid": {
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-5.51.1.tgz",
+      "integrity": "sha512-w/2qSU0vwFY+D/4ucuYRViO7iS3Uuxmj9sI/Iiqkoiax9Xppb0/6H5m3ffKv6iPMmRYbgwCgXorqx4SLLSD8Kg==",
       "dependencies": {
-        "@ledgerhq/devices": "^5.51.0",
+        "@ledgerhq/devices": "^5.51.1",
         "@ledgerhq/errors": "^5.50.0",
-        "@ledgerhq/hw-transport": "^5.51.0",
+        "@ledgerhq/hw-transport": "^5.51.1",
         "@ledgerhq/logs": "^5.50.0"
       }
     },
@@ -4090,16 +4077,6 @@
       "resolved": "https://registry.npmjs.org/@types/ledgerhq__hw-transport/-/ledgerhq__hw-transport-4.21.3.tgz",
       "integrity": "sha512-6QveiZLsFLq9WZDk8HWAZhivoGzyz5S8WV36hpUe7KrVDaTR1fDdB+syorrNRhYbyjraAuUJrIdJR5p/7doq8g==",
       "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/ledgerhq__hw-transport-webusb": {
-      "version": "4.70.1",
-      "resolved": "https://registry.npmjs.org/@types/ledgerhq__hw-transport-webusb/-/ledgerhq__hw-transport-webusb-4.70.1.tgz",
-      "integrity": "sha512-s+bt/fU5cH7etjLrNRn2LebZZqUL+YHIWciC1T6SUw2kyFpSqQQmjcM81ZrMR/tccQGfYTy3ebrJx9ZK3Mn+HA==",
-      "dev": true,
-      "dependencies": {
-        "@types/ledgerhq__hw-transport": "*",
         "@types/node": "*"
       }
     },
@@ -14652,7 +14629,6 @@
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^1.9.0"
@@ -18382,14 +18358,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ledgerhq/hw-transport": "^5.49.0",
-        "@ledgerhq/hw-transport-webusb": "^5.49.0",
+        "@ledgerhq/hw-transport-webhid": "^5.49.0",
         "@zondax/ledger-dfinity": "0.2.1"
       },
       "devDependencies": {
         "@trust/webcrypto": "^0.9.2",
         "@types/jest": "^24.9.1",
         "@types/ledgerhq__hw-transport": "^4.21.3",
-        "@types/ledgerhq__hw-transport-webusb": "^4.70.1",
         "@typescript-eslint/eslint-plugin": "^4.14.2",
         "@typescript-eslint/parser": "^4.14.2",
         "eslint": "^7.19.0",
@@ -20178,11 +20153,10 @@
       "version": "file:packages/identity-ledgerhq",
       "requires": {
         "@ledgerhq/hw-transport": "^5.49.0",
-        "@ledgerhq/hw-transport-webusb": "^5.49.0",
+        "@ledgerhq/hw-transport-webhid": "^5.49.0",
         "@trust/webcrypto": "^0.9.2",
         "@types/jest": "^24.9.1",
         "@types/ledgerhq__hw-transport": "^4.21.3",
-        "@types/ledgerhq__hw-transport-webusb": "^4.70.1",
         "@typescript-eslint/eslint-plugin": "^4.14.2",
         "@typescript-eslint/parser": "^4.14.2",
         "@zondax/ledger-dfinity": "0.2.1",
@@ -20834,24 +20808,16 @@
       }
     },
     "@ledgerhq/devices": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.51.0.tgz",
-      "integrity": "sha512-7lajbkvlSItBYcWj+A2FzEm457cFGMYU4Bs61TfFzIA8LP8bWNoVOhQ22+mvZ3HIls27hHupj/d2qEavtNaRHQ==",
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.51.1.tgz",
+      "integrity": "sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==",
       "requires": {
         "@ledgerhq/errors": "^5.50.0",
         "@ledgerhq/logs": "^5.50.0",
-        "rxjs": "^7.0.0",
+        "rxjs": "6",
         "semver": "^7.3.5"
       },
       "dependencies": {
-        "rxjs": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.0.0.tgz",
-          "integrity": "sha512-I1V/ArAtGJg4kmCfms8fULm0SwYgEsAf2d5WPCBGzTYm2qTjO3Tx4EDFaGjbOox8CeEsC69jQK22mnmfyA26sw==",
-          "requires": {
-            "tslib": "~2.1.0"
-          }
-        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -20859,11 +20825,6 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
@@ -20873,23 +20834,23 @@
       "integrity": "sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow=="
     },
     "@ledgerhq/hw-transport": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.51.0.tgz",
-      "integrity": "sha512-Tr7W2YDCIOqoEmmbn+1ZmqMUgds04e6ZYGIxY5g2NJXG2K0IITH2vi3vl4tP9zlLzUucrNWPOWQqivhX+OlrEQ==",
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz",
+      "integrity": "sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==",
       "requires": {
-        "@ledgerhq/devices": "^5.51.0",
+        "@ledgerhq/devices": "^5.51.1",
         "@ledgerhq/errors": "^5.50.0",
         "events": "^3.3.0"
       }
     },
-    "@ledgerhq/hw-transport-webusb": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-5.51.0.tgz",
-      "integrity": "sha512-q/NnAm6/bYGetKbp6GxlPuSOG+qHEkTGOM5evhAL6uLGsZQHK0Jg19KOxzyVcEACNb0fxX92X0+ND6Ygo2SPLg==",
+    "@ledgerhq/hw-transport-webhid": {
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-5.51.1.tgz",
+      "integrity": "sha512-w/2qSU0vwFY+D/4ucuYRViO7iS3Uuxmj9sI/Iiqkoiax9Xppb0/6H5m3ffKv6iPMmRYbgwCgXorqx4SLLSD8Kg==",
       "requires": {
-        "@ledgerhq/devices": "^5.51.0",
+        "@ledgerhq/devices": "^5.51.1",
         "@ledgerhq/errors": "^5.50.0",
-        "@ledgerhq/hw-transport": "^5.51.0",
+        "@ledgerhq/hw-transport": "^5.51.1",
         "@ledgerhq/logs": "^5.50.0"
       }
     },
@@ -22338,16 +22299,6 @@
       "resolved": "https://registry.npmjs.org/@types/ledgerhq__hw-transport/-/ledgerhq__hw-transport-4.21.3.tgz",
       "integrity": "sha512-6QveiZLsFLq9WZDk8HWAZhivoGzyz5S8WV36hpUe7KrVDaTR1fDdB+syorrNRhYbyjraAuUJrIdJR5p/7doq8g==",
       "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/ledgerhq__hw-transport-webusb": {
-      "version": "4.70.1",
-      "resolved": "https://registry.npmjs.org/@types/ledgerhq__hw-transport-webusb/-/ledgerhq__hw-transport-webusb-4.70.1.tgz",
-      "integrity": "sha512-s+bt/fU5cH7etjLrNRn2LebZZqUL+YHIWciC1T6SUw2kyFpSqQQmjcM81ZrMR/tccQGfYTy3ebrJx9ZK3Mn+HA==",
-      "dev": true,
-      "requires": {
-        "@types/ledgerhq__hw-transport": "*",
         "@types/node": "*"
       }
     },
@@ -29493,7 +29444,6 @@
     },
     "rxjs": {
       "version": "6.6.7",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/packages/identity-ledgerhq/.gitignore
+++ b/packages/identity-ledgerhq/.gitignore
@@ -1,9 +1,9 @@
 build_info.json
 node_modules/
 dist/
-**/*.js
-**/*.js.map
-**/*.d.ts
+lib/**/*.js
+lib/**/*.js.map
+lib/**/*.d.ts
 
 # generated docs
 /docs/reference

--- a/packages/identity-ledgerhq/README.md
+++ b/packages/identity-ledgerhq/README.md
@@ -20,7 +20,7 @@ npm i --save @dfinity/identity-ledgerhq
 import { LedgerIdentity } from '@dfinity/identity-ledgerhq';
 
 // ...
-const identity = await LedgerIdentity.fromWebUsb();
+const identity = await LedgerIdentity.create();
 const agent = new HttpAgent({ identity });
 ```
 

--- a/packages/identity-ledgerhq/package.json
+++ b/packages/identity-ledgerhq/package.json
@@ -45,14 +45,13 @@
   },
   "dependencies": {
     "@ledgerhq/hw-transport": "^5.49.0",
-    "@ledgerhq/hw-transport-webusb": "^5.49.0",
+    "@ledgerhq/hw-transport-webhid": "^5.49.0",
     "@zondax/ledger-dfinity": "0.2.1"
   },
   "devDependencies": {
     "@trust/webcrypto": "^0.9.2",
     "@types/jest": "^24.9.1",
     "@types/ledgerhq__hw-transport": "^4.21.3",
-    "@types/ledgerhq__hw-transport-webusb": "^4.70.1",
     "@typescript-eslint/eslint-plugin": "^4.14.2",
     "@typescript-eslint/parser": "^4.14.2",
     "eslint": "^7.19.0",

--- a/packages/identity-ledgerhq/src/identity/ledger.ts
+++ b/packages/identity-ledgerhq/src/identity/ledger.ts
@@ -27,7 +27,7 @@ export class LedgerIdentity extends SignIdentity {
    * Create a LedgerIdentity using the Web USB transport.
    * @param derivePath The derivation path.
    */
-  public static async fromWebUsb(derivePath = `m/44'/223'/0'/0/0`): Promise<LedgerIdentity> {
+  public static async create(derivePath = `m/44'/223'/0'/0/0`): Promise<LedgerIdentity> {
     const TransportClass = (await import('@ledgerhq/hw-transport-webhid')).default;
     const transport = await TransportClass.create();
     const app = new DfinityApp(transport);

--- a/packages/identity-ledgerhq/src/identity/ledger.ts
+++ b/packages/identity-ledgerhq/src/identity/ledger.ts
@@ -28,7 +28,7 @@ export class LedgerIdentity extends SignIdentity {
    * @param derivePath The derivation path.
    */
   public static async fromWebUsb(derivePath = `m/44'/223'/0'/0/0`): Promise<LedgerIdentity> {
-    const TransportClass = await import('@ledgerhq/hw-transport-webhid');
+    const TransportClass = (await import('@ledgerhq/hw-transport-webhid')).default;
     const transport = await TransportClass.create();
     const app = new DfinityApp(transport);
 

--- a/packages/identity-ledgerhq/src/identity/ledger.ts
+++ b/packages/identity-ledgerhq/src/identity/ledger.ts
@@ -8,7 +8,6 @@ import {
 } from '@dfinity/agent';
 import { blobFromUint8Array, BinaryBlob } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
-import TransportWebUSB from '@ledgerhq/hw-transport-webusb';
 import DfinityApp, { ResponseSign } from '@zondax/ledger-dfinity';
 import { Secp256k1PublicKey } from './secp256k1';
 
@@ -29,7 +28,8 @@ export class LedgerIdentity extends SignIdentity {
    * @param derivePath The derivation path.
    */
   public static async fromWebUsb(derivePath = `m/44'/223'/0'/0/0`): Promise<LedgerIdentity> {
-    const transport = await TransportWebUSB.create();
+    const TransportClass = await import('@ledgerhq/hw-transport-webhid');
+    const transport = await TransportClass.create();
     const app = new DfinityApp(transport);
 
     const resp = await app.getAddressAndPubKey(derivePath);

--- a/packages/identity-ledgerhq/src/identity/ledger_hq__hw_transport_webhid.d.ts
+++ b/packages/identity-ledgerhq/src/identity/ledger_hq__hw_transport_webhid.d.ts
@@ -1,0 +1,1 @@
+declare module '@ledgerhq/hw-transport-webhid';


### PR DESCRIPTION
There seems to be problems with the latest Chrome and WebUSB API, so
this is a test to mitigate those issues. See links below for more
information:

https://support.ledger.com/hc/en-us/articles/360020871157-Connection-issues-with-MetaMask-
https://github.com/LedgerHQ/ledgerjs/blob/master/docs/migrate_webusb.md
https://www.xda-developers.com/google-disables-chrome-webusb/