### PR TITLE
fix: IDL edge case involving Math.log2 function on BigInt bit count

### DIFF
--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -15,6 +15,7 @@ import {
   writeIntLE,
   writeUIntLE,
 } from './utils/leb128';
+import { ilog2 } from './utils/ilog2';
 
 // tslint:disable:max-line-length
 /**
@@ -647,7 +648,7 @@ export class FixedIntClass extends PrimitiveType<bigint | number> {
   }
 
   public encodeType() {
-    const offset = Math.log2(this._bits) - 3;
+    const offset = ilog2(this._bits) - 3;
     return slebEncode(-9 - offset);
   }
 
@@ -699,7 +700,7 @@ export class FixedNatClass extends PrimitiveType<bigint | number> {
   }
 
   public encodeType() {
-    const offset = Math.log2(this._bits) - 3;
+    const offset = ilog2(this._bits) - 3;
     return slebEncode(-5 - offset);
   }
 

--- a/packages/candid/src/utils/ilog2.test.ts
+++ b/packages/candid/src/utils/ilog2.test.ts
@@ -1,10 +1,15 @@
 import { ilog2 } from './ilog2';
 
-test('log2', () => {
+test('ilog2', () => {
   for (let n = -10; n < 100; n++) {
     expect(ilog2(n)).toBe(n > 0 ? Math.floor(Math.log2(n)) : NaN);
   }
   for (const p of [0, 1, 3, 55, 10000]) {
     expect(ilog2(BigInt(2) ** BigInt(p))).toBe(p);
   }
+
+  expect(() => ilog2(1.5)).toThrow(
+    'The number 1.5 cannot be converted to a BigInt because it is not an integer',
+  );
+  expect(() => (ilog2 as (string) => number)('abc')).toThrow('Cannot convert abc to a BigInt');
 });

--- a/packages/candid/src/utils/ilog2.test.ts
+++ b/packages/candid/src/utils/ilog2.test.ts
@@ -1,0 +1,10 @@
+import { ilog2 } from './ilog2';
+
+test('log2', () => {
+  for (let n = -10; n < 100; n++) {
+    expect(ilog2(n)).toBe(n > 0 ? Math.floor(Math.log2(n)) : NaN);
+  }
+  for (const p of [0, 1, 3, 55, 10000]) {
+    expect(ilog2(BigInt(2) ** BigInt(p))).toBe(p);
+  }
+});

--- a/packages/candid/src/utils/ilog2.ts
+++ b/packages/candid/src/utils/ilog2.ts
@@ -4,5 +4,6 @@
  * @param n number or bigint
  */
 export function ilog2(n: bigint | number) {
-  return n > 0 ? BigInt(n).toString(2).length - 1 : NaN;
+  const nBig = BigInt(n);
+  return nBig > 0 ? nBig.toString(2).length - 1 : NaN;
 }

--- a/packages/candid/src/utils/ilog2.ts
+++ b/packages/candid/src/utils/ilog2.ts
@@ -1,0 +1,8 @@
+/**
+ * Equivalent to `Math.log2` with support for `BigInt` values
+ *
+ * @param n number or bigint
+ */
+export function ilog2(n: bigint | number) {
+  return n > 0 ? BigInt(n).toString(2).length - 1 : NaN;
+}


### PR DESCRIPTION
# Description

Fixes a bug where `Math.log2` is sometimes called on a BigInt value in `@dfinity/candid` (possibly a regression from #575), causing an unexpected error in Motoko Playground. 

This PR adds a custom `ilog2` implementation ([based on this StackOverflow post](https://stackoverflow.com/questions/55355184/optimized-integer-logarithm-base2-for-bigint)) which accounts for BigInt values while providing clearer error messages when receiving invalid input. 

# How Has This Been Tested?

- Full repository test suite
- Additional test cases for `ilog2` function

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly. (N/A, regression)
- [ ] I have made corresponding changes to the documentation. (N/A)
