### PR TITLE
feat: separates candid-ui into its own package

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>Splits Candid UI out from @dfinity/candid into its own package, @dfinity/candid-ui</li>
         <li>
           add support for WebAuthn level 3
           <a href="https://w3c.github.io/webauthn/#dom-publickeycredential-authenticatorattachment"

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
           "packages/auth-client",
           "packages/assets",
           "packages/identity-secp256k1",
+          "packages/candid-ui",
           "e2e/node",
           "e2e/browser",
           "demos/sample-javascript"
@@ -784,6 +785,10 @@
     },
     "node_modules/@dfinity/principal": {
       "resolved": "packages/principal",
+      "link": true
+    },
+    "node_modules/@difnity/candid-ui": {
+      "resolved": "packages/candid-ui",
       "link": true
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -18454,6 +18459,27 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
+    "packages/candid-ui": {
+      "name": "@difnity/candid-ui",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "typescript": "^5.0.2"
+      }
+    },
+    "packages/candid-ui/node_modules/typescript": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "packages/candid/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -19761,6 +19787,20 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
           "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+          "dev": true
+        }
+      }
+    },
+    "@difnity/candid-ui": {
+      "version": "file:packages/candid-ui",
+      "requires": {
+        "typescript": "^5.0.2"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+          "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
       "packages/auth-client",
       "packages/assets",
       "packages/identity-secp256k1",
+      "packages/candid-ui",
       "e2e/node",
       "e2e/browser",
       "demos/sample-javascript"

--- a/packages/candid-ui/.gitignore
+++ b/packages/candid-ui/.gitignore
@@ -1,0 +1,2 @@
+lib
+node_modules

--- a/packages/candid-ui/README.md
+++ b/packages/candid-ui/README.md
@@ -2,4 +2,6 @@
 
 This package provides a simple UI for the Candid Interface Declaration Language. It is a simple web application that can be used to explore Candid interfaces, and to generate calls to canisters using them.
 
-More to come
+### Building
+
+To build the UI, run `npm run build` in this directory. This will generate a `lib` directory with the built library.

--- a/packages/candid-ui/README.md
+++ b/packages/candid-ui/README.md
@@ -1,0 +1,5 @@
+## Candid UI
+
+This package provides a simple UI for the Candid Interface Declaration Language. It is a simple web application that can be used to explore Candid interfaces, and to generate calls to canisters using them.
+
+More to come

--- a/packages/candid-ui/candid-core.ts
+++ b/packages/candid-ui/candid-core.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as IDL from './idl';
+import { IDL } from '@dfinity/candid';
 
 // tslint:disable:max-classes-per-file
 

--- a/packages/candid-ui/candid-ui.ts
+++ b/packages/candid-ui/candid-ui.ts
@@ -1,6 +1,6 @@
 import { IDL } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
-import * as UI from './candid-core';
+import * as UI from './candid-core.js';
 
 // tslint:disable:max-classes-per-file
 type InputBox = UI.InputBox;

--- a/packages/candid-ui/candid-ui.ts
+++ b/packages/candid-ui/candid-ui.ts
@@ -1,4 +1,4 @@
-import * as IDL from './idl';
+import { IDL } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import * as UI from './candid-core';
 

--- a/packages/candid-ui/index.ts
+++ b/packages/candid-ui/index.ts
@@ -1,0 +1,2 @@
+export * from './candid-ui';
+export * from './candid-core';

--- a/packages/candid-ui/index.ts
+++ b/packages/candid-ui/index.ts
@@ -1,2 +1,2 @@
-export * from './candid-ui';
-export * from './candid-core';
+export * from './candid-ui.js';
+export * from './candid-core.js';

--- a/packages/candid-ui/package.json
+++ b/packages/candid-ui/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@difnity/candid-ui",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "vitest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/candid-ui/package.json
+++ b/packages/candid-ui/package.json
@@ -3,11 +3,22 @@
   "version": "1.0.0",
   "description": "",
   "type": "module",
-  "main": "index.js",
+  "main": "lib/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./lib/esm/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
+  },
   "scripts": {
+    "build": "tsc -b && tsc -p tsconfig-cjs.json",
     "test": "vitest"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "^5.0.2"
+  }
 }

--- a/packages/candid-ui/tsconfig-cjs.json
+++ b/packages/candid-ui/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./lib/cjs"
+  }
+}

--- a/packages/candid-ui/tsconfig.json
+++ b/packages/candid-ui/tsconfig.json
@@ -1,0 +1,105 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "ES2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "lib": [
+      "DOM"
+    ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "ES2020" /* Specify what module code is generated. */,
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./lib/candid-ui.esm.js" /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */,
+    "outDir": "./lib/esm" /* Specify an output folder for all emitted files. */,
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}

--- a/packages/candid/src/index.ts
+++ b/packages/candid/src/index.ts
@@ -1,5 +1,3 @@
-export * from './candid-ui';
-export * from './candid-core';
 export * as IDL from './idl';
 export * from './utils/hash';
 export * from './utils/leb128';

--- a/packages/candid/tsconfig.json
+++ b/packages/candid/tsconfig.json
@@ -18,6 +18,6 @@
     "strict": true,
     "target": "es2017"
   },
-  "include": ["types/*", "src/**/*", "vendor/bls"],
+  "include": ["types/*", "src/**/*", "vendor/bls", "../candid-ui/candid-core.ts"],
   "references": []
 }

--- a/packages/candid/tsconfig.json
+++ b/packages/candid/tsconfig.json
@@ -18,6 +18,6 @@
     "strict": true,
     "target": "es2017"
   },
-  "include": ["types/*", "src/**/*", "vendor/bls", "../candid-ui/candid-core.ts"],
+  "include": ["types/*", "src/**/*", "vendor/bls"],
   "references": []
 }


### PR DESCRIPTION
# Description

Since `@dfinity/candid` is a dependency for all packages, many applications do not require the Candid UI contents. Splitting it out will also give us the ability to further contribute to Candid UI independently.

`@dfinity/candid-ui` will ship as a ESM library to make it easier to include in websites

# How Has This Been Tested?

Testing to come

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
