### PR TITLE
Check browser support before starting service worker

### DIFF
--- a/apps/sw-cert/src/index.ts
+++ b/apps/sw-cert/src/index.ts
@@ -7,9 +7,10 @@ function updateStatus(message: string) {
 
 window.addEventListener('load', async () => {
   // Verify user's web browser has necessary support
-  if (!window.navigator.serviceWorker) {
+  let unsupported = [ ["serviceWorker", window.navigator.serviceWorker], ["BigInt", window.BigInt], ["WebAssembly", window.WebAssembly] ].filter(tuple => !tuple[1]).map(tuple => tuple[0]).join(", ");
+  if (unsupported) {
     updateStatus(
-      `This web browser cannot interact with the Internet Computer securely.
+      `This web browser cannot interact with the Internet Computer securely.  (No: ${unsupported})
        Please try new web browser software.`,
     );
   } else {


### PR DESCRIPTION
# Motivation
If the browser does not support the required technologies, the service worker will fail.  This should be communicated to the end user.

# Changes
- Extend the check for supported technologies to include BigInt and WebAssembly.

# Testing
This PR has NOT been tested.  To test, it should suffice to run this on an old Iphone.  On some platforms it may be possible to test with `delete(window.WebAssembly)`.