### PR TITLE
feat: Clarify fromText() sanity check

### DIFF
--- a/packages/principal/src/index.ts
+++ b/packages/principal/src/index.ts
@@ -47,7 +47,7 @@ export class Principal {
 
     const principal = new this(arr);
     if (principal.toText() !== text) {
-      throw new Error(`Principal "${principal.toText()}" does not have a valid checksum.`);
+      throw new Error(`Principal "${principal.toText()}" does not have a valid checksum (original value "${text}" may not be a valid Principal ID).`);
     }
 
     return principal;


### PR DESCRIPTION
This prints the original value, which (I think) is more useful to the
user when trying to figure out why `toText()` couldn't create a
`Principal`.