### PR TITLE
feat: Extend WebAuthnIdentity with AuthenticatorAttachment

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -11,7 +11,14 @@
 
     <section>
       <h2>Version x.x.x</h2>
-      <ul></ul>
+      <ul>
+        <li>
+          add support for WebAuthn level 3
+          <a href="https://w3c.github.io/webauthn/#dom-publickeycredential-authenticatorattachment"
+            >authenticatorAttachment</a
+          >
+        </li>
+      </ul>
       <h2>Version 0.15.4</h2>
       <ul>
         <li>removes more circular dependencies in agent, actor, proxy, and pollingstrategy</li>


### PR DESCRIPTION
This PR extends the WebAuthnIdentity with [authenticatorAttachment](https://w3c.github.io/webauthn/#dom-publickeycredential-authenticatorattachment). In addition, the constructor is made public to allow downstream projects to construct it more easily.

# Description

This is required for Internet Identity to record the authenticatorAttachment on devices being registered.

Fixes # (issue)

# How Has This Been Tested?

There are no tests for `WebAuthnIdentity`. However, similar code has been tested in [II code](https://github.com/dfinity/internet-identity/blob/main/src/frontend/src/utils/multiWebAuthnIdentity.ts#L118). 

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
