### PR TITLE
feat: add window config string

### DIFF
--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -217,17 +217,32 @@ describe('Auth Client login', () => {
     const client = await AuthClient.create();
     // Try without #authorize hash.
     await client.login({ identityProvider: 'http://localhost' });
-    expect(global.open).toBeCalledWith('http://localhost/#authorize', 'idpWindow');
+    expect(global.open).toBeCalledWith('http://localhost/#authorize', 'idpWindow', undefined);
 
     // Try with #authorize hash.
     global.open = jest.fn();
     await client.login({ identityProvider: 'http://localhost#authorize' });
-    expect(global.open).toBeCalledWith('http://localhost/#authorize', 'idpWindow');
+    expect(global.open).toBeCalledWith('http://localhost/#authorize', 'idpWindow', undefined);
 
     // Default url
     global.open = jest.fn();
     await client.login();
-    expect(global.open).toBeCalledWith('https://identity.ic0.app/#authorize', 'idpWindow');
+    expect(global.open).toBeCalledWith(
+      'https://identity.ic0.app/#authorize',
+      'idpWindow',
+      undefined,
+    );
+
+    // Default custom window.open feature
+    global.open = jest.fn();
+    await client.login({
+      windowOpenerFeatures: 'toolbar=0,location=0,menubar=0',
+    });
+    expect(global.open).toBeCalledWith(
+      'https://identity.ic0.app/#authorize',
+      'idpWindow',
+      'toolbar=0,location=0,menubar=0',
+    );
   });
 
   it('should ignore authorize-ready events with bad origin', async () => {

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -1,6 +1,5 @@
 /** @module AuthClient */
 import {
-  Actor,
   AnonymousIdentity,
   DerEncodedPublicKey,
   Identity,
@@ -64,6 +63,11 @@ export interface AuthClientLoginOptions {
    * @default  BigInt(8) hours * BigInt(3_600_000_000_000) nanoseconds
    */
   maxTimeToLive?: bigint;
+  /**
+   * Auth Window feature config string
+   * @example "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100"
+   */
+  windowOpenerFeatures?: string;
   /**
    * Callback once login has completed
    */
@@ -342,26 +346,7 @@ export class AuthClient {
    *  }
    * });
    */
-  public async login(options?: {
-    /**
-     * Identity provider
-     * @default "https://identity.ic0.app"
-     */
-    identityProvider?: string | URL;
-    /**
-     * Expiration of the authentication in nanoseconds
-     * @default  BigInt(8) hours * BigInt(3_600_000_000_000) nanoseconds
-     */
-    maxTimeToLive?: bigint;
-    /**
-     * Callback once login has completed
-     */
-    onSuccess?: (() => void) | (() => Promise<void>);
-    /**
-     * Callback in case authentication fails
-     */
-    onError?: ((error?: string) => void) | ((error?: string) => Promise<void>);
-  }): Promise<void> {
+  public async login(options?: AuthClientLoginOptions): Promise<void> {
     let key = this._key;
     if (!key) {
       // Create a new key (whether or not one was in storage).
@@ -393,7 +378,9 @@ export class AuthClient {
     window.addEventListener('message', this._eventHandler);
 
     // Open a new window with the IDP provider.
-    this._idpWindow = window.open(identityProviderUrl.toString(), 'idpWindow') ?? undefined;
+    this._idpWindow =
+      window.open(identityProviderUrl.toString(), 'idpWindow', options?.windowOpenerFeatures) ??
+      undefined;
 
     // Check if the _idpWindow is closed by user.
     const checkInterruption = (): void => {

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -348,7 +348,31 @@ export class AuthClient {
    *  }
    * });
    */
-  public async login(options?: AuthClientLoginOptions): Promise<void> {
+  public async login(options?: {
+    /**
+     * Identity provider
+     * @default "https://identity.ic0.app"
+     */
+    identityProvider?: string | URL;
+    /**
+     * Expiration of the authentication in nanoseconds
+     * @default  BigInt(8) hours * BigInt(3_600_000_000_000) nanoseconds
+     */
+    maxTimeToLive?: bigint;
+    /**
+     * Auth Window feature config string
+     * @example "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100"
+     */
+    windowOpenerFeatures?: string;
+    /**
+     * Callback once login has completed
+     */
+    onSuccess?: (() => void) | (() => Promise<void>);
+    /**
+     * Callback in case authentication fails
+     */
+    onError?: ((error?: string) => void) | ((error?: string) => Promise<void>);
+  }): Promise<void> {
     let key = this._key;
     if (!key) {
       // Create a new key (whether or not one was in storage).

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -331,13 +331,15 @@ export class AuthClient {
    * @param {AuthClientLoginOptions} options
    * @param options.identityProvider Identity provider
    * @param options.maxTimeToLive Expiration of the authentication in nanoseconds
+   * @param options.windowOpenerFeatures Configures the opened authentication window
    * @param options.onSuccess Callback once login has completed
    * @param options.onError Callback in case authentication fails
    * @example
    * const authClient = await AuthClient.create();
    * authClient.login({
    *  identityProvider: 'http://<canisterID>.localhost:8000',
-   *  maxTimeToLive: BigInt (7) * BigInt(24) * BigInt(3_600_000_000_000) // 1 week
+   *  maxTimeToLive: BigInt (7) * BigInt(24) * BigInt(3_600_000_000_000), // 1 week
+   *  windowOpenerFeatures: "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100",
    *  onSuccess: () => {
    *    console.log('Login Successful!');
    *  },


### PR DESCRIPTION
# Description

This extends the `AuthClientLoginOptions` interface to include a configuration string used to pass to the `window.open` function. Using this string allows the user to configure the opened II authentication window.

**Tested by locally applying a sample configuration and updating the test suite**:

<img width="1383" alt="Screenshot 2022-04-06 at 21 49 24" src="https://user-images.githubusercontent.com/2835032/162059460-be03b3b9-eafa-481f-89f6-65230c59c5b6.png">

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

## Guidance needed 🙏 
- [ ] I have edited the CHANGELOG accordingly. (should I update the html?)
- [ ] I have made corresponding changes to the documentation. (how can I update the docs?)
