### PR TITLE
fix: reverts use of Headers for improved node compatibility

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,6 +13,11 @@
       <h2>Version x.x.x</h2>
       <ul>
         <li>
+          Do not use `Headers` struct during init of HttpAgent for Node compatibility. Note: still
+          supports use of Headers in application code
+        </li>
+        <li></li>
+        <li>
           fix: finish all tasks before calling onSuccess auth callback in @dfinity/auth-client
         </li>
       </ul>

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -106,7 +106,7 @@ test('call', async () => {
   expect(call1).toBe(`http://localhost/api/v2/canister/${canisterId.toText()}/call`);
   expect(call2.method).toEqual('POST');
   expect(call2.body).toEqual(cbor.encode(expectedRequest));
-  expect(call2.headers.get('Content-Type')).toEqual('application/cbor');
+  expect(call2.headers['Content-Type']).toEqual('application/cbor');
 });
 
 test.todo('query');
@@ -324,7 +324,7 @@ test('use anonymous principal if unspecified', async () => {
   const call2 = calls[0][1];
   expect(call2.method).toEqual('POST');
   expect(call2.body).toEqual(cbor.encode(expectedRequest));
-  expect(call2.headers.get('Content-Type')).toEqual('application/cbor');
+  expect(call2.headers['Content-Type']).toEqual('application/cbor');
 });
 
 describe('getDefaultFetch', () => {

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -304,10 +304,10 @@ export class HttpAgent implements Agent {
       request: {
         body: null,
         method: 'POST',
-        headers: new Headers({
+        headers: {
           'Content-Type': 'application/cbor',
           ...(this._credentials ? { Authorization: 'Basic ' + btoa(this._credentials) } : {}),
-        }),
+        },
       },
       endpoint: Endpoint.Call,
       body: submit,
@@ -394,10 +394,10 @@ export class HttpAgent implements Agent {
     let transformedRequest: any = await this._transform({
       request: {
         method: 'POST',
-        headers: new Headers({
+        headers: {
           'Content-Type': 'application/cbor',
           ...(this._credentials ? { Authorization: 'Basic ' + btoa(this._credentials) } : {}),
-        }),
+        },
       },
       endpoint: Endpoint.Query,
       body: request,
@@ -436,10 +436,10 @@ export class HttpAgent implements Agent {
     const transformedRequest: any = await this._transform({
       request: {
         method: 'POST',
-        headers: new Headers({
+        headers: {
           'Content-Type': 'application/cbor',
           ...(this._credentials ? { Authorization: 'Basic ' + btoa(this._credentials) } : {}),
-        }),
+        },
       },
       endpoint: Endpoint.ReadState,
       body: {

--- a/packages/agent/src/agent/http/transforms.ts
+++ b/packages/agent/src/agent/http/transforms.ts
@@ -36,7 +36,7 @@ export function makeNonceTransform(nonceFn: () => Nonce = makeNonce): HttpAgentR
   return async (request: HttpAgentRequest) => {
     const nonce = nonceFn();
     // Nonce needs to be inserted into the header for all requests, to enable logs to be correlated with requests.
-    const headers = request.request.headers ? new Headers(request.request.headers) : new Headers();
+    const headers = request.request.headers;
     // TODO: uncomment this when the http proxy supports it.
     // headers.set('X-IC-Request-ID', toHex(new Uint8Array(nonce)));
     request.request.headers = headers;


### PR DESCRIPTION
# Description

Due to the use of Headers inside of Agent-JS, it introduced a nodejs compatibility issue. We can simply swap back with no impact on the functionality

Fixes #685 

# How Has This Been Tested?

Unit tests

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
