### PR TITLE
fix: logout clear storage missing promise await

### DIFF
--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -488,7 +488,7 @@ export class AuthClient {
   }
 
   public async logout(options: { returnTo?: string } = {}): Promise<void> {
-    _deleteStorage(this._storage);
+    await _deleteStorage(this._storage);
 
     // Reset this auth client to a non-authenticated state.
     this._identity = new AnonymousIdentity();


### PR DESCRIPTION
# Description

The `logout` function does not `await` for the storage to be cleared before reloading the window. This can lead to an edge case race condition where the storage would partially cleared after logout while the window is reloaded.

# Fixes # (issue)

NNS-dapp PR [#1247](https://github.com/dfinity/nns-dapp/pull/1247)

# How Has This Been Tested?

Jest test in nns-dapp that failed:

```
it("agent-js should clear indexeddb auth info on logout", async () => {
      const idbStorage = new IdbStorage();
      await idbStorage.set("delegation", "value");

      const value = await idbStorage.get("delegation");
      expect(value).not.toBeNull();

      await logout({});

      const valueCleared = await idbStorage.get("delegation");
      expect(valueCleared).toBeNull(); // <--- value was still set
    });
```

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

