### PR TITLE
fix: Candid UI cannot encode nat8

### DIFF
--- a/packages/candid/src/candid-ui.ts
+++ b/packages/candid/src/candid-ui.ts
@@ -117,14 +117,14 @@ class Parse extends IDL.Visitor<string, any> {
   public visitFloat(t: IDL.FloatClass, v: string): number {
     return parseFloat(v);
   }
-  public visitFixedInt(t: FixedIntClass, v: string): number | bigint {
+  public visitFixedInt(t: IDL.FixedIntClass, v: string): number | bigint {
     if (t._bits <= 32) {
       return parseInt(v, 10);
     } else {
       return BigInt(v);
     }
   }
-  public visitFixedNat(t: FixedNatClass, v: string): number | bigint {
+  public visitFixedNat(t: IDL.FixedNatClass, v: string): number | bigint {
     if (t._bits <= 32) {
       return parseInt(v, 10);
     } else {
@@ -166,17 +166,17 @@ class Random extends IDL.Visitor<string, any> {
     return BigInt(this.generateNumber(false));
   }
   public visitFixedInt(t: IDL.FixedIntClass, v: string): number | bigint {
-    const v = this.generateNumber(true);
+    const x = this.generateNumber(true);
     if (t._bits <= 32) {
-      return v;
+      return x;
     } else {
       return BigInt(v);
     }
   }
   public visitFixedNat(t: IDL.FixedNatClass, v: string): number | bigint {
-    const v = this.generateNumber(false);
+    const x = this.generateNumber(false);
     if (t._bits <= 32) {
-      return v;
+      return x;
     } else {
       return BigInt(v);
     }

--- a/packages/candid/src/candid-ui.ts
+++ b/packages/candid/src/candid-ui.ts
@@ -117,6 +117,20 @@ class Parse extends IDL.Visitor<string, any> {
   public visitFloat(t: IDL.FloatClass, v: string): number {
     return parseFloat(v);
   }
+  public visitFixedInt(t: FixedIntClass, v: string): number | bigint {
+    if (t._bits <= 32) {
+      return parseInt(v, 10);
+    } else {
+      return BigInt(v);
+    }
+  }
+  public visitFixedNat(t: FixedNatClass, v: string): number | bigint {
+    if (t._bits <= 32) {
+      return parseInt(v, 10);
+    } else {
+      return BigInt(v);
+    }
+  }
   public visitNumber(t: IDL.PrimitiveType, v: string): bigint {
     return BigInt(v);
   }
@@ -151,11 +165,21 @@ class Random extends IDL.Visitor<string, any> {
   public visitNat(t: IDL.NatClass, v: string): bigint {
     return BigInt(this.generateNumber(false));
   }
-  public visitFixedInt(t: IDL.FixedIntClass, v: string): bigint {
-    return BigInt(this.generateNumber(true));
+  public visitFixedInt(t: IDL.FixedIntClass, v: string): number | bigint {
+    const v = this.generateNumber(true);
+    if (t._bits <= 32) {
+      return v;
+    } else {
+      return BigInt(v);
+    }
   }
-  public visitFixedNat(t: IDL.FixedNatClass, v: string): bigint {
-    return BigInt(this.generateNumber(false));
+  public visitFixedNat(t: IDL.FixedNatClass, v: string): number | bigint {
+    const v = this.generateNumber(false);
+    if (t._bits <= 32) {
+      return v;
+    } else {
+      return BigInt(v);
+    }
   }
   private generateNumber(signed: boolean): number {
     const num = Math.floor(Math.random() * 100);


### PR DESCRIPTION
Candid UI cannot encode nat8, nat16 types, because the parser only return BigInt for number types.

User get the error: "Cannot convert a BigInt value to a number"
