### PR TITLE
fix: idlemanager starting before login suceeds

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,6 +13,10 @@
       <h2>Version x.x.x</h2>
       <ul>
         <li>chore: adds js-sha256 dependency to principal</li>
+        <li>
+          bug: fixes idlemanager initializing - now either requires createOptions.identity or
+          authClient.login to be called before starting idle timeout
+        </li>
       </ul>
       <h2>Version 0.14.0</h2>
       <ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6322,8 +6322,13 @@
       }
     },
     "node_modules/amcl-js": {
-      "resolved": "packages/bls-verify/src/vendor/amcl-js",
-      "link": true
+      "version": "3.0.0",
+      "resolved": "file:packages/bls-verify/src/vendor/amcl-js-3.0.0.tgz",
+      "integrity": "sha512-YpgxYjeJ9vbfMU0YYzdA1qlmz3u4Dz02SFkcGH4wlrUQhzgdqr47ZYLU68Jf8nj9RRV6Fi1rG/5C4JlEiIy4Sg==",
+      "license": "Apache License 2.0",
+      "dependencies": {
+        "prompt": "^1.0.0"
+      }
     },
     "node_modules/amp": {
       "version": "0.3.1",
@@ -19799,14 +19804,7 @@
       "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "amcl-js": "file:src/vendor/amcl-js"
-      }
-    },
-    "packages/bls-verify/src/vendor/amcl-js": {
-      "version": "3.0.0",
-      "license": "Apache License 2.0",
-      "dependencies": {
-        "prompt": "^1.0.0"
+        "amcl-js": "file:src/vendor/amcl-js-3.0.0.tgz"
       }
     },
     "packages/bls-verify/vendor/miracl": {
@@ -21828,7 +21826,7 @@
     "@dfinity/bls-verify": {
       "version": "file:packages/bls-verify",
       "requires": {
-        "amcl-js": "file:src/vendor/amcl-js"
+        "amcl-js": "file:src/vendor/amcl-js-3.0.0.tgz"
       }
     },
     "@dfinity/candid": {
@@ -22100,7 +22098,7 @@
         "eslint": "^8.19.0",
         "eslint-plugin-jsdoc": "^39.3.3",
         "jest": "^28.1.2",
-        "js-sha256": "*",
+        "js-sha256": "^0.9.0",
         "text-encoding": "^0.7.0",
         "ts-jest": "^28.0.5",
         "ts-node": "^10.8.2",
@@ -25453,7 +25451,8 @@
       "requires": {}
     },
     "amcl-js": {
-      "version": "file:packages/bls-verify/src/vendor/amcl-js",
+      "version": "file:src/vendor/amcl-js-3.0.0.tgz",
+      "integrity": "sha512-YpgxYjeJ9vbfMU0YYzdA1qlmz3u4Dz02SFkcGH4wlrUQhzgdqr47ZYLU68Jf8nj9RRV6Fi1rG/5C4JlEiIy4Sg==",
       "requires": {
         "prompt": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6322,13 +6322,8 @@
       }
     },
     "node_modules/amcl-js": {
-      "version": "3.0.0",
-      "resolved": "file:packages/bls-verify/src/vendor/amcl-js-3.0.0.tgz",
-      "integrity": "sha512-YpgxYjeJ9vbfMU0YYzdA1qlmz3u4Dz02SFkcGH4wlrUQhzgdqr47ZYLU68Jf8nj9RRV6Fi1rG/5C4JlEiIy4Sg==",
-      "license": "Apache License 2.0",
-      "dependencies": {
-        "prompt": "^1.0.0"
-      }
+      "resolved": "packages/bls-verify/src/vendor/amcl-js",
+      "link": true
     },
     "node_modules/amp": {
       "version": "0.3.1",
@@ -19804,7 +19799,14 @@
       "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "amcl-js": "file:src/vendor/amcl-js-3.0.0.tgz"
+        "amcl-js": "file:src/vendor/amcl-js"
+      }
+    },
+    "packages/bls-verify/src/vendor/amcl-js": {
+      "version": "3.0.0",
+      "license": "Apache License 2.0",
+      "dependencies": {
+        "prompt": "^1.0.0"
       }
     },
     "packages/bls-verify/vendor/miracl": {
@@ -21826,7 +21828,7 @@
     "@dfinity/bls-verify": {
       "version": "file:packages/bls-verify",
       "requires": {
-        "amcl-js": "file:src/vendor/amcl-js-3.0.0.tgz"
+        "amcl-js": "file:src/vendor/amcl-js"
       }
     },
     "@dfinity/candid": {
@@ -25451,8 +25453,7 @@
       "requires": {}
     },
     "amcl-js": {
-      "version": "file:src/vendor/amcl-js-3.0.0.tgz",
-      "integrity": "sha512-YpgxYjeJ9vbfMU0YYzdA1qlmz3u4Dz02SFkcGH4wlrUQhzgdqr47ZYLU68Jf8nj9RRV6Fi1rG/5C4JlEiIy4Sg==",
+      "version": "file:packages/bls-verify/src/vendor/amcl-js",
       "requires": {
         "prompt": "^1.0.0"
       }

--- a/packages/bls-verify/tsconfig.json
+++ b/packages/bls-verify/tsconfig.json
@@ -18,6 +18,6 @@
     "strict": true,
     "target": "es2017"
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "types/**/*", "amcl-js-3.0.0.tgz"],
   "references": []
 }

--- a/packages/bls-verify/types/amcl.d.ts
+++ b/packages/bls-verify/types/amcl.d.ts
@@ -1,0 +1,1 @@
+declare module 'amcl-js';


### PR DESCRIPTION
# Description

I observed by setting a low timeout that idlemanager was firing even when I had not logged in. This changes the logic so that the idle timeout does not start counting unless an identity is passed in `idleOptions`, or after `authClient.login` succeeds.

# How Has This Been Tested?

New unit tests

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
