### PR TITLE
chore: improve error reporting in service worker

### DIFF
--- a/apps/sw-cert/src/sw/http_request.ts
+++ b/apps/sw-cert/src/sw/http_request.ts
@@ -315,8 +315,8 @@ export async function handleRequest(request: Request): Promise<Response> {
         return new Response('Body does not pass verification', { status: 500 });
       }
     } catch (e) {
-      console.error('An error happened:', e);
-      return new Response(null, { status: 500 });
+      console.error('Failed to fetch response:', e);
+      return new Response(`Failed to fetch response: ${e.toString()}`, { status: 500 });
     }
   }
 


### PR DESCRIPTION
This change makes the service worker return the error message as the
response body if a fetch failed.  This should give us more insight
into why some people can't access nns and identity.