### PR TITLE
feat: auth-client stores identities in indexeddb

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -10,6 +10,16 @@
     <h1>Agent-JS Changelog</h1>
 
     <section>
+      <h2>Version 0.12.3</h2>
+      <ul>
+        <li>
+          AuthClient now uses IndexedDb by default. To use localStorage, import LocalStorage
+          provider and pass it during AuthClient.create().
+        </li>
+        <ul>
+          <li>Also offers a generic Indexed Db keyval store, IdbKeyVal</li>
+        </ul>
+      </ul>
       <h2>Version 0.12.2</h2>
       <ul>
         <li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4724,7 +4724,8 @@
     },
     "node_modules/@peculiar/webcrypto": {
       "version": "1.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz",
+      "integrity": "sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.1.6",
         "@peculiar/json-schema": "^1.1.12",
@@ -6472,6 +6473,15 @@
       "version": "0.2.0",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/base64-arraybuffer-es6": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz",
+      "integrity": "sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -9310,6 +9320,15 @@
       "dev": true,
       "engines": {
         "node": "> 0.1.90"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-4.0.0.tgz",
+      "integrity": "sha512-oCfWSJ/qvQn1XPZ8SHX6kY3zr1t+bN7faZ/lltGY0SBGhFOPXnWf0+pbO/MOAgfMx6khC2gK3S/bvAgQpuQHDQ==",
+      "dev": true,
+      "dependencies": {
+        "realistic-structured-clone": "^3.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -15207,6 +15226,32 @@
       "dev": true,
       "license": "WTFPL"
     },
+    "node_modules/realistic-structured-clone": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz",
+      "integrity": "sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==",
+      "dev": true,
+      "dependencies": {
+        "domexception": "^1.0.1",
+        "typeson": "^6.1.0",
+        "typeson-registry": "^1.0.0-alpha.20"
+      }
+    },
+    "node_modules/realistic-structured-clone/node_modules/domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/realistic-structured-clone/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
     "node_modules/rechoir": {
       "version": "0.7.1",
       "license": "MIT",
@@ -16804,6 +16849,64 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typeson": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/typeson/-/typeson-6.1.0.tgz",
+      "integrity": "sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
+    "node_modules/typeson-registry": {
+      "version": "1.0.0-alpha.39",
+      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz",
+      "integrity": "sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==",
+      "dev": true,
+      "dependencies": {
+        "base64-arraybuffer-es6": "^0.7.0",
+        "typeson": "^6.0.0",
+        "whatwg-url": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/typeson-registry/node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typeson-registry/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.4"
+      }
+    },
+    "node_modules/typeson-registry/node_modules/whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "license": "MIT",
@@ -17980,16 +18083,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/jest": "^28.1.4",
+        "idb-keyval": "^6.2.0",
         "jest": "^28.1.2",
         "ts-jest": "^28.0.5",
         "ts-node": "^10.8.2"
       },
       "devDependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
         "@trust/webcrypto": "^0.9.2",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
         "eslint": "^8.19.0",
         "eslint-plugin-jsdoc": "^39.3.3",
+        "fake-indexeddb": "^4.0.0",
         "jest-environment-jsdom": "^28.1.2",
         "text-encoding": "^0.7.0",
         "tslint": "^5.20.0",
@@ -19662,12 +19768,15 @@
     "@dfinity/auth-client": {
       "version": "file:packages/auth-client",
       "requires": {
+        "@peculiar/webcrypto": "*",
         "@trust/webcrypto": "^0.9.2",
         "@types/jest": "^28.1.4",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
         "eslint": "^8.19.0",
         "eslint-plugin-jsdoc": "^39.3.3",
+        "fake-indexeddb": "^4.0.0",
+        "idb-keyval": "^6.2.0",
         "jest": "^28.1.2",
         "jest-environment-jsdom": "^28.1.2",
         "text-encoding": "^0.7.0",
@@ -22073,6 +22182,8 @@
     },
     "@peculiar/webcrypto": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz",
+      "integrity": "sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==",
       "requires": {
         "@peculiar/asn1-schema": "^2.1.6",
         "@peculiar/json-schema": "^1.1.12",
@@ -23331,6 +23442,12 @@
     },
     "base64-arraybuffer": {
       "version": "0.2.0"
+    },
+    "base64-arraybuffer-es6": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz",
+      "integrity": "sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1"
@@ -25258,6 +25375,15 @@
     "eyes": {
       "version": "0.1.8",
       "dev": true
+    },
+    "fake-indexeddb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-4.0.0.tgz",
+      "integrity": "sha512-oCfWSJ/qvQn1XPZ8SHX6kY3zr1t+bN7faZ/lltGY0SBGhFOPXnWf0+pbO/MOAgfMx6khC2gK3S/bvAgQpuQHDQ==",
+      "dev": true,
+      "requires": {
+        "realistic-structured-clone": "^3.0.0"
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3"
@@ -29130,6 +29256,34 @@
       "version": "1.2.0",
       "dev": true
     },
+    "realistic-structured-clone": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz",
+      "integrity": "sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==",
+      "dev": true,
+      "requires": {
+        "domexception": "^1.0.1",
+        "typeson": "^6.1.0",
+        "typeson-registry": "^1.0.0-alpha.20"
+      },
+      "dependencies": {
+        "domexception": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+          "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+          "dev": true,
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        }
+      }
+    },
     "rechoir": {
       "version": "0.7.1",
       "requires": {
@@ -30141,6 +30295,51 @@
     },
     "typescript": {
       "version": "4.7.4"
+    },
+    "typeson": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/typeson/-/typeson-6.1.0.tgz",
+      "integrity": "sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==",
+      "dev": true
+    },
+    "typeson-registry": {
+      "version": "1.0.0-alpha.39",
+      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz",
+      "integrity": "sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==",
+      "dev": true,
+      "requires": {
+        "base64-arraybuffer-es6": "^0.7.0",
+        "typeson": "^6.0.0",
+        "whatwg-url": "^8.4.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+          "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.7.0",
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
+      }
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10290,6 +10290,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.2.tgz",
+      "integrity": "sha512-jjKrT1EnyZewQ/gCBb/eyiYrhGzws2FeY92Yx8qT9S9GeQAmo4JFVIiWRIfKW/6Ob9A+UDAOW9j9jn58fy2HIg=="
+    },
     "node_modules/idb-keyval": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.0.tgz",
@@ -18083,14 +18088,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/jest": "^28.1.4",
-        "idb-keyval": "^6.2.0",
+        "idb": "^7.0.2",
         "jest": "^28.1.2",
         "ts-jest": "^28.0.5",
         "ts-node": "^10.8.2"
       },
       "devDependencies": {
         "@peculiar/webcrypto": "^1.4.0",
-        "@trust/webcrypto": "^0.9.2",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
         "eslint": "^8.19.0",
@@ -19768,15 +19772,14 @@
     "@dfinity/auth-client": {
       "version": "file:packages/auth-client",
       "requires": {
-        "@peculiar/webcrypto": "*",
-        "@trust/webcrypto": "^0.9.2",
+        "@peculiar/webcrypto": "^1.4.0",
         "@types/jest": "^28.1.4",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
         "eslint": "^8.19.0",
         "eslint-plugin-jsdoc": "^39.3.3",
         "fake-indexeddb": "^4.0.0",
-        "idb-keyval": "^6.2.0",
+        "idb": "^7.0.2",
         "jest": "^28.1.2",
         "jest-environment-jsdom": "^28.1.2",
         "text-encoding": "^0.7.0",
@@ -26052,6 +26055,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "idb": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.2.tgz",
+      "integrity": "sha512-jjKrT1EnyZewQ/gCBb/eyiYrhGzws2FeY92Yx8qT9S9GeQAmo4JFVIiWRIfKW/6Ob9A+UDAOW9j9jn58fy2HIg=="
     },
     "idb-keyval": {
       "version": "6.2.0",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -51,11 +51,12 @@
     "@dfinity/principal": "^0.12.2"
   },
   "devDependencies": {
-    "@trust/webcrypto": "^0.9.2",
+    "@peculiar/webcrypto": "^1.4.0",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "eslint": "^8.19.0",
     "eslint-plugin-jsdoc": "^39.3.3",
+    "fake-indexeddb": "^4.0.0",
     "jest-environment-jsdom": "^28.1.2",
     "text-encoding": "^0.7.0",
     "tslint": "^5.20.0",
@@ -65,6 +66,7 @@
   },
   "dependencies": {
     "@types/jest": "^28.1.4",
+    "idb-keyval": "^6.2.0",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "ts-node": "^10.8.2"

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@types/jest": "^28.1.4",
-    "idb-keyval": "^6.2.0",
+    "idb": "^7.0.2",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "ts-node": "^10.8.2"

--- a/packages/auth-client/src/db.test.ts
+++ b/packages/auth-client/src/db.test.ts
@@ -1,18 +1,35 @@
-import { db, getValue, removeValue, setValue } from './db';
+import 'fake-indexeddb/auto';
+import { IdbKeyVal } from './db';
+
+let testCounter = 0;
+
+const testDb = async () => {
+  return await IdbKeyVal.create({
+    dbName: 'db-' + testCounter,
+    storeName: 'store-' + testCounter,
+  });
+};
+
+beforeEach(() => {
+  testCounter += 1;
+});
 
 describe('indexeddb wrapper', () => {
   it('should store a basic key value', async () => {
-    const shouldSet = async () => await setValue(db, 'testValue', 'testKey');
+    const db = await testDb();
+    const shouldSet = async () => await db.set('testKey', 'testValue');
     expect(shouldSet).not.toThrow();
 
-    expect(await getValue(db, 'testKey')).toBe('testValue');
+    expect(await db.get('testKey')).toBe('testValue');
   });
   it('should support removing a value', async () => {
-    await setValue(db, 'testValue', 'testKey');
-    expect(await getValue(db, 'testKey')).toBe('testValue');
+    const db = await testDb();
+    await db.set('testKey', 'testValue');
 
-    await removeValue(db, 'testKey');
+    expect(await db.get('testKey')).toBe('testValue');
 
-    expect(await getValue(db, 'testKey')).toBe(undefined);
+    await db.remove('testKey');
+
+    expect(await db.get('testKey')).toBe(null);
   });
 });

--- a/packages/auth-client/src/db.test.ts
+++ b/packages/auth-client/src/db.test.ts
@@ -1,0 +1,18 @@
+import { db, getValue, removeValue, setValue } from './db';
+
+describe('indexeddb wrapper', () => {
+  it('should store a basic key value', async () => {
+    const shouldSet = async () => await setValue(db, 'testValue', 'testKey');
+    expect(shouldSet).not.toThrow();
+
+    expect(await getValue(db, 'testKey')).toBe('testValue');
+  });
+  it('should support removing a value', async () => {
+    await setValue(db, 'testValue', 'testKey');
+    expect(await getValue(db, 'testKey')).toBe('testValue');
+
+    await removeValue(db, 'testKey');
+
+    expect(await getValue(db, 'testKey')).toBe(undefined);
+  });
+});

--- a/packages/auth-client/src/db.ts
+++ b/packages/auth-client/src/db.ts
@@ -1,0 +1,45 @@
+import { openDB, IDBPDatabase } from 'idb';
+
+export type Database = Promise<IDBPDatabase<unknown>>;
+
+export const openDbStore = async () =>
+  await openDB('auth-client-db', 1, {
+    upgrade: database => {
+      if (database.objectStoreNames.contains('ic-idp')) {
+        database.clear('ic-idp');
+      }
+      database.createObjectStore('ic-idp');
+    },
+  });
+
+/**
+ *
+ * @param db database
+ * @param key string
+ * @returns
+ */
+export async function getValue<T>(db: Database, key: string): Promise<T | undefined> {
+  return (await db).get('ic-idp', key);
+}
+
+/**
+ *
+ * @param db database
+ * @param value any value to set
+ * @param key string asdf
+ */
+export async function setValue<T>(db: Database, value: T, key: string): Promise<void> {
+  (await db).put('ic-idp', value, key);
+}
+
+/**
+ *
+ * @param db database
+ * @param value any value to remove
+ * @param key string asdf
+ */
+export async function removeValue(db: Database, key: string): Promise<void> {
+  (await db).delete('ic-idp', key);
+}
+
+export const db = openDbStore();

--- a/packages/auth-client/src/db.ts
+++ b/packages/auth-client/src/db.ts
@@ -1,14 +1,17 @@
 import { openDB, IDBPDatabase } from 'idb';
 
 export type Database = Promise<IDBPDatabase<unknown>>;
+export const AUTH_DB_NAME = 'auth-client-db';
+export const OBJECT_STORE_NAME = 'keyval-store';
 
 export const openDbStore = async () =>
-  await openDB('auth-client-db', 1, {
+  await openDB(AUTH_DB_NAME, 1, {
     upgrade: database => {
-      if (database.objectStoreNames.contains('ic-idp')) {
-        database.clear('ic-idp');
+      database.objectStoreNames;
+      if (database.objectStoreNames.contains(OBJECT_STORE_NAME)) {
+        database.clear(OBJECT_STORE_NAME);
       }
-      database.createObjectStore('ic-idp');
+      database.createObjectStore(OBJECT_STORE_NAME);
     },
   });
 
@@ -19,7 +22,7 @@ export const openDbStore = async () =>
  * @returns
  */
 export async function getValue<T>(db: Database, key: string): Promise<T | undefined> {
-  return (await db).get('ic-idp', key);
+  return (await db).get(OBJECT_STORE_NAME, key);
 }
 
 /**
@@ -29,7 +32,7 @@ export async function getValue<T>(db: Database, key: string): Promise<T | undefi
  * @param key string asdf
  */
 export async function setValue<T>(db: Database, value: T, key: string): Promise<void> {
-  (await db).put('ic-idp', value, key);
+  (await db).put(OBJECT_STORE_NAME, value, key);
 }
 
 /**
@@ -39,7 +42,7 @@ export async function setValue<T>(db: Database, value: T, key: string): Promise<
  * @param key string asdf
  */
 export async function removeValue(db: Database, key: string): Promise<void> {
-  (await db).delete('ic-idp', key);
+  (await db).delete(OBJECT_STORE_NAME, key);
 }
 
 export const db = openDbStore();

--- a/packages/auth-client/src/db.ts
+++ b/packages/auth-client/src/db.ts
@@ -1,11 +1,22 @@
 import { openDB, IDBPDatabase } from 'idb';
+import { KEY_STORAGE_DELEGATION, KEY_STORAGE_KEY } from './storage';
 
 type Database = IDBPDatabase<unknown>;
+type IDBValidKey = string | number | Date | BufferSource | IDBValidKey[];
 const AUTH_DB_NAME = 'auth-client-db';
 const OBJECT_STORE_NAME = 'ic-keyval';
 
-const openDbStore = async (dbName = AUTH_DB_NAME, storeName = OBJECT_STORE_NAME, version: number) =>
-  await openDB(dbName, version, {
+const _openDbStore = async (
+  dbName = AUTH_DB_NAME,
+  storeName = OBJECT_STORE_NAME,
+  version: number,
+) => {
+  // Clear legacy stored delegations
+  if (localStorage && localStorage.getItem(KEY_STORAGE_DELEGATION)) {
+    localStorage.removeItem(KEY_STORAGE_DELEGATION);
+    localStorage.removeItem(KEY_STORAGE_KEY);
+  }
+  return await openDB(dbName, version, {
     upgrade: database => {
       database.objectStoreNames;
       if (database.objectStoreNames.contains(storeName)) {
@@ -14,14 +25,9 @@ const openDbStore = async (dbName = AUTH_DB_NAME, storeName = OBJECT_STORE_NAME,
       database.createObjectStore(storeName);
     },
   });
+};
 
-/**
- *
- * @param db database
- * @param key string
- * @returns
- */
-async function getValue<T>(
+async function _getValue<T>(
   db: Database,
   storeName: string,
   key: IDBValidKey,
@@ -29,13 +35,7 @@ async function getValue<T>(
   return await db.get(storeName, key);
 }
 
-/**
- *
- * @param db database
- * @param value any value to set
- * @param key string asdf
- */
-async function setValue<T>(
+async function _setValue<T>(
   db: Database,
   storeName: string,
   key: IDBValidKey,
@@ -44,13 +44,7 @@ async function setValue<T>(
   return await db.put(storeName, value, key);
 }
 
-/**
- *
- * @param db database
- * @param value any value to remove
- * @param key string asdf
- */
-async function removeValue(db: Database, storeName: string, key: IDBValidKey): Promise<void> {
+async function _removeValue(db: Database, storeName: string, key: IDBValidKey): Promise<void> {
   return await db.delete(storeName, key);
 }
 
@@ -59,22 +53,58 @@ export type DBCreateOptions = {
   storeName?: string;
   version?: number;
 };
+
+/**
+ * Simple Key Value store
+ * Defaults to `'auth-client-db'` with an object store of `'ic-keyval'`
+ */
 export class IdbKeyVal {
-  public static async create(options?: DBCreateOptions) {
+  /**
+   *
+   * @param {DBCreateOptions} options {@link DbCreateOptions}
+   * @param {DBCreateOptions['dbName']} options.dbName name for the indexeddb database
+   * @default 'auth-client-db'
+   * @param {DBCreateOptions['storeName']} options.storeName name for the indexeddb Data Store
+   * @default 'ic-keyval'
+   * @param {DBCreateOptions['version']} options.version version of the database. Increment to safely upgrade
+   * @constructs an {@link IdbKeyVal}
+   */
+  public static async create(options?: DBCreateOptions): Promise<IdbKeyVal> {
     const { dbName = AUTH_DB_NAME, storeName = OBJECT_STORE_NAME, version = 1 } = options ?? {};
-    const db = await openDbStore(dbName, storeName, version);
+    const db = await _openDbStore(dbName, storeName, version);
     return new IdbKeyVal(db, storeName);
   }
 
+  // Do not use - instead prefer create
   private constructor(private _db: Database, private _storeName: string) {}
 
+  /**
+   * Basic setter
+   * @param {IDBValidKey} key string | number | Date | BufferSource | IDBValidKey[]
+   * @param value value to set
+   * @returns void
+   */
   public async set<T>(key: IDBValidKey, value: T) {
-    return await setValue<T>(this._db, this._storeName, key, value);
+    return await _setValue<T>(this._db, this._storeName, key, value);
   }
+  /**
+   * Basic getter
+   * Pass in a type T for type safety if you know the type the value will have if it is found
+   * @param {IDBValidKey} key string | number | Date | BufferSource | IDBValidKey[]
+   * @returns `Promise<T | null>`
+   * @example
+   * await get<string>('exampleKey') -> 'exampleValue'
+   */
   public async get<T>(key: IDBValidKey): Promise<T | null> {
-    return (await getValue<T>(this._db, this._storeName, key)) ?? null;
+    return (await _getValue<T>(this._db, this._storeName, key)) ?? null;
   }
+
+  /**
+   * Remove a key
+   * @param key {@link IDBValidKey}
+   * @returns void
+   */
   public async remove(key: IDBValidKey) {
-    return await removeValue(this._db, this._storeName, key);
+    return await _removeValue(this._db, this._storeName, key);
   }
 }

--- a/packages/auth-client/src/db.ts
+++ b/packages/auth-client/src/db.ts
@@ -4,9 +4,6 @@ type Database = IDBPDatabase<unknown>;
 const AUTH_DB_NAME = 'auth-client-db';
 const OBJECT_STORE_NAME = 'ic-keyval';
 
-// Increment if schema changes
-const AUTH_CLIENT_DB_VERSION = 1;
-
 const openDbStore = async (dbName = AUTH_DB_NAME, storeName = OBJECT_STORE_NAME, version: number) =>
   await openDB(dbName, version, {
     upgrade: database => {
@@ -64,11 +61,7 @@ export type DBCreateOptions = {
 };
 export class IdbKeyVal {
   public static async create(options?: DBCreateOptions) {
-    const {
-      dbName = AUTH_DB_NAME,
-      storeName = OBJECT_STORE_NAME,
-      version = AUTH_CLIENT_DB_VERSION,
-    } = options ?? {};
+    const { dbName = AUTH_DB_NAME, storeName = OBJECT_STORE_NAME, version = 1 } = options ?? {};
     const db = await openDbStore(dbName, storeName, version);
     return new IdbKeyVal(db, storeName);
   }

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -1,9 +1,10 @@
+import 'fake-indexeddb/auto';
 import { Actor, HttpAgent } from '@dfinity/agent';
 import { AgentError } from '@dfinity/agent/lib/cjs/errors';
 import { IDL } from '@dfinity/candid';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { Principal } from '@dfinity/principal';
-import { AuthClient, AuthClientStorage, ERROR_USER_INTERRUPT } from './index';
+import { AuthClient, ERROR_USER_INTERRUPT, IdbStorage } from './index';
 
 /**
  * A class for mocking the IDP service.
@@ -318,6 +319,21 @@ describe('Auth Client', () => {
     // wait for default 30 minute idle timeout
     jest.advanceTimersByTime(30 * 60 * 1000);
     expect(idleFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('IdbStorage', () => {
+  it('should handle get and set', async () => {
+    const storage = new IdbStorage();
+
+    await storage.set('testKey', 'testValue');
+    expect(await storage.get('testKey')).toBe('testValue');
+  });
+});
+
+describe('EncryptedIdbStorage', () => {
+  it.skip('should handle get and set', async () => {
+    // The CryptoKey does not currently interact correctly with the fake-indexeddb mock
   });
 });
 

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -5,6 +5,7 @@ import { IDL } from '@dfinity/candid';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { Principal } from '@dfinity/principal';
 import { AuthClient, ERROR_USER_INTERRUPT, IdbStorage } from './index';
+import { AuthClientStorage } from './storage';
 
 /**
  * A class for mocking the IDP service.
@@ -76,7 +77,6 @@ describe('Auth Client', () => {
       fetch,
       toString: jest.fn(() => 'http://localhost:8000'),
     };
-    const newLocation = window.location;
 
     const identity = Ed25519KeyIdentity.generate();
     const mockFetch: jest.Mock = jest.fn();
@@ -328,12 +328,6 @@ describe('IdbStorage', () => {
 
     await storage.set('testKey', 'testValue');
     expect(await storage.get('testKey')).toBe('testValue');
-  });
-});
-
-describe('EncryptedIdbStorage', () => {
-  it.skip('should handle get and set', async () => {
-    // The CryptoKey does not currently interact correctly with the fake-indexeddb mock
   });
 });
 

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -18,13 +18,13 @@ import { IdleManager, IdleManagerOptions } from './idleManager';
 import {
   AuthClientStorage,
   IdbStorage,
-  KEY_ENCRYPTION,
   KEY_STORAGE_DELEGATION,
   KEY_STORAGE_KEY,
   KEY_VECTOR,
 } from './storage';
 
-export { IdbStorage, LocalStorage, EncryptedIdbStorage } from './storage';
+export { IdbStorage, LocalStorage } from './storage';
+export { IdbKeyVal, DBCreateOptions } from './db';
 
 const IDENTITY_PROVIDER_DEFAULT = 'https://identity.ic0.app';
 const IDENTITY_PROVIDER_ENDPOINT = '#authorize';
@@ -42,7 +42,7 @@ export interface AuthClientCreateOptions {
    */
   identity?: SignIdentity;
   /**
-   * Optional storage with get, set, and remove. Uses LocalStorage by default
+   * Optional storage with get, set, and remove. Uses {@link IdbStorage} by default
    */
   storage?: AuthClientStorage;
   /**
@@ -488,6 +488,5 @@ export class AuthClient {
 async function _deleteStorage(storage: AuthClientStorage) {
   await storage.remove(KEY_STORAGE_KEY);
   await storage.remove(KEY_STORAGE_DELEGATION);
-  await storage.remove(KEY_ENCRYPTION);
   await storage.remove(KEY_VECTOR);
 }

--- a/packages/auth-client/src/storage.ts
+++ b/packages/auth-client/src/storage.ts
@@ -17,6 +17,9 @@ export interface AuthClientStorage {
   remove(key: string): Promise<void>;
 }
 
+/**
+ * Legacy implementation of AuthClientStorage, for use where IndexedDb is not available
+ */
 export class LocalStorage implements AuthClientStorage {
   constructor(public readonly prefix = 'ic-', private readonly _localStorage?: Storage) {}
 

--- a/packages/auth-client/src/storage.ts
+++ b/packages/auth-client/src/storage.ts
@@ -1,0 +1,145 @@
+import { db, getValue, removeValue, setValue } from './db';
+const set = async <T>(key: string, value: T) => await setValue<T>(db, value, key);
+const get = async <T>(key: string): Promise<T | undefined> => await getValue<T>(db, key);
+const remove = async (key: string) => await removeValue(db, key);
+
+export const KEY_STORAGE_KEY = 'identity';
+export const KEY_STORAGE_DELEGATION = 'delegation';
+export const KEY_ENCRYPTION = 'encrypt-key';
+export const KEY_VECTOR = 'iv';
+
+/**
+ * Interface for persisting user authentication data
+ */
+export interface AuthClientStorage {
+  get(key: string): Promise<string | null>;
+
+  set(key: string, value: string): Promise<void>;
+
+  remove(key: string): Promise<void>;
+}
+
+export class LocalStorage implements AuthClientStorage {
+  constructor(public readonly prefix = 'ic-', private readonly _localStorage?: Storage) {}
+
+  public get(key: string): Promise<string | null> {
+    return Promise.resolve(this._getLocalStorage().getItem(this.prefix + key));
+  }
+
+  public set(key: string, value: string): Promise<void> {
+    this._getLocalStorage().setItem(this.prefix + key, value);
+    return Promise.resolve();
+  }
+
+  public remove(key: string): Promise<void> {
+    this._getLocalStorage().removeItem(this.prefix + key);
+    return Promise.resolve();
+  }
+
+  private _getLocalStorage() {
+    if (this._localStorage) {
+      return this._localStorage;
+    }
+
+    const ls =
+      typeof window === 'undefined'
+        ? typeof global === 'undefined'
+          ? typeof self === 'undefined'
+            ? undefined
+            : self.localStorage
+          : global.localStorage
+        : window.localStorage;
+
+    if (!ls) {
+      throw new Error('Could not find local storage.');
+    }
+
+    return ls;
+  }
+}
+
+export class IdbStorage implements AuthClientStorage {
+  public async get(key: string): Promise<string | null> {
+    return (await get(key)) ?? null;
+  }
+
+  public async set(key: string, value: string): Promise<void> {
+    await set(key, value);
+  }
+
+  public async remove(key: string): Promise<void> {
+    await remove(key);
+  }
+}
+export class EncryptedIdbStorage implements AuthClientStorage {
+  storedKey: CryptoKey | undefined;
+  private get encryptKey() {
+    return new Promise<CryptoKey>(resolve => {
+      if (this.storedKey) resolve(this.storedKey);
+      get<CryptoKey | undefined>(KEY_ENCRYPTION).then(async storedKey => {
+        const key =
+          storedKey ??
+          (await crypto.subtle.generateKey(
+            {
+              name: 'AES-CBC',
+              length: 256,
+            },
+            false,
+            ['encrypt', 'decrypt'],
+          ));
+        this.storedKey = storedKey;
+
+        await set(KEY_ENCRYPTION, key);
+        resolve(key);
+      });
+    });
+  }
+  private get iv() {
+    return new Promise<Uint8Array>(resolve => {
+      get<Uint8Array | undefined>(KEY_VECTOR).then(async storedIv => {
+        const iv = storedIv ?? (await crypto.getRandomValues(new Uint8Array(16)));
+
+        await set(KEY_VECTOR, iv);
+        resolve(iv);
+      });
+    });
+  }
+
+  public async get(key: string): Promise<string | null> {
+    const encryptKey = await await this.encryptKey;
+    const encrypted = await get<ArrayBuffer>(key);
+
+    if (encrypted) {
+      const decoder = new TextDecoder();
+      const decrypted = await crypto.subtle.decrypt(
+        { name: 'AES-CBC', iv: await this.iv },
+        encryptKey,
+        encrypted,
+      );
+      return decoder.decode(decrypted);
+    }
+    return null;
+  }
+
+  public async set(key: string, value: string): Promise<void> {
+    const encoder = new TextEncoder();
+    const encryptKey = await await this.encryptKey;
+
+    try {
+      await set(
+        key,
+        await crypto.subtle.encrypt(
+          { name: 'AES-CBC', iv: await this.iv },
+          encryptKey,
+          encoder.encode(value).buffer,
+        ),
+      );
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  public async remove(key: string): Promise<void> {
+    await remove(key);
+  }
+}

--- a/packages/auth-client/test-setup.ts
+++ b/packages/auth-client/test-setup.ts
@@ -7,6 +7,7 @@
 // Note that we can use webpack configuration to make some features available to
 // Node.js in a similar way.
 import { Crypto } from '@peculiar/webcrypto';
+import 'fake-indexeddb/auto';
 global.crypto = new Crypto();
 global.TextEncoder = require('text-encoding').TextEncoder;
 global.TextDecoder = require('text-encoding').TextDecoder;

--- a/packages/auth-client/test-setup.ts
+++ b/packages/auth-client/test-setup.ts
@@ -8,7 +8,6 @@
 // Node.js in a similar way.
 import { Crypto } from '@peculiar/webcrypto';
 global.crypto = new Crypto();
-import 'fake-indexeddb/auto';
 global.TextEncoder = require('text-encoding').TextEncoder;
 global.TextDecoder = require('text-encoding').TextDecoder;
 require('whatwg-fetch');

--- a/packages/auth-client/test-setup.ts
+++ b/packages/auth-client/test-setup.ts
@@ -6,8 +6,9 @@
 //
 // Note that we can use webpack configuration to make some features available to
 // Node.js in a similar way.
-
-global.crypto = require('@trust/webcrypto');
+import { Crypto } from '@peculiar/webcrypto';
+global.crypto = new Crypto();
+import 'fake-indexeddb/auto';
 global.TextEncoder = require('text-encoding').TextEncoder;
 global.TextDecoder = require('text-encoding').TextDecoder;
 require('whatwg-fetch');


### PR DESCRIPTION
# Description

AuthClient now uses IndexedDb by default, as localStorage is less secure.
Also offers a generic Indexed Db keyval store, IdbKeyVal


I decided to leave out encryption for this PR to reduce overhead - could be added at a later date https://gist.github.com/krpeacock/9203f1c6bbd8c55f2eef5e001223edf2

Fixes SDK-313

# How Has This Been Tested?

Unit test coverage

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
