### PR TITLE
fix: auth-client identity option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9482,8 +9482,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "license": "MIT"
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -21142,7 +21143,9 @@
       "version": "3.1.1"
     },
     "path-parse": {
-      "version": "1.0.6"
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -1,3 +1,4 @@
+import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { AuthClient } from './index';
 
 /**
@@ -31,6 +32,15 @@ describe('Auth Client', () => {
     const test = await AuthClient.create();
     expect(await test.isAuthenticated()).toBe(false);
     expect(test.getIdentity().getPrincipal().isAnonymous()).toBe(true);
+  });
+
+  it('should initialize with a provided identity', async () => {
+    const identity = Ed25519KeyIdentity.generate();
+    const test = await AuthClient.create({
+      identity,
+    });
+    expect(test.getIdentity().getPrincipal().isAnonymous()).toBe(false);
+    expect(test.getIdentity()).toBe(identity);
   });
 
   it('should log users out', async () => {

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -177,7 +177,9 @@ export class AuthClient {
       try {
         const chainStorage = await storage.get(KEY_LOCALSTORAGE_DELEGATION);
 
-        if (chainStorage) {
+        if (options.identity) {
+          identity = options.identity;
+        } else if (chainStorage) {
           chain = DelegationChain.fromJSON(chainStorage);
 
           // Verify that the delegation isn't expired.


### PR DESCRIPTION
I encountered a bug trying to intialize an authClient using a Plug identity, where I was still getting an anonymous identity back. This will properly use the option we pass to `AuthClient.create`