### PR TITLE
chore: excludes tests from tsconfig build process

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
     { "path": "packages/identity" }
   ],
   "include": ["packages/**/types/*"],
-  "resolveJsonModule": true
+  "resolveJsonModule": true,
+  "exclude": ["**/src/**/*.test.ts"]
 }


### PR DESCRIPTION
also allows you to do unallowed things like modifying window for tests