### PR TITLE
feat: generate nonce for HttpAgent calls

### DIFF
--- a/demos/ledgerhq/src/main.js
+++ b/demos/ledgerhq/src/main.js
@@ -82,8 +82,6 @@ document.getElementById('sendBtn').addEventListener('click', async () => {
 
   // Need to run a replica locally which has ledger canister running on it
   const agent = new HttpAgent({ host, identity });
-  // Ledger Hardware Wallet requires that the request must contain a nonce
-  agent.addTransform(makeNonceTransform());
 
   const resp = await agent.call(canisterId, {
     methodName: document.getElementById('methodName').value,

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -32,7 +32,7 @@
           HttpAgent now generates a nonce to ensure that calls are unique by default. If you want to
           opt out or provide your own nonce logic, you can now pass an option of
           <pre>disableNonce: true</pre>
-          during the agent initalization.
+          during the agent initialization.
         </li>
       </ul>
       <h2>Version 0.10.3</h2>

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -28,6 +28,12 @@
           versions to 0 for major version updates
         </li>
         <li>Removes jest-expect-message, which was making test error messages less useful</li>
+        <li>
+          HttpAgent now generates a nonce to ensure that calls are unique by default. If you want to
+          opt out or provide your own nonce logic, you can now pass an option of
+          <pre>disableNonce: true</pre>
+          during the agent initalization.
+        </li>
       </ul>
       <h2>Version 0.10.3</h2>
       <ul>

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -29,10 +29,17 @@
         </li>
         <li>Removes jest-expect-message, which was making test error messages less useful</li>
         <li>
-          HttpAgent now generates a nonce to ensure that calls are unique by default. If you want to
-          opt out or provide your own nonce logic, you can now pass an option of
-          <pre>disableNonce: true</pre>
-          during the agent initialization.
+          <p>
+            HttpAgent now generates a nonce to ensure that calls are unique by default. If you want
+            to opt out or provide your own nonce logic, you can now pass an option of
+            <code>disableNonce: true</code>during the agent initialization.
+          </p>
+          <p>
+            If you are currently using
+            <code>agent.addTransform(makeNonceTransform())</code>
+            , please note that you should remove that logic, or add the <code>disableNonce</code>
+            option to your agent when upgrading.
+          </p>
         </li>
       </ul>
       <h2>Version 0.10.3</h2>

--- a/e2e/node/basic/counter.test.ts
+++ b/e2e/node/basic/counter.test.ts
@@ -1,9 +1,9 @@
 /**
  * @jest-environment node
  */
-import counterCanister from '../canisters/counter';
+import counterCanister, { noncelessCanister } from '../canisters/counter';
 
-jest.setTimeout(30000);
+jest.setTimeout(40000);
 describe('counter', () => {
   it('should greet', async () => {
     const { actor: counter } = await counterCanister();
@@ -12,6 +12,26 @@ describe('counter', () => {
     } catch (error) {
       console.error(error);
     }
+  });
+  it('should submit distinct requests with nonce by default', async () => {
+    const { actor: counter } = await counterCanister();
+    const values = await Promise.all(new Array(4).fill(undefined).map(() => counter.inc_read()));
+    const set1 = new Set(values);
+    const values2 = await Promise.all(new Array(4).fill(undefined).map(() => counter.inc_read()));
+    const set2 = new Set(values2);
+
+    // Sets of unique results should be the same length
+    expect(set1.size).toBe(values.length);
+    expect(set2.size).toEqual(values2.length);
+  });
+  it('should submit duplicate requests if nonce is disabled', async () => {
+    const { actor: counter } = await noncelessCanister();
+    const values = await Promise.all(new Array(4).fill(undefined).map(() => counter.inc_read()));
+    const set1 = new Set(values);
+    const values2 = await Promise.all(new Array(4).fill(undefined).map(() => counter.inc_read()));
+    const set2 = new Set(values2);
+
+    expect(set1.size < values.length || set2.size < values2.length).toBe(true);
   });
   it('should increment', async () => {
     const { actor: counter } = await counterCanister();

--- a/e2e/node/canisters/counter.ts
+++ b/e2e/node/canisters/counter.ts
@@ -1,9 +1,9 @@
-import { Actor } from '@dfinity/agent';
+import { Actor, HttpAgent } from '@dfinity/agent';
 import { IDL } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import { readFileSync } from 'fs';
 import path from 'path';
-import agent from '../utils/agent';
+import agent, { port, identity } from '../utils/agent';
 
 let cache: {
   canisterId: Principal;
@@ -27,6 +27,7 @@ export default async function (): Promise<{
     const idl: IDL.InterfaceFactory = ({ IDL }) => {
       return IDL.Service({
         inc: IDL.Func([], [], []),
+        inc_read: IDL.Func([], [IDL.Nat], []),
         read: IDL.Func([], [IDL.Nat], ['query']),
         greet: IDL.Func([IDL.Text], [IDL.Text], []),
         queryGreet: IDL.Func([IDL.Text], [IDL.Text], ['query']),
@@ -41,4 +42,42 @@ export default async function (): Promise<{
   }
 
   return cache;
+}
+/**
+ * With no cache and nonce disabled
+ */
+export async function noncelessCanister(): Promise<{
+  canisterId: Principal;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  actor: any;
+}> {
+  const module = readFileSync(path.join(__dirname, 'counter.wasm'));
+  const disableNonceAgent = await Promise.resolve(
+    new HttpAgent({
+      host: 'http://127.0.0.1:' + port,
+      identity,
+      disableNonce: true,
+    }),
+  ).then(async agent => {
+    await agent.fetchRootKey();
+    return agent;
+  });
+
+  const canisterId = await Actor.createCanister({ agent: disableNonceAgent });
+  await Actor.install({ module }, { canisterId, agent: disableNonceAgent });
+  const idl: IDL.InterfaceFactory = ({ IDL }) => {
+    return IDL.Service({
+      inc: IDL.Func([], [], []),
+      inc_read: IDL.Func([], [IDL.Nat], []),
+      read: IDL.Func([], [IDL.Nat], ['query']),
+      greet: IDL.Func([IDL.Text], [IDL.Text], []),
+      queryGreet: IDL.Func([IDL.Text], [IDL.Text], ['query']),
+    });
+  };
+
+  return {
+    canisterId,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    actor: Actor.createActor(idl, { canisterId, agent: await disableNonceAgent }) as any,
+  };
 }

--- a/e2e/node/utils/agent.ts
+++ b/e2e/node/utils/agent.ts
@@ -1,10 +1,10 @@
-import { HttpAgent, makeNonceTransform } from '@dfinity/agent';
+import { HttpAgent } from '@dfinity/agent';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 
-const identity = Ed25519KeyIdentity.generate();
+export const identity = Ed25519KeyIdentity.generate();
 export const principal = identity.getPrincipal();
 
-const port = parseInt(process.env['REPLICA_PORT'] || '', 10);
+export const port = parseInt(process.env['REPLICA_PORT'] || '', 10);
 if (Number.isNaN(port)) {
   throw new Error('The environment variable REPLICA_PORT is not a number.');
 }
@@ -12,7 +12,6 @@ if (Number.isNaN(port)) {
 const agent = Promise.resolve(new HttpAgent({ host: 'http://127.0.0.1:' + port, identity })).then(
   async agent => {
     await agent.fetchRootKey();
-    agent.addTransform(makeNonceTransform());
     return agent;
   },
 );

--- a/packages/agent/src/actor.test.ts
+++ b/packages/agent/src/actor.test.ts
@@ -98,7 +98,7 @@ describe('makeActor', () => {
 
     let nonceCount = 0;
 
-    const httpAgent = new HttpAgent({ fetch: mockFetch });
+    const httpAgent = new HttpAgent({ fetch: mockFetch, disableNonce: true });
     httpAgent.addTransform(makeNonceTransform(() => nonces[nonceCount++]));
 
     const actor = Actor.createActor(actorInterface, { canisterId, agent: httpAgent });

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -49,7 +49,6 @@ test('call', async () => {
   const principal = Principal.anonymous();
 
   const httpAgent = new HttpAgent({ fetch: mockFetch, host: 'http://localhost' });
-  httpAgent.addTransform(makeNonceTransform(() => nonce));
 
   const methodName = 'greet';
   const arg = new Uint8Array([]);
@@ -116,7 +115,11 @@ test('queries with the same content should have the same signature', async () =>
 
   const principal = await Principal.anonymous();
 
-  const httpAgent = new HttpAgent({ fetch: mockFetch, host: 'http://localhost' });
+  const httpAgent = new HttpAgent({
+    fetch: mockFetch,
+    host: 'http://localhost',
+    disableNonce: true,
+  });
   httpAgent.addTransform(makeNonceTransform(() => nonce));
 
   const methodName = 'greet';
@@ -188,7 +191,11 @@ test('use anonymous principal if unspecified', async () => {
   const nonce = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]) as Nonce;
   const principal = Principal.anonymous();
 
-  const httpAgent = new HttpAgent({ fetch: mockFetch, host: 'http://localhost' });
+  const httpAgent = new HttpAgent({
+    fetch: mockFetch,
+    host: 'http://localhost',
+    disableNonce: true,
+  });
   httpAgent.addTransform(makeNonceTransform(() => nonce));
 
   const methodName = 'greet';


### PR DESCRIPTION
# Description

HttpAgent will now provide a unique nonce in calls to ensure that the replica treats each call as unique.

# How Has This Been Tested?

Tested in our integration test suie

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
