### PR TITLE
fix: Implements DER wrapping and unwrapping

### DIFF
--- a/packages/identity/src/identity/der.ts
+++ b/packages/identity/src/identity/der.ts
@@ -69,8 +69,8 @@ export const ED25519_OID = Uint8Array.from([
 
 export const wrapDER = (cose: ArrayBuffer, oid: Uint8Array): Uint8Array => {
   // The Bit String header needs to include the unused bit count byte in its length
-  const bitStringHeader = 2 + encodeLenBytes(cose.byteLength + 1);
-  const len = oid.byteLength + bitStringHeader + cose.byteLength;
+  const bitStringHeaderLength = 2 + encodeLenBytes(cose.byteLength + 1);
+  const len = oid.byteLength + bitStringHeaderLength + cose.byteLength;
   let offset = 0;
   const buf = new Uint8Array(1 + encodeLenBytes(len) + len);
   // Sequence

--- a/packages/identity/src/identity/der.ts
+++ b/packages/identity/src/identity/der.ts
@@ -1,0 +1,113 @@
+const bufEquals = (b1: ArrayBuffer, b2: ArrayBuffer): boolean => {
+  if (b1.byteLength !== b2.byteLength) return false;
+  const u1 = new Uint8Array(b1);
+  const u2 = new Uint8Array(b2);
+  for (let i = 0; i < u1.length; i++) {
+    if (u1[i] !== u2[i]) return false;
+  }
+  return true;
+};
+
+const encodeLenBytes = (len: number): number => {
+  if (len <= 0x7f) {
+    return 1;
+  } else if (len <= 0xff) {
+    return 2;
+  } else if (len <= 0xffff) {
+    return 3;
+  } else if (len <= 0xffffff) {
+    return 4;
+  } else {
+    throw new Error('Length too long (> 4 bytes)');
+  }
+};
+
+const encodeLen = (buf: Uint8Array, offset: number, len: number): number => {
+  if (len <= 0x7f) {
+    buf[offset] = len;
+    return 1;
+  } else if (len <= 0xff) {
+    buf[offset] = 0x81;
+    buf[offset + 1] = len;
+    return 2;
+  } else if (len <= 0xffff) {
+    buf[offset] = 0x82;
+    buf[offset + 1] = len >> 8;
+    buf[offset + 2] = len;
+    return 3;
+  } else if (len <= 0xffffff) {
+    buf[offset] = 0x83;
+    buf[offset + 1] = len >> 16;
+    buf[offset + 2] = len >> 8;
+    buf[offset + 3] = len;
+    return 4;
+  } else {
+    throw new Error('Length too long (> 4 bytes)');
+  }
+};
+
+const decodeLenBytes = (buf: Uint8Array, offset: number): number => {
+  if (buf[offset] < 0x80) return 1;
+  if (buf[offset] === 0x80) throw new Error('Invalid length 0');
+  if (buf[offset] === 0x81) return 2;
+  if (buf[offset] === 0x82) return 3;
+  if (buf[offset] === 0x83) return 4;
+  throw new Error('Length too long (> 4 bytes)');
+};
+
+export const DER_COSE_OID = Uint8Array.from([
+  ...[0x30, 0x0c], // SEQUENCE
+  ...[0x06, 0x0a], // OID with 10 bytes
+  ...[0x2b, 0x06, 0x01, 0x04, 0x01, 0x83, 0xb8, 0x43, 0x01, 0x01], // DER encoded COSE
+]);
+
+export const ED25519_OID = Uint8Array.from([
+  ...[0x30, 0x05], // SEQUENCE
+  ...[0x06, 0x03], // OID with 3 bytes
+  ...[0x2b, 0x65, 0x70], // id-Ed25519 OID
+]);
+
+export const wrapDER = (cose: ArrayBuffer, oid: Uint8Array): Uint8Array => {
+  // The Bit String header needs to include the unused bit count byte in its length
+  const bitStringHeader = 2 + encodeLenBytes(cose.byteLength + 1);
+  const len = oid.byteLength + bitStringHeader + cose.byteLength;
+  let offset = 0;
+  const buf = new Uint8Array(1 + encodeLenBytes(len) + len);
+  // Sequence
+  buf[offset++] = 0x30;
+  // Sequence Length
+  offset += encodeLen(buf, offset, len);
+
+  // OID
+  buf.set(oid, offset);
+  offset += oid.byteLength;
+
+  // Bit String Header
+  buf[offset++] = 0x03;
+  offset += encodeLen(buf, offset, cose.byteLength + 1);
+  // 0 padding
+  buf[offset++] = 0x00;
+  buf.set(new Uint8Array(cose), offset);
+
+  return buf;
+};
+
+export const unwrapDER = (derEncoded: ArrayBuffer, oid: Uint8Array): Uint8Array => {
+  let offset = 0;
+  const expect = (n: number, msg: string) => {
+    if (buf[offset++] !== n) throw new Error('Expected: ' + msg);
+  };
+  const buf = new Uint8Array(derEncoded);
+  expect(0x30, 'sequence');
+  offset += decodeLenBytes(buf, offset);
+
+  if (!bufEquals(buf.slice(offset, offset + oid.byteLength), oid)) {
+    throw new Error('Not the expected OID.');
+  }
+  offset += oid.byteLength;
+
+  expect(0x03, 'bit string');
+  offset += decodeLenBytes(buf, offset);
+  expect(0x00, '0 padding');
+  return buf.slice(offset);
+};

--- a/packages/identity/src/identity/ed25519.test.ts
+++ b/packages/identity/src/identity/ed25519.test.ts
@@ -33,15 +33,6 @@ test('DER decoding of ED25519 keys', async () => {
   });
 });
 
-test('DER encoding of invalid keys', async () => {
-  expect(() => {
-    Ed25519PublicKey.fromRaw(blobFromUint8Array(Buffer.alloc(31, 0))).toDer();
-  }).toThrow();
-  expect(() => {
-    Ed25519PublicKey.fromRaw(blobFromUint8Array(Buffer.alloc(31, 0))).toDer();
-  }).toThrow();
-});
-
 test('DER decoding of invalid keys', async () => {
   // Too short.
   expect(() => {

--- a/packages/identity/src/identity/ed25519.ts
+++ b/packages/identity/src/identity/ed25519.ts
@@ -29,10 +29,6 @@ export class Ed25519PublicKey implements PublicKey {
   private static RAW_KEY_LENGTH = 32;
 
   private static derEncode(publicKey: BinaryBlob): DerEncodedBlob {
-    // TODO: Validation before encoding is weird, is this necessary?
-    if (publicKey.byteLength !== this.RAW_KEY_LENGTH) {
-      throw new Error('An Ed25519 public key must be exactly 32bytes long');
-    }
     return derBlobFromBlob(blobFromUint8Array(wrapDER(publicKey, ED25519_OID)));
   }
 

--- a/packages/identity/src/identity/webauthn.ts
+++ b/packages/identity/src/identity/webauthn.ts
@@ -8,26 +8,10 @@ import {
 } from '@dfinity/candid';
 import borc from 'borc';
 import * as tweetnacl from 'tweetnacl';
+import { DER_COSE_OID, wrapDER } from './der';
 
 function _coseToDerEncodedBlob(cose: ArrayBuffer): DerEncodedBlob {
-  const c = new Uint8Array(cose);
-
-  if (c.byteLength > 230) {
-    // 'Tis true, 'tis too much.
-    throw new Error('Cannot encode byte length of more than 230.');
-  }
-
-  // prettier-ignore
-  const der = new Uint8Array([
-    0x30, 0x10 + c.byteLength + 1,  // Sequence of length 16 + c.length.
-    0x30, 0x0C,  // Sequence of length 12
-    // OID 1.3.6.1.4.1.56387.1.1
-    0x06, 0x0A, 0x2B, 0x06, 0x01, 0x04, 0x01, 0x83, 0xB8, 0x43, 0x01, 0x01,
-    0x03, 1 + c.byteLength, 0x00,  // BIT String of length c.length.
-    ...c,
-  ]);
-
-  return derBlobFromBlob(blobFromUint8Array(der));
+  return derBlobFromBlob(blobFromUint8Array(wrapDER(cose, DER_COSE_OID)));
 }
 
 /**

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -6,3 +6,4 @@ export {
   SignedDelegation,
 } from './identity/delegation';
 export { WebAuthnIdentity } from './identity/webauthn';
+export { wrapDER, unwrapDER, DER_COSE_OID, ED25519_OID } from './identity/der';


### PR DESCRIPTION
This is needed to be able to use the WebAuthn identity with public keys larger than 127 bytes. It should be a non-breaking change, unless someone relied on identity creation failing for larger keys.

So far this library hardcoded the DER prefixes, which works until the payload becomes larger than 127 bytes, as you need to encode the length of sequences and bitstrings according to the "Definite scheme" as described here: https://en.wikipedia.org/wiki/X.690#Definite_form

Along the same line we need to unwrap DER in other places, which runs into the same issue. So far this library pretends we can always slice off a fixed amount of bytes at the front to remove the DER wrapper, but we actually need to parse just enough structure to know how many bytes are used to encode lengths.