### PR TITLE
chore: adds js-sha256 dependency to principal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ dist
 
 # Generated Docs
 docs/generated/agent
+docs/generated/assets
 docs/generated/auth-client
 docs/generated/authentication
 docs/generated/identity

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -10,6 +10,10 @@
     <h1>Agent-JS Changelog</h1>
 
     <section>
+      <h2>Version x.x.x</h2>
+      <ul>
+        <li>chore: adds js-sha256 dependency to principal</li>
+      </ul>
       <h2>Version 0.14.0</h2>
       <ul>
         <li>
@@ -28,8 +32,8 @@
           storage call
         </li>
         <li>
-          New package: @dfinity/assets. This package provides an asset manager to manage assets
-          on an assets canister.
+          New package: @dfinity/assets. This package provides an asset manager to manage assets on
+          an assets canister.
         </li>
         <li>bug: auth-client storage wrapper returns after resolve to avoid idb to be recreated</li>
       </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20152,6 +20152,7 @@
       "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "js-sha256": "^0.9.0",
         "ts-node": "^10.8.2"
       },
       "devDependencies": {
@@ -22099,6 +22100,7 @@
         "eslint": "^8.19.0",
         "eslint-plugin-jsdoc": "^39.3.3",
         "jest": "^28.1.2",
+        "js-sha256": "*",
         "text-encoding": "^0.7.0",
         "ts-jest": "^28.0.5",
         "ts-node": "^10.8.2",

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -58,6 +58,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "dependencies": {
+    "js-sha256": "^0.9.0",
     "ts-node": "^10.8.2"
   }
 }


### PR DESCRIPTION
# Description

Principal was using a package used elsewhere but was not included in its package dependencies

Fixes #522 
# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
