### PR TITLE
chore: replaces links with icp.host to xyz for nice url for docs

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -16,6 +16,7 @@
           Support for the SubtleCrypto interface in @dfinity/identity using the new ECDSAKeyIdentity
         </li>
         <li>CanisterStatus no longer suppresses rootKey errors</li>
+        <li>Readme's point to https://agent-js.icp.xyz</li>
       </ul>
       <h2>Version 0.12.1</h2>
       <ul>

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -4,7 +4,7 @@ JavaScript and TypeScript library to interact with the [Internet Computer](https
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://agent-js.icp.host/agent/index.html).
+Additional API Documentation can be found [here](https://agent-js.icp.xyz/agent/index.html).
 
 ---
 

--- a/packages/auth-client/README.md
+++ b/packages/auth-client/README.md
@@ -6,7 +6,7 @@ Simple interface to get your web application authenticated with the Internet Ide
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://agent-js.icp.host/auth-client/index.html).
+Additional API Documentation can be found [here](https://agent-js.icp.xyz/auth-client/index.html).
 
 ---
 

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -4,7 +4,7 @@ JavaScript and TypeScript library to support manage Identities and enable simple
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://agent-js.icp.host/authentication/index.html).
+Additional API Documentation can be found [here](https://agent-js.icp.xyz/authentication/index.html).
 
 ---
 

--- a/packages/candid/README.md
+++ b/packages/candid/README.md
@@ -4,7 +4,7 @@ JavaScript and TypeScript library to work with Candid interfaces
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://agent-js.icp.host/candid/index.html).
+Additional API Documentation can be found [here](https://agent-js.icp.xyz/candid/index.html).
 
 ---
 

--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -4,7 +4,7 @@ JavaScript and TypeScript library to manage Identities and enable simple Web Aut
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://agent-js.icp.host/identity/index.html).
+Additional API Documentation can be found [here](https://agent-js.icp.xyz/identity/index.html).
 
 ---
 

--- a/packages/principal/README.md
+++ b/packages/principal/README.md
@@ -4,7 +4,7 @@ JavaScript and TypeScript library to work with Internet Computer Principals
 
 Visit the [Dfinity Forum](https://forum.dfinity.org/) and [SDK Documentation](https://sdk.dfinity.org/docs/index.html) for more information and support building on the Internet Computer.
 
-Additional API Documentation can be found [here](https://agent-js.icp.host/principal/index.html).
+Additional API Documentation can be found [here](https://agent-js.icp.xyz/principal/index.html).
 
 ---
 


### PR DESCRIPTION
# Description

There's a nicer format for canister urls with icns. The docs can now avoid a redirect using https://agent-js.icp.xyz

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
