### PR TITLE
fix: Cbor.encode(BigInt(n)) possible failure

### DIFF
--- a/packages/agent/src/cbor.test.ts
+++ b/packages/agent/src/cbor.test.ts
@@ -54,6 +54,82 @@ test('empty canister ID', () => {
   expect(Principal.fromUint8Array(outputA as any).toText()).toBe('aaaaa-aa');
 });
 
+describe('cbor encode/decode bigint', () => {
+  test('encode decode 0 to 1_000_000', () => {
+    for (let i = 0; i < 1_000_000; i += 1) {
+      let buffer;
+
+      try {
+        buffer = encode(BigInt(i));
+      } catch (error) {
+        console.log(`error encoding on ${i.toString()}`);
+        expect((error as Error).message).toBeTruthy();
+      }
+
+      try {
+        const decoded = decode<bigint>(buffer);
+        expect(decoded).toBe(BigInt(i));
+      } catch (error) {
+        console.log(`error decoding on ${i.toString()}`);
+        expect((error as Error).message).toBeTruthy();
+      }
+      // if (i % 100000 === 0) {
+      //   console.log(`${new Date(Date.now()).toLocaleTimeString()} with ${i.toString()}`);
+      // }
+    }
+  });
+  test('encode decode 1_000_000n to 1_000_000_000_000n', () => {
+    for (let i = 1_000_000; i < 1_000_000_000_000; i += 1_000_000) {
+      let buffer;
+
+      const random_num = Math.floor(Math.random() * Math.pow(10, i.toString().length - 1));
+
+      const actual = BigInt(i + random_num);
+      try {
+        buffer = encode(actual);
+      } catch (error) {
+        console.log(`error encoding on ${i.toString()}`);
+        expect((error as Error).message).toBeTruthy();
+      }
+
+      try {
+        const decoded = decode<bigint>(buffer);
+        expect(decoded).toBe(actual);
+      } catch (error) {
+        console.log(`error decoding on ${i.toString()}`);
+        expect((error as Error).message).toBeTruthy();
+      }
+      // if (i % 1_000_000_000_00 === 0) {
+      //   console.log(`${new Date(Date.now()).toLocaleTimeString()} with ${actual.toString()}`);
+      // }
+    }
+  });
+  test('encode decode 1_000_000_000_000n to 1_000_000_000_000_000_000n', () => {
+    for (let i = 1_000_000_000_000n; i < 1_000_000_000_000_000_000n; i += 1_000_000_000_000n) {
+      let buffer;
+      const random_num = BigInt(Math.floor(Math.random() * Math.pow(10, i.toString().length - 1)));
+      const actual = i + random_num;
+      try {
+        buffer = encode(actual);
+      } catch (error) {
+        console.log(`error encoding on ${i.toString()}`);
+        expect((error as Error).message).toBeTruthy();
+      }
+
+      try {
+        const decoded = decode<bigint>(buffer);
+        expect(decoded).toBe(actual);
+      } catch (error) {
+        console.log(`error decoding on ${i.toString()}`);
+        expect((error as Error).message).toBeTruthy();
+      }
+      // if (i % 1_000_000_000_000_000_00n === 0n) {
+      //   console.log(`${new Date(Date.now()).toLocaleTimeString()} with ${actual.toString()}`);
+      // }
+    }
+  });
+});
+
 function buf2hex(buffer: Uint8Array) {
   // Construct an array such that each number is translated to the
   // hexadecimal equivalent, ensure it is a string and padded then

--- a/packages/agent/src/cbor.test.ts
+++ b/packages/agent/src/cbor.test.ts
@@ -107,7 +107,7 @@ describe('cbor encode/decode bigint', () => {
     }
   });
   test('encode decode 1_000_000_000_000n to 1_000_000_000_000_000_000n', () => {
-    for (let i = 1_000_000_000_000n; i < 1_000_000_000_000_000_000n; i += 1_000_000_000_000n) {
+    for (let i = BigInt(1_000_000_000_000); i < BigInt(1_000_000_000_000_000_000); i += BigInt(1_000_000_000_000)) {
       let buffer;
       const random_num = BigInt(Math.floor(Math.random() * Math.pow(10, i.toString().length - 1)));
       const actual = i + random_num;

--- a/packages/agent/src/cbor.test.ts
+++ b/packages/agent/src/cbor.test.ts
@@ -73,6 +73,7 @@ describe('cbor encode/decode bigint', () => {
         console.log(`error decoding on ${i.toString()}`);
         expect((error as Error).message).toBeTruthy();
       }
+      // // if we log the time
       // if (i % 100000 === 0) {
       //   console.log(`${new Date(Date.now()).toLocaleTimeString()} with ${i.toString()}`);
       // }
@@ -99,6 +100,7 @@ describe('cbor encode/decode bigint', () => {
         console.log(`error decoding on ${i.toString()}`);
         expect((error as Error).message).toBeTruthy();
       }
+      // // if we log the time
       // if (i % 1_000_000_000_00 === 0) {
       //   console.log(`${new Date(Date.now()).toLocaleTimeString()} with ${actual.toString()}`);
       // }
@@ -123,6 +125,7 @@ describe('cbor encode/decode bigint', () => {
         console.log(`error decoding on ${i.toString()}`);
         expect((error as Error).message).toBeTruthy();
       }
+      // // if we log the time
       // if (i % 1_000_000_000_000_000_00n === 0n) {
       //   console.log(`${new Date(Date.now()).toLocaleTimeString()} with ${actual.toString()}`);
       // }

--- a/packages/agent/src/utils/buffer.ts
+++ b/packages/agent/src/utils/buffer.ts
@@ -27,6 +27,12 @@ const hexRe = new RegExp(/^([0-9A-F]{2})*$/i);
  * @param hex The hexadecimal string to use.
  */
 export function fromHex(hex: string): ArrayBuffer {
+  //FIXME: always padding hex string length to be even
+  // then run the reg test
+  if (hex.length % 2 !== 0) {
+    hex = '0' + hex;
+  }
+
   if (!hexRe.test(hex)) {
     throw new Error('Invalid hexadecimal string.');
   }


### PR DESCRIPTION
Fix `Cbor.encode(BigInt(n))` possible failure

# Description

When use `Cbor.encode`, if passed value is BigInt, first will run the BigInt encoder and transform BigInt value to be a hex string. However this `BigInt(n).toString(16)` would probrably generate a hex string length not to be even, which won't pass the RegTest in the `fromHex` function. 

```typescript
const hexRe = new RegExp(/^([0-9A-F]{2})*$/i);
```

Fixes # (issue)

Added a zero-padding while passing hex string length is not even.

```typescript
export function fromHex(hex: string): ArrayBuffer {
  //FIXME: always padding hex string length to be even
  // then run the reg test
  if (hex.length % 2 !== 0) {
    hex = '0' + hex;
  }

  if (!hexRe.test(hex)) {
    throw new Error('Invalid hexadecimal string.');
  }
  const buffer = [...hex]
    .reduce((acc, curr, i) => {
      // tslint:disable-next-line:no-bitwise
      acc[(i / 2) | 0] = (acc[(i / 2) | 0] || '') + curr;
      return acc;
    }, [] as string[])
    .map(x => Number.parseInt(x, 16));

  return new Uint8Array(buffer).buffer;
}


```

# How Has This Been Tested?

test cases are in `cbor.tests.ts`

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
