### PR TITLE
feat: introduces X-Request-ID header to more easily identify retried requests

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,7 +13,7 @@
       <h2>Version x.x.x</h2>
       <ul>
         <li>
-          introduces X-Request-ID header to more easily identify retried requests. Also uses a
+          introduces X-IC-Request-ID header to more easily identify retried requests. Also uses a
           standard Headers constuctor to manage headers
         </li>
         <ul>

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,10 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>
+          introduces X-Request-ID header to more easily identify retried requests. Also uses a
+          standard Headers constuctor to manage headers
+        </li>
         <ul>
           Changes default stored key for auth-client to use ECDSAKey
           <li>Also updates the storage interface types to support CryptoKeyPair</li>

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -486,9 +486,9 @@ describe('makeNonce', () => {
 
       expect(mockFetch).toBeCalledTimes(1);
       const request = mockFetch.mock.calls[0][1];
-      expect(request.headers.get?.('X-Request-Id')).toBeDefined();
+      expect(request.headers.get?.('X-IC-Request-ID')).toBeDefined();
 
-      const nonce = request.headers.get('X-Request-Id');
+      const nonce = request.headers.get('X-IC-Request-ID');
       expect(nonce).toBeDefined();
       expect(nonce).toHaveLength(32);
     });

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -293,10 +293,10 @@ export class HttpAgent implements Agent {
       request: {
         body: null,
         method: 'POST',
-        headers: {
+        headers: new Headers({
           'Content-Type': 'application/cbor',
           ...(this._credentials ? { Authorization: 'Basic ' + btoa(this._credentials) } : {}),
-        },
+        }),
       },
       endpoint: Endpoint.Call,
       body: submit,
@@ -383,10 +383,10 @@ export class HttpAgent implements Agent {
     let transformedRequest: any = await this._transform({
       request: {
         method: 'POST',
-        headers: {
+        headers: new Headers({
           'Content-Type': 'application/cbor',
           ...(this._credentials ? { Authorization: 'Basic ' + btoa(this._credentials) } : {}),
-        },
+        }),
       },
       endpoint: Endpoint.Query,
       body: request,
@@ -425,10 +425,10 @@ export class HttpAgent implements Agent {
     const transformedRequest: any = await this._transform({
       request: {
         method: 'POST',
-        headers: {
+        headers: new Headers({
           'Content-Type': 'application/cbor',
           ...(this._credentials ? { Authorization: 'Basic ' + btoa(this._credentials) } : {}),
-        },
+        }),
       },
       endpoint: Endpoint.ReadState,
       body: {

--- a/packages/agent/src/agent/http/transforms.ts
+++ b/packages/agent/src/agent/http/transforms.ts
@@ -37,7 +37,7 @@ export function makeNonceTransform(nonceFn: () => Nonce = makeNonce): HttpAgentR
     const nonce = nonceFn();
     // Nonce needs to be inserted into the header for all requests, to enable logs to be correlated with requests.
     const headers = request.request.headers ? new Headers(request.request.headers) : new Headers();
-    headers.set('X-Request-ID', toHex(new Uint8Array(nonce)));
+    headers.set('X-IC-Request-ID', toHex(new Uint8Array(nonce)));
     request.request.headers = headers;
 
     // Nonce only needs to be inserted into the body for async calls, to prevent replay attacks.

--- a/packages/agent/src/agent/http/transforms.ts
+++ b/packages/agent/src/agent/http/transforms.ts
@@ -1,6 +1,7 @@
 import { lebEncode } from '@dfinity/candid';
 import * as cbor from 'simple-cbor';
 import { Endpoint, HttpAgentRequest, HttpAgentRequestTransformFn, makeNonce, Nonce } from './types';
+import { toHex } from '../../utils/buffer';
 
 const NANOSECONDS_PER_MILLISECONDS = BigInt(1_000_000);
 
@@ -33,8 +34,13 @@ export class Expiry {
  */
 export function makeNonceTransform(nonceFn: () => Nonce = makeNonce): HttpAgentRequestTransformFn {
   return async (request: HttpAgentRequest) => {
-    // Nonce are only useful for async calls, to prevent replay attacks. Other types of
-    // calls don't need Nonce so we just skip creating one.
+    const nonce = nonceFn();
+    // Nonce needs to be inserted into the header for all requests, to enable logs to be correlated with requests.
+    const headers = request.request.headers ? new Headers(request.request.headers) : new Headers();
+    headers.set('X-Request-ID', toHex(new Uint8Array(nonce)));
+    request.request.headers = headers;
+
+    // Nonce only needs to be inserted into the body for async calls, to prevent replay attacks.
     if (request.endpoint === Endpoint.Call) {
       request.body.nonce = nonceFn();
     }


### PR DESCRIPTION
# Description

During the SNS-1 launch retrospective, we identified the difficulty in identifying retried requests as a pain point. 

Adding a unique request id header (using the standard key, despite the similarity to the Request ID specified for checking the status of updates in the Internet Computer Specification

Fixes # SDK-880

# How Has This Been Tested?

new unit tests

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
