### PR TITLE
feat: Retry failed `read_state` requests

### DIFF
--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -466,13 +466,12 @@ export class HttpAgent implements Agent {
     const transformedRequest = request ?? (await this.createReadStateRequest(fields, identity));
     const body = cbor.encode(transformedRequest.body);
 
-    const response = await this._fetch(
-      '' + new URL(`/api/v2/canister/${canister}/read_state`, this._host),
-      {
+    const response = await this._requestAndRetry(() =>
+      this._fetch('' + new URL(`/api/v2/canister/${canister}/read_state`, this._host), {
         ...this._fetchOptions,
         ...transformedRequest.request,
         body,
-      },
+      }),
     );
 
     if (!response.ok) {


### PR DESCRIPTION
# Description

When making an `update` request to the IC, the agent first submits a `call` request, then it polls `read_state` until the result is ready. If the `call` request fails it would be retried, but that same retry logic wasn't being applied to the `read_state` requests, so if any request to `read_state` failed, the caller would receive an error even though their request may still complete successfully.

This PR wraps calls to `read_state` in the same retry pattern which is already in use on `call`, `query` and `status` requests.

# How Has This Been Tested?

It hasn't yet, I'm about to test it on OpenChat locally.

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
