### PR TITLE
chore: removes a circular dependency on index for canisterStatus

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>chore: removes a circular dependency on index for canisterStatus</li>
         <li>chore: documents usage of fetch and fetchOptions for HttpAgent</li>
       </ul>
       <h2>Version 0.15.3</h2>

--- a/packages/agent/src/canisterStatus/index.ts
+++ b/packages/agent/src/canisterStatus/index.ts
@@ -3,8 +3,10 @@
 import { lebDecode, PipeArrayBuffer } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import { AgentError } from '../errors';
-import { HttpAgent, Cbor, Certificate, toHex } from '..';
-import type { CreateCertificateOptions } from '..';
+import { HttpAgent } from '../agent/http';
+import { Certificate, CreateCertificateOptions } from '../certificate';
+import { toHex } from '../utils/buffer';
+import * as Cbor from '../cbor';
 
 /**
  * Types of an entry on the canisterStatus map.


### PR DESCRIPTION
# Description

chore: removes a circular dependency on index for canisterStatus

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
