### PR TITLE
fix(candid): Stringify all bigints

### DIFF
--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -402,3 +402,7 @@ test('IDL encoding (multiple arguments)', () => {
   );
   test_args([], [], '4449444c0000', 'empty args');
 });
+
+test('Stringify bigint', () => {
+  expect(() => IDL.encode([IDL.Nat], [{ x: BigInt(42) }])).toThrow(/Invalid nat argument/);
+});

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -175,7 +175,7 @@ export abstract class Type<T = any> {
   }
 
   public valueToString(x: T): string {
-    return JSON.stringify(x);
+    return toReadableString(x);
   }
 
   /* Implement `T` in the IDL spec, only needed for non-primitive types */
@@ -1312,11 +1312,9 @@ export class ServiceClass extends ConstructType<PrincipalId> {
  * @returns {string}
  */
 function toReadableString(x: unknown): string {
-  if (typeof x === 'bigint') {
-    return `BigInt(${x})`;
-  } else {
-    return JSON.stringify(x);
-  }
+  return JSON.stringify(x, (_key, value) =>
+    typeof value === 'bigint' ? `BigInt(${value})` : value,
+  );
 }
 
 /**


### PR DESCRIPTION
Ensures that all nested `bigints` are stringified.

Previously, would simply throw a `TypeError: Do not know how to serialize a BigInt` during encode or decode errors