### PR TITLE
feat: Allow to decode t as opt t

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,7 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
-        <li></li>
+        <li>feat: Add support for type coercion of `t` to `opt t` when decoding candid values.</li>
       </ul>
       <h2>Version 0.15.5</h2>
       <ul>

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -180,7 +180,9 @@ test('IDL encoding (arraybuffer)', () => {
   IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array()]);
   IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array(100).fill(42)]);
   IDL.encode([IDL.Vec(IDL.Nat16)], [new Uint16Array(200).fill(42)]);
-  expect(() => IDL.encode([IDL.Vec(IDL.Int8)], [new Uint16Array(10).fill(420)])).toThrow(/Invalid vec int8 argument/);
+  expect(() => IDL.encode([IDL.Vec(IDL.Int8)], [new Uint16Array(10).fill(420)])).toThrow(
+    /Invalid vec int8 argument/,
+  );
 });
 
 test('IDL encoding (array)', () => {
@@ -676,4 +678,17 @@ test('should decode matching optional fields if wire type contains additional fi
   expect(decoded).toEqual({
     b: ['123'],
   });
+});
+
+test('should coerce value to opt value', () => {
+  const encoded = IDL.encode([IDL.Text], ['hello']);
+  const value = IDL.decode([IDL.Opt(IDL.Text)], encoded)[0] as [string];
+  expect(value).toEqual(['hello']);
+});
+
+test('should not coerce nested opt opt', () => {
+  const encoded = IDL.encode([IDL.Text], ['hello']);
+  expect(() => IDL.decode([IDL.Opt(IDL.Opt(IDL.Text))], encoded)).toThrow(
+    'type mismatch: type on the wire text, expect type opt opt text',
+  );
 });

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -914,10 +914,25 @@ export class OptClass<T> extends ConstructType<[T] | []> {
     typeTable.add(this, concat(opCode, buffer));
   }
 
+  public checkType(t: Type): Type {
+    try {
+      return super.checkType(t);
+    } catch (e) {
+      // try to coerce t to opt t
+      if (!(t instanceof OptClass) && !(this._type instanceof OptClass)) {
+        if (this._type.checkType(t)) {
+          return t;
+        }
+      }
+      // rethrow if opt coercion is not applicable
+      throw e;
+    }
+  }
+
   public decodeValue(b: Pipe, t: Type): [T] | [] {
     const opt = this.checkType(t);
     if (!(opt instanceof OptClass)) {
-      throw new Error('Not an option type');
+      return [this._type.decodeValue(b, opt)];
     }
     switch (safeReadUint8(b)) {
       case 0:


### PR DESCRIPTION
# Description

This is a strawman PR to implement coercion of `t` to `opt t` when decoding values.
The test suite still passes, but I'm not sure if I broke something else in the process.

Also it uses control flow by exception, which is rather ugly.

Fixes # (issue)

# How Has This Been Tested?

Unit tests have been added to test the feature.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
