### PR TITLE
fix: auth-client usage in web worker and nodejs

### DIFF
--- a/packages/auth-client/src/db.ts
+++ b/packages/auth-client/src/db.ts
@@ -1,5 +1,5 @@
 import { openDB, IDBPDatabase } from 'idb';
-import { KEY_STORAGE_DELEGATION, KEY_STORAGE_KEY } from './storage';
+import { isBrowser, KEY_STORAGE_DELEGATION, KEY_STORAGE_KEY } from './storage';
 
 type Database = IDBPDatabase<unknown>;
 type IDBValidKey = string | number | Date | BufferSource | IDBValidKey[];
@@ -12,7 +12,7 @@ const _openDbStore = async (
   version: number,
 ) => {
   // Clear legacy stored delegations
-  if (localStorage && localStorage.getItem(KEY_STORAGE_DELEGATION)) {
+  if (isBrowser && localStorage?.getItem(KEY_STORAGE_DELEGATION)) {
     localStorage.removeItem(KEY_STORAGE_DELEGATION);
     localStorage.removeItem(KEY_STORAGE_KEY);
   }

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -18,6 +18,7 @@ import { IdleManager, IdleManagerOptions } from './idleManager';
 import {
   AuthClientStorage,
   IdbStorage,
+  isBrowser,
   KEY_STORAGE_DELEGATION,
   KEY_STORAGE_KEY,
   KEY_VECTOR,
@@ -195,7 +196,7 @@ export class AuthClient {
       key = options.identity;
     } else {
       let maybeIdentityStorage = await storage.get(KEY_STORAGE_KEY);
-      if (!maybeIdentityStorage) {
+      if (!maybeIdentityStorage && isBrowser) {
         // Attempt to migrate from localstorage
         try {
           const fallbackLocalStorage = new LocalStorage();

--- a/packages/auth-client/src/storage.ts
+++ b/packages/auth-client/src/storage.ts
@@ -6,6 +6,8 @@ export const KEY_VECTOR = 'iv';
 // Increment if any fields are modified
 export const DB_VERSION = 1;
 
+export const isBrowser = typeof window !== 'undefined';
+
 /**
  * Interface for persisting user authentication data
  */


### PR DESCRIPTION
# Description

`auth-client` cannot be used in web worker or in NodeJS context  because `window.localStorage` is not available.

e.g. stacktrace while trying to use `v0.13.1` in a jest test:

> ReferenceError: localStorage is not defined
> 
>       18 |  */
>       19 | export const createAuthClient = (): Promise<AuthClient> =>
>     > 20 |   AuthClient.create({
>          |              ^
>       21 |     idleOptions: {
>       22 |       disableIdle: true,
>       23 |       disableDefaultIdleCallback: true,
> 
>       at _openDbStore (node_modules/@dfinity/auth-client/src/db.ts:15:3)
>       at Function.create (node_modules/@dfinity/auth-client/src/db.ts:74:22)
>       at node_modules/@dfinity/auth-client/src/storage.ts:74:17
>       at IdbStorage.get _db [as _db] (node_modules/@dfinity/auth-client/src/storage.ts:72:12)
>       at IdbStorage.get (node_modules/@dfinity/auth-client/src/storage.ts:82:27)
>       at Function.create (node_modules/@dfinity/auth-client/src/index.ts:197:48)
>       at createAuthClient (src/lib/utils/auth.utils.ts:20:14)
>       at Object.signOut (src/lib/stores/auth.store.ts:69:60)
>       at Object.<anonymous> (src/tests/lib/stores/auth.store.spec.ts:10:21)

# Fixes # (issue)

NNS-dapp PR [#1247](https://github.com/dfinity/nns-dapp/pull/1247)

# How Has This Been Tested?

Manually in the browser (window and web worker) and with a jest test.
