### PR TITLE
chore: replaces peacock.dev redirects with agent-js.icp.host

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -4,7 +4,7 @@ JavaScript and TypeScript library to interact with the [Internet Computer](https
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://peacock.dev/agent-docs).
+Additional API Documentation can be found [here](https://agent-js.icp.host/agent/index.html).
 
 ---
 

--- a/packages/auth-client/README.md
+++ b/packages/auth-client/README.md
@@ -6,7 +6,7 @@ Simple interface to get your web application authenticated with the Internet Ide
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://peacock.dev/auth-client-docs).
+Additional API Documentation can be found [here](https://agent-js.icp.host/auth-client/index.html).
 
 ---
 

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -4,7 +4,7 @@ JavaScript and TypeScript library to support manage Identities and enable simple
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://peacock.dev/authentication-docs).
+Additional API Documentation can be found [here](https://agent-js.icp.host/authentication/index.html).
 
 ---
 

--- a/packages/candid/README.md
+++ b/packages/candid/README.md
@@ -4,7 +4,7 @@ JavaScript and TypeScript library to work with Candid interfaces
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://peacock.dev/principal-docs).
+Additional API Documentation can be found [here](https://agent-js.icp.host/candid/index.html).
 
 ---
 

--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -4,7 +4,7 @@ JavaScript and TypeScript library to manage Identities and enable simple Web Aut
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://peacock.dev/identity-docs).
+Additional API Documentation can be found [here](https://agent-js.icp.host/identity/index.html).
 
 ---
 

--- a/packages/principal/README.md
+++ b/packages/principal/README.md
@@ -4,7 +4,7 @@ JavaScript and TypeScript library to work with Internet Computer Principals
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://peacock.dev/principal-docs).
+Additional API Documentation can be found [here](https://agent-js.icp.host/principal/index.html).
 
 ---
 


### PR DESCRIPTION
Replaces a redirect via peacock.dev to our docs with an IC-native option.