### PR TITLE
feat: httpagent should allow its identity to be invalidated

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "engines": {
     "node": "^12 || ^14 || ^16",
-    "npm": "^7.17"
+    "npm": "^7.17 || ^18"
   },
   "scripts": {
     "lint:e2e": "eslint --cache --cache-location node_modules/.cache/eslint 'e2e/*/**/*.ts*'",

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -6,7 +6,7 @@ import { Principal } from '@dfinity/principal';
 import { requestIdOf } from '../../request_id';
 
 import { JSDOM } from 'jsdom';
-import { AnonymousIdentity, Identity, SignIdentity } from '../..';
+import { AnonymousIdentity, SignIdentity } from '../..';
 import { Ed25519KeyIdentity } from '../../../../identity/src/identity/ed25519';
 import { AgentError } from '../../errors';
 const { window } = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`);

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -281,31 +281,31 @@ describe('invalidate identity', () => {
       "This identity has expired due this application's security policy. Please refresh your authentication.";
 
     // Test Agent.call
-    await agent
-      .call(canisterId, {
+    try {
+      await agent.call(canisterId, {
         methodName: 'test',
         arg: new ArrayBuffer(16),
-      })
-      .catch((reason: AgentError) => {
-        expect(reason.message).toBe(expectedError);
       });
+    } catch (error) {
+      expect(error.message).toBe(expectedError);
+    }
     // Test Agent.query
-    await agent
-      .query(canisterId, {
+    try {
+      await agent.query(canisterId, {
         methodName: 'test',
         arg: new ArrayBuffer(16),
-      })
-      .catch((reason: AgentError) => {
-        expect(reason.message).toBe(expectedError);
       });
+    } catch (error) {
+      expect(error.message).toBe(expectedError);
+    }
     // Test readState
-    await agent
-      .readState(canisterId, {
+    try {
+      await agent.readState(canisterId, {
         paths: [[new ArrayBuffer(16)]],
-      })
-      .catch((reason: AgentError) => {
-        expect(reason.message).toBe(expectedError);
       });
+    } catch (error) {
+      expect(error.message).toBe(expectedError);
+    }
   });
 });
 describe('replace identity', () => {

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -6,11 +6,18 @@ import { Principal } from '@dfinity/principal';
 import { requestIdOf } from '../../request_id';
 
 import { JSDOM } from 'jsdom';
-import { AnonymousIdentity } from '../..';
+import { AnonymousIdentity, Identity } from '../..';
+import { Ed25519KeyIdentity } from '../../../../identity/src/identity/ed25519';
 import { AgentError } from '../../errors';
 const { window } = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`);
 window.fetch = global.fetch;
 global.window = window;
+
+function createIdentity(seed: number): Ed25519KeyIdentity {
+  const seed1 = new Array(32).fill(0);
+  seed1[0] = seed;
+  return Ed25519KeyIdentity.generate(new Uint8Array(seed1));
+}
 
 const originalDateNowFn = global.Date.now;
 const originalWindow = global.window;
@@ -257,13 +264,7 @@ describe('getDefaultFetch', () => {
 });
 
 describe('invalidate identity', () => {
-  const mockFetch: jest.Mock = jest.fn((resource, init) => {
-    return Promise.resolve(
-      new Response(null, {
-        status: 200,
-      }),
-    );
-  });
+  const mockFetch: jest.Mock = jest.fn();
   it('should allow its identity to be invalidated', () => {
     const identity = new AnonymousIdentity();
     const agent = new HttpAgent({ identity, fetch: mockFetch, host: 'http://localhost' });
@@ -275,18 +276,80 @@ describe('invalidate identity', () => {
     const identity = new AnonymousIdentity();
     const agent = new HttpAgent({ identity, fetch: mockFetch, host: 'http://localhost' });
     agent.invalidateIdentity();
+
+    const expectedError =
+      "This identity has expired due this application's security policy. Please refresh your authentication.";
+
+    // Test Agent.call
     await agent
       .call(canisterId, {
         methodName: 'test',
         arg: new ArrayBuffer(16),
       })
       .catch((reason: AgentError) => {
-        expect(reason.message).toBe(
-          "This identity has expired due this application's security policy. Please refresh your authentication.",
-        );
+        expect(reason.message).toBe(expectedError);
+      });
+    // Test Agent.query
+    await agent
+      .query(canisterId, {
+        methodName: 'test',
+        arg: new ArrayBuffer(16),
+      })
+      .catch((reason: AgentError) => {
+        expect(reason.message).toBe(expectedError);
+      });
+    // Test readState
+    await agent
+      .readState(canisterId, {
+        paths: [[new ArrayBuffer(16)]],
+      })
+      .catch((reason: AgentError) => {
+        expect(reason.message).toBe(expectedError);
       });
   });
 });
 describe('replace identity', () => {
-  it.todo('should allow an actor to replace its identity');
+  it('should allow an actor to replace its identity', () => {
+    const identity = new AnonymousIdentity();
+    const agent = new HttpAgent({ identity, fetch: mockFetch, host: 'http://localhost' });
+
+    const identity2 = new AnonymousIdentity();
+    const replace = () => agent.replaceIdentity(identity2);
+    expect(replace).not.toThrowError();
+  });
+  it.only('should use the new identity in calls', async () => {
+    const mockFetch: jest.Mock = jest.fn((resource, init) => {
+      return Promise.resolve(
+        new Response(null, {
+          status: 200,
+        }),
+      );
+    });
+    const expectedError =
+      "This identity has expired due this application's security policy. Please refresh your authentication.";
+
+    const canisterId: Principal = Principal.fromText('2chl6-4hpzw-vqaaa-aaaaa-c');
+    const identity = new AnonymousIdentity();
+    const agent = new HttpAgent({ identity, fetch: mockFetch, host: 'http://localhost' });
+    // First invalidate identity
+    agent.invalidateIdentity();
+    await agent
+      .query(canisterId, {
+        methodName: 'test',
+        arg: new ArrayBuffer(16),
+      })
+      .catch((reason: AgentError) => {
+        // This should fail
+        expect(reason.message).toBe(expectedError);
+      });
+
+    // Then, add new identity
+    const identity2 = createIdentity(0);
+    agent.replaceIdentity(identity2);
+    await agent.call(canisterId, {
+      methodName: 'test',
+      arg: new ArrayBuffer(16),
+    });
+    expect(mockFetch).toBeCalledTimes(1);
+  });
 });

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -6,7 +6,7 @@ import { Principal } from '@dfinity/principal';
 import { requestIdOf } from '../../request_id';
 
 import { JSDOM } from 'jsdom';
-import { AnonymousIdentity, Identity } from '../..';
+import { AnonymousIdentity, Identity, SignIdentity } from '../..';
 import { Ed25519KeyIdentity } from '../../../../identity/src/identity/ed25519';
 import { AgentError } from '../../errors';
 const { window } = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`);
@@ -309,6 +309,7 @@ describe('invalidate identity', () => {
   });
 });
 describe('replace identity', () => {
+  const mockFetch: jest.Mock = jest.fn();
   it('should allow an actor to replace its identity', () => {
     const identity = new AnonymousIdentity();
     const agent = new HttpAgent({ identity, fetch: mockFetch, host: 'http://localhost' });
@@ -317,7 +318,7 @@ describe('replace identity', () => {
     const replace = () => agent.replaceIdentity(identity2);
     expect(replace).not.toThrowError();
   });
-  it.only('should use the new identity in calls', async () => {
+  it('should use the new identity in calls', async () => {
     const mockFetch: jest.Mock = jest.fn((resource, init) => {
       return Promise.resolve(
         new Response(null, {
@@ -344,7 +345,7 @@ describe('replace identity', () => {
       });
 
     // Then, add new identity
-    const identity2 = createIdentity(0);
+    const identity2 = createIdentity(0) as unknown as SignIdentity;
     agent.replaceIdentity(identity2);
     await agent.call(canisterId, {
       methodName: 'test',

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -206,12 +206,12 @@ export class HttpAgent implements Agent {
     },
     identity?: Identity | Promise<Identity>,
   ): Promise<SubmitResponse> {
-    if (!this._identity) {
+    const id = await (identity !== undefined ? await identity : await this._identity);
+    if (!id) {
       throw new Error(
         "This identity has expired due this application's security policy. Please refresh your authentication.",
       );
     }
-    const id = (await (identity !== undefined ? await identity : await this._identity)) as Identity;
     const canister = Principal.from(canisterId);
     const ecid = options.effectiveCanisterId
       ? Principal.from(options.effectiveCanisterId)
@@ -281,8 +281,7 @@ export class HttpAgent implements Agent {
     identity?: Identity | Promise<Identity>,
   ): Promise<QueryResponse> {
     const id = await (identity !== undefined ? await identity : await this._identity);
-
-    if (!this._identity) {
+    if (!id) {
       throw new IdentityInvalidError(
         "This identity has expired due this application's security policy. Please refresh your authentication.",
       );
@@ -343,7 +342,7 @@ export class HttpAgent implements Agent {
   ): Promise<ReadStateResponse> {
     const canister = typeof canisterId === 'string' ? Principal.fromText(canisterId) : canisterId;
     const id = await (identity !== undefined ? await identity : await this._identity);
-    if (!this._identity) {
+    if (!id) {
       throw new IdentityInvalidError(
         "This identity has expired due this application's security policy. Please refresh your authentication.",
       );

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -54,13 +54,11 @@ const IC0_SUB_DOMAIN = '.ic0.app';
 class HttpDefaultFetchError extends AgentError {
   constructor(public readonly message: string) {
     super(message);
-    Object.setPrototypeOf(this, HttpDefaultFetchError.prototype);
   }
 }
 export class IdentityInvalidError extends AgentError {
   constructor(public readonly message: string) {
     super(message);
-    Object.setPrototypeOf(this, IdentityInvalidError.prototype);
   }
 }
 

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -1,7 +1,7 @@
 import { JsonObject } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import { AgentError } from '../../errors';
-import { AnonymousIdentity, Identity } from '../../auth';
+import { AnonymousIdentity, Identity, SignIdentity } from '../../auth';
 import * as cbor from '../../cbor';
 import { requestIdOf } from '../../request_id';
 import { fromHex } from '../../utils/buffer';
@@ -423,6 +423,10 @@ export class HttpAgent implements Agent {
 
   public invalidateIdentity(): void {
     this._identity = null;
+  }
+
+  public replaceIdentity(identity: Identity): void {
+    this._identity = Promise.resolve(identity);
   }
 
   protected _transform(request: HttpAgentRequest): Promise<HttpAgentRequest> {

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -208,7 +208,7 @@ export class HttpAgent implements Agent {
   ): Promise<SubmitResponse> {
     const id = await (identity !== undefined ? await identity : await this._identity);
     if (!id) {
-      throw new Error(
+      throw new IdentityInvalidError(
         "This identity has expired due this application's security policy. Please refresh your authentication.",
       );
     }

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -1,7 +1,7 @@
 import { JsonObject } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import { AgentError } from '../../errors';
-import { AnonymousIdentity, Identity, SignIdentity } from '../../auth';
+import { AnonymousIdentity, Identity } from '../../auth';
 import * as cbor from '../../cbor';
 import { requestIdOf } from '../../request_id';
 import { fromHex } from '../../utils/buffer';

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -4,4 +4,9 @@
  *
  * @todo https://github.com/dfinity/agent-js/issues/420
  */
-export class AgentError extends Error {}
+export class AgentError extends Error {
+  constructor(public readonly message: string) {
+    super(message);
+    Object.setPrototypeOf(this, AgentError.prototype);
+  }
+}


### PR DESCRIPTION
A step toward idle timeouts in auth-client