### PR TITLE
fix: breaking auth flow on Safari desktop - prevent confirmation popup

### DIFF
--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -378,31 +378,32 @@ describe('Auth Client login', () => {
     const client = await AuthClient.create();
     // Try without #authorize hash.
     await client.login({ identityProvider: 'http://localhost' });
-    expect(global.open).toBeCalledWith('http://localhost/#authorize', 'idpWindow', undefined);
+    expect(global.open).toBeCalledWith(undefined, 'idpWindow', undefined);
+    expect((client as unknown as { _idpWindow?: Window })._idpWindow?.location).toEqual(
+      'http://localhost/#authorize',
+    );
 
     // Try with #authorize hash.
-    global.open = jest.fn();
     await client.login({ identityProvider: 'http://localhost#authorize' });
-    expect(global.open).toBeCalledWith('http://localhost/#authorize', 'idpWindow', undefined);
+    expect(global.open).toBeCalledWith(undefined, 'idpWindow', undefined);
+    expect((client as unknown as { _idpWindow?: Window })._idpWindow?.location).toEqual(
+      'http://localhost/#authorize',
+    );
 
     // Default url
-    global.open = jest.fn();
     await client.login();
-    expect(global.open).toBeCalledWith(
+    expect(global.open).toBeCalledWith(undefined, 'idpWindow', undefined);
+    expect((client as unknown as { _idpWindow?: Window })._idpWindow?.location).toEqual(
       'https://identity.ic0.app/#authorize',
-      'idpWindow',
-      undefined,
     );
 
     // Default custom window.open feature
-    global.open = jest.fn();
     await client.login({
       windowOpenerFeatures: 'toolbar=0,location=0,menubar=0',
     });
-    expect(global.open).toBeCalledWith(
+    expect(global.open).toBeCalledWith(undefined, 'idpWindow', 'toolbar=0,location=0,menubar=0');
+    expect((client as unknown as { _idpWindow?: Window })._idpWindow?.location).toEqual(
       'https://identity.ic0.app/#authorize',
-      'idpWindow',
-      'toolbar=0,location=0,menubar=0',
     );
   });
   it('should login with a derivation origin', async () => {


### PR DESCRIPTION
# Description

Auth flow on Safari desktop  with agent-js `v0.13.x` is broken. 

Scenario:

- user click on a "login" button in a dapp
- dapp calls `authClient.login(...)`
- Safari prevent `window.open` and ask user to confirm the opening of the new window/popup
- user confirm popup
- Safari open II but loose the information `#authorize` 👉 sign in flow is broken

# Root cause of the issue

> Following is the result of my debugging and interpretation - i.e. did not find any issue in webkit bugtracker and don't have spec to share.

Browsers prevent the opening of url (`window.open` or `a.click`) - with target `_blank` at least - without user interaction. In Safari, it seems that the browser also considers async callback that are executed within a function that opens new window as no user interaction and therefore prevent their opening.

```
const sleep = () => {
    return new Promise((resolve) => {
        setTimeout(() => {
            resolve();
        }, 1000)
    })
}

const login = async () => {
   await sleep();
   window.open(...); // 👉 Safari warn user of the opening of a popup
}
```

Agent-js `v0.13.x` introduces the usage of IndexedDB which requires async callback to be queried. As the `login` function checks for the current key in the storage (`KEY_STORAGE_KEY`), the function matches above criteria - an async callback is executed before window open in the same function - and that's why the issue occurs.

Note that with agent-js `v0.12.x` there weren't such an issue because, I am assuming, using the local storage is not async.

# Solution - workaround

This PR fixes the issue by opening first the window, executing the async callback and then loading the IDP provider URL.

However, this feels like a temporary solution. I can imagine that a proper refactoring of `AuthClient`, rollbacking to localstorage or dropping the use of separate window would be cleaner solutions.

# How Has This Been Tested?

Locally and manually with NNS-dapp.

# Screenshots

![agent-js-safari-desktop-issue](https://user-images.githubusercontent.com/16886711/187627757-6fe2159d-68d4-4aaf-9661-7c9071ee9f93.gif)

