### PR TITLE
fix: fetch binding

### DIFF
--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -95,7 +95,7 @@ function getDefaultFetch(): typeof fetch {
   } else if (typeof global !== 'undefined') {
     // Node context
     if (global.fetch) {
-      defaultFetch = global.fetch;
+      defaultFetch = global.fetch.bind(global);
     } else {
       throw new HttpDefaultFetchError(
         'Fetch implementation was not available. You appear to be in a Node.js context, but global.fetch was not available.',
@@ -103,7 +103,7 @@ function getDefaultFetch(): typeof fetch {
     }
   } else if (typeof self !== 'undefined') {
     if (self.fetch) {
-      defaultFetch = self.fetch;
+      defaultFetch = self.fetch.bind(self);
     }
   }
 


### PR DESCRIPTION
Problem:
When `@dfinity/agent@0.10.2` used by boundary node service-worker, then `this._fetch(...)` throws error `Failed to fetch response: TypeError: Failed to execute 'fetch' on 'WorkerGlobalScope': Illegal invocation`

Its caused by missing `.bind(...)` in fetch gettter