### PR TITLE
feat: migrate to secure ECDSA key for auth-client

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,10 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <ul>
+          Changes default stored key for auth-client to use ECDSAKey
+          <li>Also updates the storage interface types to support CryptoKeyPair</li>
+        </ul>
         <li>updates link to identity-secp256k1 in docs site</li>
       </ul>
       <h2>Version 0.15.1</h2>

--- a/packages/auth-client/src/__snapshots__/index.test.ts.snap
+++ b/packages/auth-client/src/__snapshots__/index.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Migration from Ed25519Key should continue using an existing Ed25519Key and delegation 1`] = `
+DelegationIdentity {
+  "_delegation": Object {
+    "delegations": Array [
+      Object {
+        "delegation": Object {
+          "expiration": "15e6375edc280000",
+          "pubkey": "302a300506032b6570032100d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809",
+        },
+        "signature": "4e1365d5be0d4d0991088894ec850b6b1ffe7f1f00e53d82d6687f1aa8365f42129c2fee35f2f9d41c5749534b81017000c1a93095e406ff0ada03ed864d000a",
+      },
+    ],
+    "publicKey": "302a300506032b6570032100d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809",
+  },
+  "_inner": Array [
+    "302a300506032b6570032100d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809",
+    "4bbff6b476463558d7be318aa342d1a97778d70833038680187950e9e02486c0d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809",
+  ],
+}
+`;

--- a/packages/auth-client/src/db.test.ts
+++ b/packages/auth-client/src/db.test.ts
@@ -32,4 +32,65 @@ describe('indexeddb wrapper', () => {
 
     expect(await db.get('testKey')).toBe(null);
   });
+  it('should support storing a CryptoKeyPair', async () => {
+    const db = await testDb();
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: 'RSA-OAEP',
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: { name: 'SHA-256' },
+      },
+      true,
+      ['encrypt', 'decrypt'],
+    );
+    await db.set('testKey', keyPair);
+    const storedKey = (await db.get('testKey')) as CryptoKeyPair;
+
+    expect(storedKey).toMatchInlineSnapshot(
+      keyPair,
+      `
+      Object {
+        "privateKey": Object {
+          "algorithm": Object {
+            "hash": Object {
+              "name": "SHA-256",
+            },
+            "modulusLength": 2048,
+            "name": "RSA-OAEP",
+            "publicExponent": Object {
+              "0": 1,
+              "1": 0,
+              "2": 1,
+            },
+          },
+          "extractable": true,
+          "type": "private",
+          "usages": Array [
+            "decrypt",
+          ],
+        },
+        "publicKey": Object {
+          "algorithm": Object {
+            "hash": Object {
+              "name": "SHA-256",
+            },
+            "modulusLength": 2048,
+            "name": "RSA-OAEP",
+            "publicExponent": Object {
+              "0": 1,
+              "1": 0,
+              "2": 1,
+            },
+          },
+          "extractable": true,
+          "type": "public",
+          "usages": Array [
+            "encrypt",
+          ],
+        },
+      }
+    `,
+    );
+  });
 });

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -749,7 +749,7 @@ describe('Migration from Ed25519Key', () => {
 
     const key = await Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
     const chain = DelegationChain.create(key, key.getPublicKey(), expiration);
-    const fakeStore = {};
+    const fakeStore: Record<any, any> = {};
     fakeStore[KEY_STORAGE_DELEGATION] = JSON.stringify((await chain).toJSON());
     fakeStore[KEY_STORAGE_KEY] = JSON.stringify(testSecrets);
 
@@ -773,7 +773,7 @@ describe('Migration from Ed25519Key', () => {
     expect(fakeStore).toMatchInlineSnapshot(`Object {}`);
   });
   it('should generate and store a ECDSAKey if no key is stored', async () => {
-    const fakeStore = {};
+    const fakeStore: Record<any, any> = {};
     const storage: AuthClientStorage = {
       remove: jest.fn(),
       get: jest.fn(),

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -2,7 +2,7 @@ import 'fake-indexeddb/auto';
 import { Actor, HttpAgent } from '@dfinity/agent';
 import { AgentError } from '@dfinity/agent/lib/cjs/errors';
 import { IDL } from '@dfinity/candid';
-import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { DelegationChain, Ed25519KeyIdentity } from '@dfinity/identity';
 import { Principal } from '@dfinity/principal';
 import { AuthClient, ERROR_USER_INTERRUPT, IdbStorage } from './index';
 import {
@@ -691,5 +691,105 @@ describe('Migration from localstorage', () => {
     await AuthClient.create({ storage });
 
     expect(storage.set as jest.Mock).toBeCalledTimes(3);
+  });
+});
+
+describe('Migration from Ed25519Key', () => {
+  const testSecrets = [
+    '302a300506032b6570032100d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809',
+    '4bbff6b476463558d7be318aa342d1a97778d70833038680187950e9e02486c0d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809',
+  ];
+  it('should continue using an existing Ed25519Key and delegation', async () => {
+    // set the jest timer to a fixed value
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
+
+    // two days from now
+    const expiration = new Date('2020-01-03T00:00:00.000Z');
+
+    const key = await Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
+    const chain = DelegationChain.create(key, key.getPublicKey(), expiration);
+    const storage: AuthClientStorage = {
+      remove: jest.fn(),
+      get: jest.fn(async x => {
+        if (x === KEY_STORAGE_DELEGATION) return JSON.stringify((await chain).toJSON());
+        if (x === KEY_STORAGE_KEY) return JSON.stringify(testSecrets);
+        return null;
+      }),
+      set: jest.fn(),
+    };
+
+    const client = await AuthClient.create({ storage });
+
+    const identity = await client.getIdentity();
+    expect(identity).toMatchSnapshot();
+  });
+  it('should continue using an existing Ed25519Key with no delegation', async () => {
+    // set the jest timer to a fixed value
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
+
+    const storage: AuthClientStorage = {
+      remove: jest.fn(),
+      get: jest.fn(async x => {
+        if (x === KEY_STORAGE_KEY) return JSON.stringify(testSecrets);
+        return null;
+      }),
+      set: jest.fn(),
+    };
+
+    const client = await AuthClient.create({ storage });
+
+    const identity = await client.getIdentity();
+    expect(identity.getPrincipal().isAnonymous()).toBe(true);
+  });
+  it('should continue using an existing Ed25519Key with an expired delegation', async () => {
+    // set the jest timer to a fixed value
+    jest.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
+
+    // two days ago
+    const expiration = new Date('2019-12-30T00:00:00.000Z');
+
+    const key = await Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
+    const chain = DelegationChain.create(key, key.getPublicKey(), expiration);
+    const fakeStore = {};
+    fakeStore[KEY_STORAGE_DELEGATION] = JSON.stringify((await chain).toJSON());
+    fakeStore[KEY_STORAGE_KEY] = JSON.stringify(testSecrets);
+
+    const storage: AuthClientStorage = {
+      remove: jest.fn(async x => {
+        delete fakeStore[x];
+      }),
+      get: jest.fn(async x => {
+        return fakeStore[x] ?? null;
+      }),
+      set: jest.fn(),
+    };
+
+    const client = await AuthClient.create({ storage });
+
+    const identity = await client.getIdentity();
+    expect(identity.getPrincipal().isAnonymous()).toBe(true);
+
+    // expect the delegation to be removed
+    expect(storage.remove as jest.Mock).toBeCalledTimes(3);
+    expect(fakeStore).toMatchInlineSnapshot(`Object {}`);
+  });
+  it('should generate and store a ECDSAKey if no key is stored', async () => {
+    const fakeStore = {};
+    const storage: AuthClientStorage = {
+      remove: jest.fn(),
+      get: jest.fn(),
+      set: jest.fn(async (x, y) => {
+        fakeStore[x] = y;
+      }),
+    };
+    const client = await AuthClient.create({ storage });
+
+    // It should have stored a cryptoKey
+    expect(Object.keys(fakeStore[KEY_STORAGE_KEY])).toMatchInlineSnapshot(`
+      Array [
+        "privateKey",
+        "publicKey",
+      ]
+    `);
   });
 });

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -77,7 +77,6 @@ describe('Auth Client', () => {
   it('should initialize an idleManager if an identity is passed', async () => {
     const test = await AuthClient.create({ identity: await Ed25519KeyIdentity.generate() });
     expect(test.idleManager).toBeDefined();
-    test.idleManager; //?
   });
   it('should be able to invalidate an identity after going idle', async () => {
     // setup actor

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -233,7 +233,7 @@ export class AuthClient {
 
     let identity = new AnonymousIdentity();
     let chain: null | DelegationChain = null;
-
+    key;
     if (key) {
       try {
         const chainStorage = await storage.get(KEY_STORAGE_DELEGATION);

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -12,6 +12,7 @@ import {
   isDelegationValid,
   DelegationIdentity,
   Ed25519KeyIdentity,
+  ECDSAKeyIdentity,
 } from '@dfinity/identity';
 import { Principal } from '@dfinity/principal';
 import { IdleManager, IdleManagerOptions } from './idleManager';
@@ -42,7 +43,7 @@ export interface AuthClientCreateOptions {
   /**
    * An identity to use as the base
    */
-  identity?: SignIdentity;
+  identity?: SignIdentity | ECDSAKeyIdentity;
   /**
    * Optional storage with get, set, and remove. Uses {@link IdbStorage} by default
    */
@@ -191,7 +192,7 @@ export class AuthClient {
   ): Promise<AuthClient> {
     const storage = options.storage ?? new IdbStorage();
 
-    let key: null | SignIdentity = null;
+    let key: null | SignIdentity | ECDSAKeyIdentity = null;
     if (options.identity) {
       key = options.identity;
     } else {
@@ -217,9 +218,14 @@ export class AuthClient {
       }
       if (maybeIdentityStorage) {
         try {
-          key = Ed25519KeyIdentity.fromJSON(maybeIdentityStorage);
+          if (typeof maybeIdentityStorage === 'object') {
+            key = await ECDSAKeyIdentity.fromKeyPair(maybeIdentityStorage);
+          } else if (typeof maybeIdentityStorage === 'string') {
+            // This is a legacy identity, which is a serialized Ed25519KeyIdentity.
+            key = Ed25519KeyIdentity.fromJSON(maybeIdentityStorage);
+          }
         } catch (e) {
-          // Ignore this, this means that the localStorage value isn't a valid Ed25519KeyIdentity
+          // Ignore this, this means that the localStorage value isn't a valid Ed25519KeyIdentity or ECDSAKeyIdentity
           // serialization.
         }
       }
@@ -231,6 +237,11 @@ export class AuthClient {
     if (key) {
       try {
         const chainStorage = await storage.get(KEY_STORAGE_DELEGATION);
+        if (typeof chainStorage === 'object' && chainStorage !== null) {
+          throw new Error(
+            'Delegation chain is incorrectly stored. A delegation chain should be stored as a string.',
+          );
+        }
 
         if (options.identity) {
           identity = options.identity;
@@ -263,7 +274,7 @@ export class AuthClient {
 
     if (!key) {
       // Create a new key (whether or not one was in storage).
-      key = Ed25519KeyIdentity.generate();
+      key = await ECDSAKeyIdentity.generate();
       await storage.set(KEY_STORAGE_KEY, JSON.stringify(key));
     }
 

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -233,7 +233,6 @@ export class AuthClient {
 
     let identity = new AnonymousIdentity();
     let chain: null | DelegationChain = null;
-    key;
     if (key) {
       try {
         const chainStorage = await storage.get(KEY_STORAGE_DELEGATION);

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -275,7 +275,7 @@ export class AuthClient {
     if (!key) {
       // Create a new key (whether or not one was in storage).
       key = await ECDSAKeyIdentity.generate();
-      await storage.set(KEY_STORAGE_KEY, JSON.stringify(key));
+      await storage.set(KEY_STORAGE_KEY, (key as ECDSAKeyIdentity).getKeyPair());
     }
 
     return new this(identity, key, chain, storage, idleManager, options);

--- a/packages/auth-client/src/storage.ts
+++ b/packages/auth-client/src/storage.ts
@@ -8,13 +8,15 @@ export const DB_VERSION = 1;
 
 export const isBrowser = typeof window !== 'undefined';
 
+export type StoredKey = string | CryptoKeyPair;
+
 /**
  * Interface for persisting user authentication data
  */
 export interface AuthClientStorage {
-  get(key: string): Promise<string | null>;
+  get(key: string): Promise<StoredKey | null>;
 
-  set(key: string, value: string): Promise<void>;
+  set(key: string, value: StoredKey): Promise<void>;
 
   remove(key: string): Promise<void>;
 }


### PR DESCRIPTION
# Description

Now that we have the non-exportable ECDSAKeyIdentity using CryptoKeys, we can use it as the base key for II Delegations. 

Fixes # FOLLOW-814

# How Has This Been Tested?



New unit tests, also by compiling the package and using it in the auth-client-demo application

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.


[FOLLOW-814]: https://dfinity.atlassian.net/browse/FOLLOW-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ