### PR TITLE
fix: add setBigUint64 polyfill

### DIFF
--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -363,7 +363,7 @@ describe('replace identity', () => {
   });
 });
 
-describe.only('makeNonce', () => {
+describe('makeNonce', () => {
   it('should create unique values', () => {
     const nonces = new Set();
     for (let i = 0; i < 100; i++) {
@@ -375,26 +375,33 @@ describe.only('makeNonce', () => {
   describe('setBigUint64 polyfill', () => {
     const DataViewConstructor = DataView;
     let spyOnSetUint32: jest.SpyInstance;
+    let usePolyfill = false;
 
-    beforeAll(() =>
+    beforeAll(() => {
+      jest.spyOn(Math, 'random').mockImplementation(() => 0.5);
       jest.spyOn(globalThis, 'DataView').mockImplementation(buffer => {
         const view: DataView = new DataViewConstructor(buffer);
-        view.setBigUint64 = undefined;
+        view.setBigUint64 = usePolyfill ? undefined : view.setBigUint64;
         spyOnSetUint32 = jest.spyOn(view, 'setUint32');
         return view;
-      }),
-    );
-    afterAll(jest.restoreAllMocks);
+      });
+    });
 
-    it('should create unique values using polyfill', () => {
-      const nonces = new Set();
+    afterAll(() => {
+      jest.clearAllMocks();
+      jest.restoreAllMocks();
+    });
 
-      for (let i = 0; i < 100; i++) {
-        nonces.add(toHexString(makeNonce()));
-        expect(spyOnSetUint32).toBeCalledTimes(4);
-      }
+    it('should create same value using polyfill', () => {
+      const originalNonce = toHexString(makeNonce());
+      expect(spyOnSetUint32).toBeCalledTimes(2);
 
-      expect(nonces.size).toBe(100);
+      usePolyfill = true;
+
+      const nonce = toHexString(makeNonce());
+      expect(spyOnSetUint32).toBeCalledTimes(4);
+
+      expect(nonce).toBe(originalNonce);
     });
   });
 });

--- a/packages/agent/src/agent/http/types.ts
+++ b/packages/agent/src/agent/http/types.ts
@@ -110,7 +110,14 @@ export function makeNonce(): Nonce {
   const now = BigInt(+Date.now());
   const randHi = Math.floor(Math.random() * 0xffffffff);
   const randLo = Math.floor(Math.random() * 0xffffffff);
-  view.setBigUint64(0, now);
+  // Fix for IOS < 14.8 setBigUint64 absence
+  if (typeof view.setBigUint64 === 'function') {
+    view.setBigUint64(0, now);
+  } else {
+    const TWO_TO_THE_32 = BigInt(1) << BigInt(32);
+    view.setUint32(0, Number(now >> BigInt(32)));
+    view.setUint32(4, Number(now % TWO_TO_THE_32));
+  }
   view.setUint32(8, randHi);
   view.setUint32(12, randLo);
 


### PR DESCRIPTION
# Description

Adds the `setBigUint64` polyfill because of the multiple [error reports](https://dfinity.slack.com/archives/C01S03NBM7S/p1654161676609929). (based on [nns-dapp solution](https://github.com/dfinity/nns-dapp/blob/55a89a9b5d5d4241277822197efc62f3d3e8d6ce/frontend/ts/src/canisters/converter.ts#L25))
