### PR TITLE
fix: don't use spread operator when encoding vec

### DIFF
--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -160,6 +160,7 @@ test('IDL encoding (array)', () => {
     '4449444c016d7c01000400010203',
     'Array of Ints',
   );
+  IDL.encode([IDL.Vec(IDL.Nat16)], [new Array(200000).fill(42)]);
   expect(() => IDL.encode([IDL.Vec(IDL.Int)], [BigInt(0)])).toThrow(/Invalid vec int argument/);
   expect(() => IDL.encode([IDL.Vec(IDL.Int)], [['fail']])).toThrow(/Invalid vec int argument/);
 });

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -747,11 +747,13 @@ export class VecClass<T> extends ConstructType<T[]> {
     if (this._blobOptimization) {
       return concat(len, new Uint8Array(x as unknown as number[]));
     }
-    let res = len;
+    const buf = new Pipe(new ArrayBuffer(len.byteLength + x.length), 0);
+    buf.write(len);
     for (const d of x) {
-      res = concat(res, this._type.encodeValue(d));
+      const encoded = this._type.encodeValue(d);
+      buf.write(new Uint8Array(encoded));
     }
-    return res;
+    return buf.buffer;
   }
 
   public _buildTypeTableImpl(typeTable: TypeTable) {

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -747,8 +747,11 @@ export class VecClass<T> extends ConstructType<T[]> {
     if (this._blobOptimization) {
       return concat(len, new Uint8Array(x as unknown as number[]));
     }
-
-    return concat(len, ...x.map(d => this._type.encodeValue(d)));
+    let res = len;
+    for (const d of x) {
+      res = concat(res, this._type.encodeValue(d));
+    }
+    return res;
   }
 
   public _buildTypeTableImpl(typeTable: TypeTable) {


### PR DESCRIPTION
The spread operator (and Array.assign) loads the entire source array onto the stack, then pushes it onto the destination array. It causes stack overflow with large vector.