### PR TITLE
fix: time tests only use faketimers once

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -16,9 +16,7 @@
           Adds retry logic to HttpAgent. By default, retries three times before throwing an error,
           to offer a more cohesive workflow
         </li>
-      </ul>
-      <h2>Version 0.13.4</h2>
-      <ul>
+        <li>fixes flaky tests for syncTime</li>
         <li>chore: auth-client expose storage constant keys</li>
         <li>
           bug: auth-client resolves window.open issue in login function in safari due to async


### PR DESCRIPTION
# Description

fixes some flaky tests for the synctime feature

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
