### PR TITLE
fix: graceful upgrade from localstorage to idb without breaking sessions

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -19,6 +19,7 @@
         <ul>
           <li>Also offers a generic Indexed Db keyval store, IdbKeyVal</li>
         </ul>
+        <li>AuthClient migrates gracefully from localstorage to IDB when upgrading</li>
       </ul>
       <h2>Version 0.12.2</h2>
       <ul>


### PR DESCRIPTION
# Description

This change makes the upgrade to IDB smoother, by checking to see if the user has a delegation stored in localstorage during initialization, if none is found in the default or provided storage implementation. 

# How Has This Been Tested?

unit testing

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
