### PR TITLE
fix: homepage/repository in package.json

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -4,7 +4,15 @@
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to interact with the Internet Computer",
-  "homepage": "https://sdk.dfinity.org/docs/index.html",
+  "homepage": "https://smartcontracts.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfinity/agent-js.git",
+    "directory": "packages/agent"
+  },
+  "bugs": {
+      "url": "https://github.com/dfinity/agent-js/issues"
+  },
   "keywords": [
     "internet computer",
     "internet-computer",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -4,7 +4,15 @@
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to provide a simple integration with an IC Internet Identity",
-  "homepage": "https://sdk.dfinity.org/docs/index.html",
+  "homepage": "https://smartcontracts.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfinity/agent-js.git",
+    "directory": "packages/auth-client"
+  },
+  "bugs": {
+      "url": "https://github.com/dfinity/agent-js/issues"
+  },
   "keywords": [
     "internet computer",
     "ic",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -4,7 +4,15 @@
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to manage identity and authentication with the Internet Computer",
-  "homepage": "https://sdk.dfinity.org/docs/index.html",
+  "homepage": "https://smartcontracts.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfinity/agent-js.git",
+    "directory": "packages/authentication"
+  },
+  "bugs": {
+      "url": "https://github.com/dfinity/agent-js/issues"
+  },
   "keywords": [
     "internet computer",
     "ic",

--- a/packages/candid/package.json
+++ b/packages/candid/package.json
@@ -4,7 +4,15 @@
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to work with candid interfaces",
-  "homepage": "https://sdk.dfinity.org/docs/index.html",
+  "homepage": "https://smartcontracts.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfinity/agent-js.git",
+    "directory": "packages/candid"
+  },
+  "bugs": {
+      "url": "https://github.com/dfinity/agent-js/issues"
+  },
   "keywords": [
     "internet computer",
     "ic",

--- a/packages/identity-ledgerhq/package.json
+++ b/packages/identity-ledgerhq/package.json
@@ -4,7 +4,15 @@
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to manage identity and authentication with the Internet Computer",
-  "homepage": "https://sdk.dfinity.org/docs/index.html",
+  "homepage": "https://smartcontracts.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfinity/agent-js.git",
+    "directory": "packages/identity-ledgerhq"
+  },
+  "bugs": {
+      "url": "https://github.com/dfinity/agent-js/issues"
+  },
   "keywords": [
     "internet computer",
     "ic",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -4,7 +4,15 @@
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to manage identity with the Internet Computer",
-  "homepage": "https://sdk.dfinity.org/docs/index.html",
+  "homepage": "https://smartcontracts.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfinity/agent-js.git",
+    "directory": "packages/identity"
+  },
+  "bugs": {
+      "url": "https://github.com/dfinity/agent-js/issues"
+  },
   "keywords": [
     "internet computer",
     "ic",

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -4,7 +4,15 @@
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to work with Internet Computer principals",
-  "homepage": "https://sdk.dfinity.org/docs/index.html",
+  "homepage": "https://smartcontracts.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dfinity/agent-js.git",
+    "directory": "packages/principal"
+  },
+  "bugs": {
+      "url": "https://github.com/dfinity/agent-js/issues"
+  },
   "keywords": [
     "internet computer",
     "ic",


### PR DESCRIPTION
Signed-off-by: Dominic Woerner <dominic.woerner@dfinity.org>

# Description
Homepage link in npm registry was broken and link to repository/package and issue tracking was missing.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
