### PR TITLE
fix: canisterStatus throws if root key is not fetched

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -15,6 +15,7 @@
         <li>
           Support for the SubtleCrypto interface in @dfinity/identity using the new ECDSAKeyIdentity
         </li>
+        <li>CanisterStatus no longer suppresses rootKey errors</li>
       </ul>
       <h2>Version 0.12.1</h2>
       <ul>

--- a/e2e/node/basic/canisterStatus.test.ts
+++ b/e2e/node/basic/canisterStatus.test.ts
@@ -2,16 +2,39 @@ import { CanisterStatus, HttpAgent } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import counter from '../canisters/counter';
 
-describe('canister status', () => {
+jest.setTimeout(30_000);
+describe.only('canister status', () => {
   it('should fetch successfully', async () => {
-    const foo = await (await counter)();
+    const counterObj = await (await counter)();
     const agent = new HttpAgent({ host: `http://localhost:${process.env.REPLICA_PORT}` });
+    await agent.fetchRootKey();
     const request = await CanisterStatus.request({
-      canisterId: Principal.from(foo.canisterId),
+      canisterId: Principal.from(counterObj.canisterId),
       agent,
       paths: ['controllers'],
     });
 
     expect(Array.isArray(request.get('controllers'))).toBe(true);
+  });
+  it('should throw an error if fetchRootKey has not been called', async () => {
+    const counterObj = await (await counter)();
+    const agent = new HttpAgent({ host: `http://localhost:${process.env.REPLICA_PORT}` });
+    const shouldThrow = async () => {
+      // eslint-disable-next-line no-useless-catch
+      try {
+        const request = await CanisterStatus.request({
+          canisterId: Principal.from(counterObj.canisterId),
+          agent,
+          paths: ['controllers'],
+        }).catch(error => {
+          throw error;
+        });
+        console.log(request);
+      } catch (error) {
+        throw error;
+      }
+    };
+
+    expect(shouldThrow).rejects.toThrow();
   });
 });

--- a/e2e/node/basic/canisterStatus.test.ts
+++ b/e2e/node/basic/canisterStatus.test.ts
@@ -1,0 +1,17 @@
+import { CanisterStatus, HttpAgent } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
+import counter from '../canisters/counter';
+
+describe('canister status', () => {
+  it('should fetch successfully', async () => {
+    const foo = await (await counter)();
+    const agent = new HttpAgent({ host: `http://localhost:${process.env.REPLICA_PORT}` });
+    const request = await CanisterStatus.request({
+      canisterId: Principal.from(foo.canisterId),
+      agent,
+      paths: ['controllers'],
+    });
+
+    expect(Array.isArray(request.get('controllers'))).toBe(true);
+  });
+});

--- a/e2e/node/basic/counter.test.ts
+++ b/e2e/node/basic/counter.test.ts
@@ -34,15 +34,12 @@ describe('counter', () => {
     expect(set1.size < values.length || set2.size < values2.length).toBe(true);
   });
   it('should increment', async () => {
-    const { actor: counter } = await counterCanister();
-    try {
-      expect(Number(await counter.read())).toEqual(0);
-      await counter.inc();
-      expect(Number(await counter.read())).toEqual(1);
-      await counter.inc();
-      expect(Number(await counter.read())).toEqual(2);
-    } catch (error) {
-      console.error(error);
-    }
+    const { actor: counter } = await noncelessCanister();
+
+    expect(Number(await counter.read())).toEqual(0);
+    await counter.inc();
+    expect(Number(await counter.read())).toEqual(1);
+    await counter.inc();
+    expect(Number(await counter.read())).toEqual(2);
   });
 });

--- a/e2e/node/test-setup.ts
+++ b/e2e/node/test-setup.ts
@@ -7,12 +7,12 @@
 // Note that we can use webpack configuration to make some features available to
 
 // Node.js in a similar way.
-// import { TextEncoder, TextDecoder } from 'text-encoding'; // eslint-disable-line
+import { TextEncoder, TextDecoder } from 'text-encoding'; // eslint-disable-line
 // import fetch from 'isomorphic-fetch';
 // global.crypto = crypto as unknown as Crypto;
 // console.log('subtle', crypto['subtle']); // eslint-disable-line
-// global.TextDecoder = TextDecoder; // eslint-disable-line
-// global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder; // eslint-disable-line
+global.TextEncoder = TextEncoder;
 
 // global.TextDecoder = TextDecoder; // eslint-disable-line
 // (global.fetch as any) = fetch;


### PR DESCRIPTION
# Description

Previously the utility suppressed the error and returned a map with all fields as null. Now, if you are on the local replica or a testnet, rootkey errors will cause canisterstatus to throw

Fixes SDK-577

# How Has This Been Tested?

new e2e suite for canisterstatus

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
