### PR TITLE
fix: Correctly decode optional struct fields

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -10,7 +10,11 @@
     <h1>Agent-JS Changelog</h1>
 
     <section>
-      <h2>Version 0.10.5</h2>
+      <h2>Version 0.11.1</h2>
+      <ul>
+        <li>Fix for a corner case that could lead to incorrect decoding of record types.</li>
+      </ul>
+      <h2>Version 0.11.0</h2>
       <ul>
         <li>
           makeNonce now returns unique values. Previously only the first byte of the nonce was

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -6,6 +6,8 @@ import * as IDL from './idl';
 import { Principal } from '@dfinity/principal';
 import { fromHexString, toHexString } from './utils/buffer';
 import { idlLabelToId } from './utils/hash';
+import fs from 'fs';
+import { fromHex, toHex } from '@dfinity/agent/lib/cjs/utils/buffer';
 
 function testEncode(typ: IDL.Type, val: any, hex: string, _str: string) {
   expect(toHexString(IDL.encode([typ], [val]))).toEqual(hex);
@@ -543,7 +545,21 @@ test('decode unknown func', () => {
     fromHexString('4449444c016a0171017d01010100010103caffee03666f6f'),
   )[0] as any;
   expect(value).toEqual([Principal.fromText('w7x7r-cok77-xa'), 'foo']);
-  expect(value.type()).toEqual(IDL.Func([], [], []));
+  expect(value.type()).toEqual(IDL.Func([IDL.Text], [IDL.Nat], ['query']));
+});
+
+test('decode unknown funcasdf', () => {
+  const value = IDL.decode(
+    [IDL.Unknown],
+    fromHexString('4449444c016a0371717a027178010101000101000c696e7374616c6c5f636f6465'),
+  )[0] as any;
+});
+
+it('fooo2', () => {
+  fs.readFile('candid.txt', 'utf8', (err, data) => {
+    const decoded = IDL.decode([IDL.Unknown], fromHex(data))[0] as any;
+    console.log(decoded.type().display());
+  });
 });
 
 test('decode / encode unknown mutual recursive lists', () => {

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -608,3 +608,23 @@ test('decode / encode unknown nested record', () => {
   const decodedValue2 = IDL.decode([recordType], fromHexString(reencoded))[0] as any;
   expect(decodedValue2).toEqual(value);
 });
+
+test('should correctly decode expected optional fields with lower hash than required fields', () => {
+  const HttpResponse = IDL.Record({
+    body: IDL.Text,
+    headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+    streaming_strategy: IDL.Opt(IDL.Text),
+    status_code: IDL.Int,
+    upgrade: IDL.Opt(IDL.Bool),
+  });
+  const encoded =
+    '4449444c036c04a2f5ed880471c6a4a19806019ce9c69906029aa1b2f90c7c6d7f6e7e010003666f6f000101c801';
+  const value = IDL.decode([HttpResponse], fromHexString(encoded))[0];
+  expect(value).toEqual({
+    body: 'foo',
+    headers: [],
+    status_code: BigInt(200),
+    streaming_strategy: [],
+    upgrade: [true],
+  });
+});

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -6,8 +6,6 @@ import * as IDL from './idl';
 import { Principal } from '@dfinity/principal';
 import { fromHexString, toHexString } from './utils/buffer';
 import { idlLabelToId } from './utils/hash';
-import fs from 'fs';
-import { fromHex, toHex } from '@dfinity/agent/lib/cjs/utils/buffer';
 
 function testEncode(typ: IDL.Type, val: any, hex: string, _str: string) {
   expect(toHexString(IDL.encode([typ], [val]))).toEqual(hex);
@@ -536,7 +534,7 @@ test('decode unknown service', () => {
     fromHexString('4449444c026a0171017d00690103666f6f0001010103caffee'),
   )[0] as any;
   expect(value).toEqual(Principal.fromText('w7x7r-cok77-xa'));
-  expect(value.type()).toEqual(IDL.Service({}));
+  expect(value.type()).toEqual(IDL.Service({ foo: IDL.Func([IDL.Text], [IDL.Nat], []) }));
 });
 
 test('decode unknown func', () => {
@@ -546,20 +544,6 @@ test('decode unknown func', () => {
   )[0] as any;
   expect(value).toEqual([Principal.fromText('w7x7r-cok77-xa'), 'foo']);
   expect(value.type()).toEqual(IDL.Func([IDL.Text], [IDL.Nat], ['query']));
-});
-
-test('decode unknown funcasdf', () => {
-  const value = IDL.decode(
-    [IDL.Unknown],
-    fromHexString('4449444c016a0371717a027178010101000101000c696e7374616c6c5f636f6465'),
-  )[0] as any;
-});
-
-it('fooo2', () => {
-  fs.readFile('candid.txt', 'utf8', (err, data) => {
-    const decoded = IDL.decode([IDL.Unknown], fromHex(data))[0] as any;
-    console.log(decoded.type().display());
-  });
 });
 
 test('decode / encode unknown mutual recursive lists', () => {

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -922,32 +922,43 @@ export class RecordClass extends ConstructType<Record<string, any>> {
       throw new Error('Not a record type');
     }
     const x: Record<string, any> = {};
-    let idx = 0;
-    for (const [hash, type] of record._fields) {
-      let [expectKey, expectType] = this._fields[idx];
 
-      // skip expected optional fields that are not present in the data
-      while (
-        (expectType instanceof OptClass || expectType instanceof ReservedClass) &&
-        idx < this._fields.length &&
-        idlLabelToId(this._fields[idx][0]) !== idlLabelToId(hash)
-      ) {
-        x[expectKey] = [];
-        idx++;
-        [expectKey, expectType] = this._fields[idx];
-      }
+    let expectedRecordIdx = 0;
+    let actualRecordIdx = 0;
+    while (actualRecordIdx < record._fields.length) {
+      const [hash, type] = record._fields[actualRecordIdx];
 
-      if (idx >= this._fields.length || idlLabelToId(this._fields[idx][0]) !== idlLabelToId(hash)) {
-        // skip unexpected fields present in the data
+      if (expectedRecordIdx >= this._fields.length) {
+        // skip unexpected left over fields present on the wire
         type.decodeValue(b, type);
+        actualRecordIdx++;
         continue;
       }
+
+      const [expectKey, expectType] = this._fields[expectedRecordIdx];
+      if (idlLabelToId(this._fields[expectedRecordIdx][0]) !== idlLabelToId(hash)) {
+        // the current field on the wire does not match the expected field
+
+        // skip expected optional fields that are not present on the wire
+        if (expectType instanceof OptClass || expectType instanceof ReservedClass) {
+          x[expectKey] = [];
+          expectedRecordIdx++;
+          continue;
+        }
+
+        // skip unexpected interspersed fields present on the wire
+        type.decodeValue(b, type);
+        actualRecordIdx++;
+        continue;
+      }
+
       x[expectKey] = expectType.decodeValue(b, type);
-      idx++;
+      expectedRecordIdx++;
+      actualRecordIdx++;
     }
 
     // initialize left over expected optional fields
-    for (const [expectKey, expectType] of this._fields.slice(idx)) {
+    for (const [expectKey, expectType] of this._fields.slice(expectedRecordIdx)) {
       if (expectType instanceof OptClass || expectType instanceof ReservedClass) {
         // TODO this assumes null value in opt is represented as []
         x[expectKey] = [];


### PR DESCRIPTION
# Description

Fixes incorrect decoding of optional struct fields.

# How Has This Been Tested?

A unit test for this corner case has been added.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
