### PR TITLE
feat: support for bls verification polyfill

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -4,5 +4,11 @@
       "type": "assets",
       "source": ["docs/generated"]
     }
+  },
+  "networks": {
+    "local": {
+      "bind": "127.0.0.1:8000",
+      "type": "ephemeral"
+    }
   }
 }

--- a/dfx.json
+++ b/dfx.json
@@ -4,11 +4,5 @@
       "type": "assets",
       "source": ["docs/generated"]
     }
-  },
-  "networks": {
-    "local": {
-      "bind": "127.0.0.1:8000",
-      "type": "ephemeral"
-    }
   }
 }

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -10,6 +10,10 @@
     <h1>Agent-JS Changelog</h1>
 
     <section>
+      <h2>Version 0.13.3</h2>
+      <ul>
+        <li>adds ability to polyfill bls verification in Certificate</li>
+      </ul>
       <h2>Version 0.13.2</h2>
       <ul>
         <li>auth-client avoids localstorage global and can be used in a web worker or nodejs</li>

--- a/e2e/node/basic/canisterStatus.test.ts
+++ b/e2e/node/basic/canisterStatus.test.ts
@@ -3,8 +3,10 @@ import { Principal } from '@dfinity/principal';
 import counter from '../canisters/counter';
 
 jest.setTimeout(30_000);
+afterEach(async () => {
+  await Promise.resolve();
+});
 describe.only('canister status', () => {
-  jest.useFakeTimers();
   it('should fetch successfully', async () => {
     const counterObj = await (await counter)();
     const agent = new HttpAgent({ host: `http://localhost:${process.env.REPLICA_PORT}` });

--- a/e2e/node/basic/canisterStatus.test.ts
+++ b/e2e/node/basic/canisterStatus.test.ts
@@ -4,6 +4,7 @@ import counter from '../canisters/counter';
 
 jest.setTimeout(30_000);
 describe.only('canister status', () => {
+  jest.useFakeTimers();
   it('should fetch successfully', async () => {
     const counterObj = await (await counter)();
     const agent = new HttpAgent({ host: `http://localhost:${process.env.REPLICA_PORT}` });

--- a/packages/agent/src/canisterStatus/index.ts
+++ b/packages/agent/src/canisterStatus/index.ts
@@ -4,6 +4,7 @@ import { lebDecode, PipeArrayBuffer } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import { AgentError } from '../errors';
 import { HttpAgent, Cbor, Certificate, toHex } from '..';
+import type { CreateCertificateOptions } from '..';
 
 /**
  * Types of an entry on the canisterStatus map.
@@ -50,6 +51,7 @@ export type CanisterStatusOptions = {
   canisterId: Principal;
   agent: HttpAgent;
   paths?: Path[] | Set<Path>;
+  blsVerify?: CreateCertificateOptions['blsVerify'];
 };
 
 /**

--- a/packages/agent/src/certificate.ts
+++ b/packages/agent/src/certificate.ts
@@ -136,7 +136,8 @@ export class Certificate {
   public static async create(options: CreateCertificateOptions): Promise<Certificate> {
     let blsVerify = options.blsVerify;
     if (!blsVerify) {
-      blsVerify = await (await import('./utils/bls')).blsVerify;
+      const bls = await import('./utils/bls');
+      blsVerify = bls.blsVerify;
     }
     const cert = new Certificate(
       options.certificate,

--- a/packages/agent/src/polling/index.ts
+++ b/packages/agent/src/polling/index.ts
@@ -1,6 +1,6 @@
 import { Principal } from '@dfinity/principal';
 import { Agent, RequestStatusResponseStatus } from '../agent';
-import { Certificate } from '../certificate';
+import { Certificate, CreateCertificateOptions } from '../certificate';
 import { RequestId } from '../request_id';
 import { toHex } from '../utils/buffer';
 
@@ -29,6 +29,7 @@ export async function pollForResponse(
   strategy: PollStrategy,
   // eslint-disable-next-line
   request?: any,
+  blsVerify?: CreateCertificateOptions['blsVerify'],
 ): Promise<ArrayBuffer> {
   const path = [new TextEncoder().encode('request_status'), requestId];
   const currentRequest = request ?? (await agent.createReadStateRequest?.({ paths: [path] }));
@@ -38,6 +39,7 @@ export async function pollForResponse(
     certificate: state.certificate,
     rootKey: agent.rootKey,
     canisterId: canisterId,
+    blsVerify,
   });
   const maybeBuf = cert.lookup([...path, new TextEncoder().encode('status')]);
   let status;


### PR DESCRIPTION
# Description

In order to accommodate environments where web assembly is not supported, allows a polyfill for BLS verification to be passed during the creation of an Actor. Unblocks React Native support

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
