### PR TITLE
fix: migration from localstorage to idb

### DIFF
--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -612,7 +612,7 @@ describe('Migration from localstorage', () => {
     expect(storage.set as jest.Mock).toBeCalledTimes(0);
   });
   it('should migrate storage from localstorage', async () => {
-    const localStorage = new LocalStorage('ic');
+    const localStorage = new LocalStorage();
     const storage: AuthClientStorage = {
       remove: jest.fn(),
       get: jest.fn(),

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -198,7 +198,7 @@ export class AuthClient {
       if (!maybeIdentityStorage) {
         // Attempt to migrate from localstorage
         try {
-          const fallbackLocalStorage = new LocalStorage('ic');
+          const fallbackLocalStorage = new LocalStorage();
           const localChain = await fallbackLocalStorage.get(KEY_STORAGE_DELEGATION);
           const localKey = await fallbackLocalStorage.get(KEY_STORAGE_KEY);
           if (localChain && localKey) {


### PR DESCRIPTION
# Description

To migrate from localstorage to idb, AuthClient tries to find current values in the storage with the incorrect keys - i.e it tries to load `icdelegation` and `icidentity` instead of `ic-delegation` and `ic-identity` and therefore, no session are found and migrated.

This is because a `LocalStorage` object is initialized with the prefix `ic` instead of `ic-`.

# How Has This Been Tested?

I tried to bump agent-js from v0.12.0 v0.13.0 in my project [cycles.watch](https://cycles.watch/) locally and noticed that I lost my session. Then debugged and found the prefix mismatch.

# Reference

This PR is a follow-up to PR #606 and release of agent-js v0.13.0 ([changelog](https://github.com/dfinity/agent-js/releases/tag/v0.13.0))

# Open questions

All consumers used to inherits prefix `ic-` or was it an option? If it was a variable that can be set by the developers, then the migration should be extended with such param as well.
