### PR TITLE
feat: fast ArrayBuffer encoding

### DIFF
--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -155,10 +155,22 @@ test('IDL encoding (tuple)', () => {
 test('IDL encoding (arraybuffer)', () => {
   // ArrayBuffer, encode only.
   testEncode(
+    IDL.Vec(IDL.Nat8),
+    new Int8Array([0, 1, 2, 3]),
+    '4449444c016d7b01000400010203',
+    'Array of Nat8s',
+  );
+  testEncode(
     IDL.Vec(IDL.Int8),
     new Int8Array([0, 1, 2, 3]),
     '4449444c016d7701000400010203',
-    'Array of Ints',
+    'Array of Int8s',
+  );
+  testEncode(
+    IDL.Vec(IDL.Int16),
+    new Int16Array([0, 1, 2, 3, 32767, -1]),
+    '4449444c016d760100060000010002000300ff7fffff',
+    'Array of Int16s',
   );
   IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array()]);
   IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array(100).fill(42)]);

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -153,7 +153,6 @@ test('IDL encoding (tuple)', () => {
 });
 
 test('IDL encoding (arraybuffer)', () => {
-  // ArrayBuffer, encode only.
   test_(
     IDL.Vec(IDL.Nat8),
     new Uint8Array([0, 1, 2, 3]),

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -154,19 +154,19 @@ test('IDL encoding (tuple)', () => {
 
 test('IDL encoding (arraybuffer)', () => {
   // ArrayBuffer, encode only.
-  testEncode(
+  test_(
     IDL.Vec(IDL.Nat8),
-    new Int8Array([0, 1, 2, 3]),
+    new Uint8Array([0, 1, 2, 3]),
     '4449444c016d7b01000400010203',
     'Array of Nat8s',
   );
-  testEncode(
+  test_(
     IDL.Vec(IDL.Int8),
     new Int8Array([0, 1, 2, 3]),
     '4449444c016d7701000400010203',
     'Array of Int8s',
   );
-  testEncode(
+  test_(
     IDL.Vec(IDL.Int16),
     new Int16Array([0, 1, 2, 3, 32767, -1]),
     '4449444c016d760100060000010002000300ff7fffff',

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -152,6 +152,20 @@ test('IDL encoding (tuple)', () => {
   );
 });
 
+test('IDL encoding (arraybuffer)', () => {
+  // ArrayBuffer, encode only.
+  testEncode(
+    IDL.Vec(IDL.Int8),
+    new Int8Array([0, 1, 2, 3]),
+    '4449444c016d7701000400010203',
+    'Array of Ints',
+  );
+  IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array()]);
+  IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array(100).fill(42)]);
+  IDL.encode([IDL.Vec(IDL.Nat16)], [new Uint16Array(200).fill(42)]);
+  expect(() => IDL.encode([IDL.Vec(IDL.Int8)], [new Uint16Array(10).fill(420)])).toThrow(/Invalid vec int8 argument/);
+});
+
 test('IDL encoding (array)', () => {
   // Array
   test_(

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -172,6 +172,12 @@ test('IDL encoding (arraybuffer)', () => {
     '4449444c016d760100060000010002000300ff7fffff',
     'Array of Int16s',
   );
+  test_(
+    IDL.Vec(IDL.Nat64),
+    new BigUint64Array([BigInt(0), BigInt(1), BigInt(1) << BigInt(60), BigInt(13)]),
+    '4449444c016d780100040000000000000000010000000000000000000000000000100d00000000000000',
+    'Array of Nat64s',
+  );
   IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array()]);
   IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array(100).fill(42)]);
   IDL.encode([IDL.Vec(IDL.Nat16)], [new Uint16Array(200).fill(42)]);

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -790,8 +790,11 @@ export class VecClass<T> extends ConstructType<T[]> {
       if (this._type.bits == 16) {
         return new Uint16Array(b.read(len * 2)) as unknown as T[];
       }
-        if (this._type.bits == 32) {
+      if (this._type.bits == 32) {
         return new Uint32Array(b.read(len * 4)) as unknown as T[];
+      }
+      if (this._type.bits == 64) {
+        return new BigUint64Array(b.read(len * 8)) as unknown as T[];
       }
     }
 
@@ -802,8 +805,11 @@ export class VecClass<T> extends ConstructType<T[]> {
       if (this._type._bits == 16) {
         return new Int16Array(b.read(len * 2)) as unknown as T[];
       }
-        if (this._type._bits == 32) {
+      if (this._type._bits == 32) {
         return new Int32Array(b.read(len * 4)) as unknown as T[];
+      }
+      if (this._type._bits == 64) {
+        return new BigInt64Array(b.read(len * 8)) as unknown as T[];
       }
     }
 

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -741,8 +741,10 @@ export class VecClass<T> extends ConstructType<T[]> {
     return v.visitVec(this, this._type, d);
   }
 
-  public covariant(x: any): x is T[] {
-    return Array.isArray(x) && x.every(v => this._type.covariant(v));
+  public covariant(x: any) {
+    // Special case for ArrayBuffer
+    return (ArrayBuffer.isView(x) && (x.length == 0 || this._type.covariant(x[0])))
+           || (Array.isArray(x) && x.every(v => this._type.covariant(v)));
   }
 
   public encodeValue(x: T[]) {

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -753,6 +753,9 @@ export class VecClass<T> extends ConstructType<T[]> {
     if (this._blobOptimization) {
       return concat(len, new Uint8Array(x as unknown as number[]));
     }
+    if (ArrayBuffer.isView(x)) {
+      return concat(len, new Uint8Array(x.buffer));
+    }
     const buf = new Pipe(new ArrayBuffer(len.byteLength + x.length), 0);
     buf.write(len);
     for (const d of x) {

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -780,7 +780,31 @@ export class VecClass<T> extends ConstructType<T[]> {
     }
     const len = Number(lebDecode(b));
     if (this._blobOptimization) {
-      return [...new Uint8Array(b.read(len))] as unknown as T[];
+      return new Uint8Array(b.read(len)) as unknown as T[];
+    }
+
+    if (this._type instanceof FixedNatClass) {
+      if (this._type.bits == 8) {
+        return new Uint8Array(b.read(len)) as unknown as T[];
+      }
+      if (this._type.bits == 16) {
+        return new Uint16Array(b.read(len * 2)) as unknown as T[];
+      }
+        if (this._type.bits == 32) {
+        return new Uint32Array(b.read(len * 4)) as unknown as T[];
+      }
+    }
+
+    if (this._type instanceof FixedIntClass) {
+      if (this._type._bits == 8) {
+        return new Int8Array(b.read(len)) as unknown as T[];
+      }
+      if (this._type._bits == 16) {
+        return new Int16Array(b.read(len * 2)) as unknown as T[];
+      }
+        if (this._type._bits == 32) {
+        return new Int32Array(b.read(len * 4)) as unknown as T[];
+      }
     }
 
     const rets: T[] = [];

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -741,9 +741,9 @@ export class VecClass<T> extends ConstructType<T[]> {
     return v.visitVec(this, this._type, d);
   }
 
-  public covariant(x: any) {
+  public covariant(x: any): x is T[] {
     // Special case for ArrayBuffer
-    return (ArrayBuffer.isView(x) && (x.length == 0 || this._type.covariant(x[0])))
+    return (ArrayBuffer.isView(x) && (x.byteLength == 0 || this._type.covariant(x[0])))
            || (Array.isArray(x) && x.every(v => this._type.covariant(v)));
   }
 

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -621,7 +621,7 @@ export class FloatClass extends PrimitiveType<number> {
  * Represents an IDL fixed-width Int(n)
  */
 export class FixedIntClass extends PrimitiveType<bigint | number> {
-  constructor(private _bits: number) {
+  constructor(public _bits: number) {
     super();
   }
 
@@ -743,7 +743,9 @@ export class VecClass<T> extends ConstructType<T[]> {
 
   public covariant(x: any): x is T[] {
     // Special case for ArrayBuffer
-    return ArrayBuffer.isView(x) || (Array.isArray(x) && x.every(v => this._type.covariant(v)));
+    const bits = this._type instanceof FixedNatClass ? this._type.bits : (this._type instanceof FixedIntClass ? this._type._bits : 0);
+    return (ArrayBuffer.isView(x) && bits == (x as any).BYTES_PER_ELEMENT * 8)
+           || (Array.isArray(x) && x.every(v => this._type.covariant(v)));
   }
 
   public encodeValue(x: T[]) {

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -724,6 +724,10 @@ export class FixedNatClass extends PrimitiveType<bigint | number> {
 
 /**
  * Represents an IDL Array
+ *
+ * Arrays of fixed-sized nat/int type (e.g. nat8), are encoded from and decoded to TypedArrays (e.g. Uint8Array).
+ * Arrays of float or other non-primitive types are encoded/decoded as untyped array in Javascript.
+ *
  * @param {Type} t
  */
 export class VecClass<T> extends ConstructType<T[]> {
@@ -779,9 +783,6 @@ export class VecClass<T> extends ConstructType<T[]> {
       throw new Error('Not a vector type');
     }
     const len = Number(lebDecode(b));
-    if (this._blobOptimization) {
-      return new Uint8Array(b.read(len)) as unknown as T[];
-    }
 
     if (this._type instanceof FixedNatClass) {
       if (this._type.bits == 8) {

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -732,6 +732,11 @@ export class FixedNatClass extends PrimitiveType<bigint | number> {
  */
 export class VecClass<T> extends ConstructType<T[]> {
   // If true, this vector is really a blob and we can just use memcpy.
+  //
+  // NOTE:
+  // With support of encoding/dencoding of TypedArrays, this optimization is
+  // only used when plain array of bytes are passed as encoding input in order
+  // to be backward compatible.
   private _blobOptimization = false;
 
   constructor(protected _type: Type<T>) {

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -743,8 +743,7 @@ export class VecClass<T> extends ConstructType<T[]> {
 
   public covariant(x: any): x is T[] {
     // Special case for ArrayBuffer
-    return (ArrayBuffer.isView(x) && (x.byteLength == 0 || this._type.covariant(x[0])))
-           || (Array.isArray(x) && x.every(v => this._type.covariant(v)));
+    return ArrayBuffer.isView(x) || (Array.isArray(x) && x.every(v => this._type.covariant(v)));
   }
 
   public encodeValue(x: T[]) {


### PR DESCRIPTION
# Description

At the moment trying to encode large binary data is very inefficient because one has to convert them to Array first before passing to the IDL encode function.
In fact trying to convert 100MB ArrayBuffer to Array will result in OOM in Node.js.

This patch adds a special case to type check and allows directly passing ArrayBuffer (e.g. Uint8Array) to the encode function and solves the problem. 

# How Has This Been Tested?

A test case is added.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.