### PR TITLE
feat: adds support for derivationOrigin

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,6 +13,14 @@
       <h2>Version 0.12.1</h2>
       <ul>
         <li>Adds UTF-8 as an encoding option for CanisterStatus custom paths</li>
+        <li>
+          Adds derivationOrigin to auth-client login to support the ability to login using the
+          identity derived from a different origin. See
+          <a
+            href="https://github.com/dfinity/internet-identity/pull/724/files#diff-44c106928503ccfb1b3f09f02513578552f66b68dea01c5ec4bd2de858bbba1a"
+            >proposed changes</a
+          >
+        </li>
       </ul>
       <h2>Version 0.12.0</h2>
       <ul>

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -382,6 +382,20 @@ describe('Auth Client login', () => {
       'toolbar=0,location=0,menubar=0',
     );
   });
+  it('should login with a derivation origin', async () => {
+    setup();
+    const client = await AuthClient.create();
+    // Try without #authorize hash.
+    await client.login({
+      identityProvider: 'http://localhost',
+      derivationOrigin: 'http://localhost:1234',
+    });
+
+    idpMock.ready('http://localhost');
+
+    const call = (idpWindow.postMessage as jest.Mock).mock.calls[0][0];
+    expect(call['derivationOrigin']).toBe('http://localhost:1234');
+  });
 
   it('should ignore authorize-ready events with bad origin', async () => {
     setup();

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -72,6 +72,11 @@ export interface AuthClientLoginOptions {
    */
   maxTimeToLive?: bigint;
   /**
+   * Origin for Identity Provider to use while generating the delegated identity. For II, the derivation origin must authorize this origin by setting a record at `<derivation-origin>/.well-known/ii-alternative-origins`.
+   * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
+   */
+  derivationOrigin?: string | URL;
+  /**
    * Auth Window feature config string
    * @example "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100"
    */
@@ -101,6 +106,7 @@ interface InternetIdentityAuthRequest {
   kind: 'authorize-client';
   sessionPublicKey: Uint8Array;
   maxTimeToLive?: bigint;
+  derivationOrigin?: string;
 }
 
 interface InternetIdentityAuthResponseSuccess {
@@ -350,6 +356,7 @@ export class AuthClient {
    * @param {AuthClientLoginOptions} options
    * @param options.identityProvider Identity provider
    * @param options.maxTimeToLive Expiration of the authentication in nanoseconds
+   * @param options.derivationOrigin Origin for Identity Provider to use while generating the delegated identity
    * @param options.windowOpenerFeatures Configures the opened authentication window
    * @param options.onSuccess Callback once login has completed
    * @param options.onError Callback in case authentication fails
@@ -382,6 +389,11 @@ export class AuthClient {
      * Auth Window feature config string
      * @example "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100"
      */
+    /**
+     * Origin for Identity Provider to use while generating the delegated identity. For II, the derivation origin must authorize this origin by setting a record at `<derivation-origin>/.well-known/ii-alternative-origins`.
+     * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
+     */
+    derivationOrigin?: string | URL;
     windowOpenerFeatures?: string;
     /**
      * Callback once login has completed
@@ -459,6 +471,7 @@ export class AuthClient {
             kind: 'authorize-client',
             sessionPublicKey: new Uint8Array(this._key?.getPublicKey().toDer() as ArrayBuffer),
             maxTimeToLive: options?.maxTimeToLive,
+            derivationOrigin: options?.derivationOrigin?.toString(),
           };
           this._idpWindow?.postMessage(request, identityProviderUrl.origin);
           break;


### PR DESCRIPTION
# Description

Agent-js should allow to pass on a derivation_origin during login that should be used for principal derivation (as opposed to the front-end origin)

# How Has This Been Tested?

Unit test added

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
