### PR TITLE
feat: reuse signed request when reading state

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,6 +13,17 @@
       <h2>Version 0.12.1</h2>
       <ul>
         <li>Adds UTF-8 as an encoding option for CanisterStatus custom paths</li>
+        <li>
+          Adds a public method "createReadStateRequest" that creates the request for "readState".
+        </li>
+        <li>
+          Add an extra parameter to "readState" to pass a created request. If this parameter is
+          passed, the method does the request directly without creating a new one.
+        </li>
+        <li>
+          Use the "createReadStateRequest" and the extra parameter when polling for the response to
+          avoid signing requests during polling.
+        </li>
       </ul>
       <h2>Version 0.12.0</h2>
       <ul>

--- a/e2e/node/basic/basic.test.ts
+++ b/e2e/node/basic/basic.test.ts
@@ -36,6 +36,42 @@ test('read_state', async () => {
   expect(Math.abs(time - now) < 5).toBe(true);
 });
 
+test('read_state with passed request', async () => {
+  const resolvedAgent = await agent;
+  const now = Date.now() / 1000;
+  const path = [new TextEncoder().encode('time')];
+  const canisterId = Principal.fromHex('00000000000000000001');
+  const request = await resolvedAgent.createReadStateRequest({ paths: [path] });
+  const response = await resolvedAgent.readState(
+    canisterId,
+    {
+      paths: [path],
+    },
+    undefined,
+    request,
+  );
+  if (resolvedAgent.rootKey == null) throw new Error(`The agent doesn't have a root key yet`);
+  const cert = await Certificate.create({
+    certificate: response.certificate,
+    rootKey: resolvedAgent.rootKey,
+    canisterId: canisterId,
+  });
+  expect(cert.lookup([new TextEncoder().encode('Time')])).toBe(undefined);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const rawTime = cert.lookup(path)!;
+  const decoded = IDL.decode(
+    [IDL.Nat],
+    new Uint8Array([
+      ...new TextEncoder().encode('DIDL\x00\x01\x7d'),
+      ...(new Uint8Array(rawTime) || []),
+    ]),
+  )[0];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const time = Number(decoded as any) / 1e9;
+  // The diff between decoded time and local time is within 5s
+  expect(Math.abs(time - now) < 5).toBe(true);
+});
+
 test('createCanister', async () => {
   // Make sure this doesn't fail.
   await getManagementCanister({

--- a/packages/agent/src/agent/api.ts
+++ b/packages/agent/src/agent/api.ts
@@ -112,15 +112,31 @@ export interface Agent {
   getPrincipal(): Promise<Principal>;
 
   /**
+   * Create the request for the read state call.
+   * `readState` uses this internally.
+   * Useful to avoid signing the same request multiple times.
+   */
+  createReadStateRequest?(
+    options: ReadStateOptions,
+    identity?: Identity,
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  ): Promise<any>;
+
+  /**
    * Send a read state query to the replica. This includes a list of paths to return,
    * and will return a Certificate. This will only reject on communication errors,
    * but the certificate might contain less information than requested.
    * @param effectiveCanisterId A Canister ID related to this call.
    * @param options The options for this call.
+   * @param identity Identity for the call. If not specified, uses the instance identity.
+   * @param request The request to send in case it has already been created.
    */
   readState(
     effectiveCanisterId: Principal | string,
     options: ReadStateOptions,
+    identity?: Identity,
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+    request?: any,
   ): Promise<ReadStateResponse>;
 
   call(canisterId: Principal | string, fields: CallOptions): Promise<SubmitResponse>;


### PR DESCRIPTION
# Description

Enable the `readState` of the Agent to reuse the request.

## Motivation

Signing with the hardware wallet requires the user to accept from the device. Reusing the signed request will improve the user experience for hardware wallet users.

# How Has This Been Tested?

I linked a branch of nns-dapp to the changes in this PR and validated that everything worked, not just the new feature.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
