### PR TITLE
fix: make makeNonce return unique random values

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -10,6 +10,13 @@
     <h1>Agent-JS Changelog</h1>
 
     <section>
+      <h2>Version 0.10.5</h2>
+      <ul>
+        <li>
+          makeNonce now returns unique values. Previously only the first byte of the nonce was
+          populated.
+        </li>
+      </ul>
       <h2>Version 0.10.3</h2>
       <ul>
         <li>

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -1,13 +1,14 @@
 import { HttpAgent, Nonce } from '../index';
 import * as cbor from '../../cbor';
 import { Expiry, makeNonceTransform } from './transforms';
-import { CallRequest, Envelope, SubmitRequestType } from './types';
+import { CallRequest, Envelope, makeNonce, SubmitRequestType } from './types';
 import { Principal } from '@dfinity/principal';
 import { requestIdOf } from '../../request_id';
 
 import { JSDOM } from 'jsdom';
 import { AnonymousIdentity, SignIdentity } from '../..';
 import { Ed25519KeyIdentity } from '../../../../identity/src/identity/ed25519';
+import { toHexString } from '../../../../identity/src/buffer';
 import { AgentError } from '../../errors';
 const { window } = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`);
 window.fetch = global.fetch;
@@ -353,4 +354,11 @@ describe('replace identity', () => {
     });
     expect(mockFetch).toBeCalledTimes(1);
   });
+});
+describe('makeNonce should create unique values', () => {
+  const nonces = new Set();
+  for (let i = 0; i < 100; i++) {
+    nonces.add(toHexString(makeNonce()));
+  }
+  expect(nonces.size).toBe(100);
 });

--- a/packages/agent/src/agent/http/types.ts
+++ b/packages/agent/src/agent/http/types.ts
@@ -107,10 +107,12 @@ export function makeNonce(): Nonce {
   // Encode 128 bits.
   const buffer = new ArrayBuffer(16);
   const view = new DataView(buffer);
-  const value = BigInt(+Date.now()) * BigInt(100000) + BigInt(Math.floor(Math.random() * 100000));
-  view.setBigUint64(0, value);
-  // tslint:disable-next-line:no-bitwise
-  view.setBigUint64(1, value >> BigInt(64));
+  const now = BigInt(+Date.now());
+  const randHi = Math.floor(Math.random() * 0xffffffff);
+  const randLo = Math.floor(Math.random() * 0xffffffff);
+  view.setBigUint64(0, now);
+  view.setUint32(8, randHi);
+  view.setUint32(12, randLo);
 
   return buffer as Nonce;
 }


### PR DESCRIPTION
# Description

The makeNonce method ended up returning the same value: 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

There were a couple problems:
- DateTime.now() * 100,000 didn't extend any values into the high 64 bits
- view.setBigUint64(1, value) sets 8 bytes starting at byte offset 1, not the address of the second biguint64

The end result was that only the first byte of the nonce would have a nonzero value.

This change puts the current time in the high 64 bits (the first several bytes are still zero), and fills the low 64 bits with random data.

Fixes https://dfinity.atlassian.net/browse/SDK-396

# How Has This Been Tested?

The first commit in this branch added a unit test, the failure of which demonstrates that the nonce values were not unique.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] There were no required changes to the documentation.
