### PR TITLE
fix: resolves window.open issue in safari due to async storage call

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -21,6 +21,10 @@
           </li>
         </ul>
       </ul>
+      <h3>Version 0.13.3</h3>
+        <ul>
+          <li>Auth Client moves key fallback generation to the create method instead of login and makes the _key non-nullable. This fixes a regression with async window.open behavior in Safari</li>
+        </ul>
       <h2>Version 0.13.2</h2>
       <ul>
         <li>auth-client avoids localstorage global and can be used in a web worker or nodejs</li>

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -594,7 +594,8 @@ describe('Migration from localstorage', () => {
 
     await AuthClient.create({ storage });
 
-    expect(storage.set as jest.Mock).toBeCalledTimes(0);
+    // Key is stored during creation when none is provided
+    expect(storage.set as jest.Mock).toBeCalledTimes(1);
   });
   it('should not attempt to migrate if a delegation is already stored', async () => {
     const storage: AuthClientStorage = {
@@ -609,7 +610,7 @@ describe('Migration from localstorage', () => {
 
     await AuthClient.create({ storage });
 
-    expect(storage.set as jest.Mock).toBeCalledTimes(0);
+    expect(storage.set as jest.Mock).toBeCalledTimes(1);
   });
   it('should migrate storage from localstorage', async () => {
     const localStorage = new LocalStorage();
@@ -624,18 +625,6 @@ describe('Migration from localstorage', () => {
 
     await AuthClient.create({ storage });
 
-    expect(storage.set as jest.Mock).toBeCalledTimes(2);
-    expect((storage.set as jest.Mock).mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          "delegation",
-          "test",
-        ],
-        Array [
-          "identity",
-          "key",
-        ],
-      ]
-    `);
+    expect(storage.set as jest.Mock).toBeCalledTimes(3);
   });
 });


### PR DESCRIPTION
# Description

Auth Client moves key fallback generation to the create method instead of login and makes the _key non-nullable. This fixes a regression with async window.open behavior in Safari

Fixes #619

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
