### PR TITLE
feat: Enhancements to `LedgerIdentity`.

### DIFF
--- a/demos/ledgerhq/package.json
+++ b/demos/ledgerhq/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@dfinity/agent": "^0.9.1",
     "@dfinity/authentication": "^0.9.1",
+    "@dfinity/candid": "^0.9.1",
     "@dfinity/identity": "^0.9.1",
     "@dfinity/identity-ledgerhq": "^0.9.1",
     "@dfinity/principal": "^0.9.1",

--- a/packages/identity-ledgerhq/src/identity/ledger.ts
+++ b/packages/identity-ledgerhq/src/identity/ledger.ts
@@ -10,6 +10,7 @@ import { blobFromUint8Array, BinaryBlob } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import DfinityApp, { ResponseSign } from '@zondax/ledger-dfinity';
 import { Secp256k1PublicKey } from './secp256k1';
+import TransportClass from "@ledgerhq/hw-transport-webhid";
 
 /**
  * Convert the HttpAgentRequest body into cbor which can be signed by the Ledger Hardware Wallet.
@@ -28,30 +29,59 @@ export class LedgerIdentity extends SignIdentity {
    * @param derivePath The derivation path.
    */
   public static async create(derivePath = `m/44'/223'/0'/0/0`): Promise<LedgerIdentity> {
-    const TransportClass = (await import('@ledgerhq/hw-transport-webhid')).default;
+    const [app, transport] = await this._connect();
+
+    try {
+      const publicKey = await this._fetchPublicKeyFromDevice(app, derivePath);
+      return new this(derivePath, publicKey);
+    } finally {
+      // Always close the transport.
+      transport.close();
+    }
+  }
+
+  private constructor(
+    public readonly derivePath: string,
+    private readonly _publicKey: Secp256k1PublicKey,
+  ) {
+    super();
+  }
+
+  /**
+   * Connect to a ledger hardware wallet.
+   */
+  private static async _connect(): Promise<[DfinityApp, TransportClass]> {
+    if (!await TransportClass.isSupported()) {
+      // Data on browser compatibility is taken from https://caniuse.com/webhid
+      throw "Your browser doesn't support WebHID, which is necessary to communicate with your wallet.\n\nSupported browsers:\n* Chrome (Desktop) v89+\n* Edge v89+\n* Opera v76+";
+    }
+
     const transport = await TransportClass.create();
     const app = new DfinityApp(transport);
 
+    return [app, transport];
+  }
+
+  private static async _fetchPublicKeyFromDevice(app: DfinityApp, derivePath: string): Promise<Secp256k1PublicKey> {
     const resp = await app.getAddressAndPubKey(derivePath);
+
+    if (resp.returnCode == 28161) {
+      throw "Please open the Internet Computer app on your wallet and try again.";
+    } else if (resp.returnCode == 27014) {
+      throw "Ledger Wallet is locked. Unlock it and try again."
+    } else if (resp.returnCode == 65535) {
+      throw "Unable to fetch the public key. Please try again."
+    }
+
     // This type doesn't have the right fields in it, so we have to manually type it.
     const principal = (resp as unknown as { principalText: string }).principalText;
     const publicKey = Secp256k1PublicKey.fromRaw(blobFromUint8Array(resp.publicKey));
-    const address = resp.address;
 
     if (principal !== Principal.selfAuthenticating(publicKey.toDer()).toText()) {
       throw new Error('Principal returned by device does not match public key.');
     }
 
-    return new this(app, derivePath, publicKey, address.buffer);
-  }
-
-  private constructor(
-    private readonly _app: DfinityApp,
-    public readonly derivePath: string,
-    private readonly _publicKey: Secp256k1PublicKey,
-    private readonly _address: ArrayBuffer,
-  ) {
-    super();
+    return publicKey;
   }
 
   /**
@@ -59,7 +89,9 @@ export class LedgerIdentity extends SignIdentity {
    * and verify the address/pubkey are the same as on the device screen.
    */
   public async showAddressAndPubKeyOnDevice(): Promise<void> {
-    await this._app.showAddressAndPubKey(this.derivePath);
+    this._executeWithApp(async (app: DfinityApp) => {
+      await app.showAddressAndPubKey(this.derivePath);
+    });
   }
 
   public getPublicKey(): PublicKey {
@@ -67,21 +99,23 @@ export class LedgerIdentity extends SignIdentity {
   }
 
   public async sign(blob: BinaryBlob): Promise<BinaryBlob> {
-    const resp: ResponseSign = await this._app.sign(this.derivePath, Buffer.from(blob));
-    const signatureRS = resp.signatureRS;
-    if (!signatureRS) {
-      throw new Error(
-        `A ledger error happened during signature:\n` +
+    return await this._executeWithApp(async (app: DfinityApp) => {
+      const resp: ResponseSign = await app.sign(this.derivePath, Buffer.from(blob));
+      const signatureRS = resp.signatureRS;
+      if (!signatureRS) {
+        throw new Error(
+          `A ledger error happened during signature:\n` +
           `Code: ${resp.returnCode}\n` +
           `Message: ${JSON.stringify(resp.errorMessage)}\n`,
-      );
-    }
+        );
+      }
 
-    if (signatureRS?.byteLength !== 64) {
-      throw new Error(`Signature must be 64 bytes long (is ${signatureRS.length})`);
-    }
+      if (signatureRS?.byteLength !== 64) {
+        throw new Error(`Signature must be 64 bytes long (is ${signatureRS.length})`);
+      }
 
-    return blobFromUint8Array(new Uint8Array(signatureRS));
+      return blobFromUint8Array(new Uint8Array(signatureRS));
+    });
   }
 
   public async transformRequest(request: HttpAgentRequest): Promise<unknown> {
@@ -95,5 +129,22 @@ export class LedgerIdentity extends SignIdentity {
         sender_sig: signature,
       },
     };
+  }
+
+  private async _executeWithApp<T>(func: (app: DfinityApp) => Promise<T>): Promise<T> {
+    const [app, transport] = await LedgerIdentity._connect();
+
+    try {
+      // Verify that the public key of the device matches the public key of this identity.
+      const devicePublicKey = await LedgerIdentity._fetchPublicKeyFromDevice(app, this.derivePath);
+      if (JSON.stringify(devicePublicKey) !== JSON.stringify(this._publicKey)) {
+        throw new Error("Found unexpected public key. Are you sure you're using the right wallet?");
+      }
+
+      // Run the provided function.
+      return await func(app);
+    } finally {
+      transport.close();
+    }
   }
 }


### PR DESCRIPTION
This PR contains a number of updates to `LedgerIdentity` that were
necessary for the integration with the NNS dapp.

* Calls to the identity automatically open and close the connection to
  the device. Previously, the connection remained open, and there was no
  way to manage it from outside the identity class.

* LedgerIdentity now verifies that the public key of the wallet is the
  public key of the identity. That way, a LedgerIdentity can only
  be used with the wallet that it was instantiated with.

* Additional error-handling has been added.