### PR TITLE
fix: Make requests from ic0.app domain to raw.ic0.app

### DIFF
--- a/apps/sw-cert/src/sw/http_request.ts
+++ b/apps/sw-cert/src/sw/http_request.ts
@@ -324,7 +324,7 @@ export async function handleRequest(request: Request): Promise<Response> {
   // The same domain will always load using our service worker, and not the same domain
   // would load by reference. If you want security for your users at that point you
   // should use SRI to make sure the resource matches.
-  if (!url.hostname.endsWith(swDomains)) {
+  if (!url.hostname.endsWith(swDomains) || url.hostname.endsWith(`raw.${swDomains}`)) {
     // todo: Do we need to check for headers and certify the content here?
     return await fetch(request);
   }


### PR DESCRIPTION
Now, we are not able to make requests  to `raw.ic0.app` from the frontend, where the service worker is already installed.

Steps for reproduce:
- go to any app (for example go to OpenChat `https://7e6iv-biaaa-aaaaf-aaada-cai.ic0.app/`)
- open the console
- we make a request to the same canister in raw domain zone `fetch('https://7e6iv-biaaa-aaaaf-aaada-cai.raw.ic0.app')`
- got 404 error

[Link to the forum topic](https://forum.dfinity.org/t/is-it-possible-to-make-raw-ic0-app-calls-from-ic0-app-and-reverse/8224)

PS. Perhaps this solution is not the best, but let's find the right one.