### PR TITLE
fix: finish all tasks before calling onSuccess callback

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,7 +12,9 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
-        <li></li>
+        <li>
+          fix: finish all tasks before calling onSuccess auth callback in @dfinity/auth-client
+        </li>
       </ul>
       <h2>Version 0.15.5</h2>
       <ul>


### PR DESCRIPTION
# Description

The `onSuccess` callback was called before writing the delegation chain to storage. Since the writing of the chain to storage is asynchronous, an app that performs some full page navigation or a page refresh in their `onSuccess` callback _might_ interrupt the operation.

# How Has This Been Tested?

This was causing flakiness in some e2e tests that I was working on for a dapp. Roughly 20% of the runs were failing. Making this change removes the flakiness and the tests pass now 100% of the time.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
