### PR TITLE
fix: Typo in JsonnableWebAuthnIdentitiy

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,14 +13,14 @@
       <h2>Version x.x.x</h2>
       <ul>
         <li>chore: corrections to publishing docs</li>
+        <li>
+          fix: typo in JsonnableWebAuthnIdentitiy, breaking change that requires users to update their imports to JsonnableWebAuthnIdentity when this type is used
+        </li>
       </ul>
       <h2>Version 0.15.7</h2>
       <ul>
         <li>
           fix: finish all tasks before calling onSuccess auth callback in @dfinity/auth-client
-        </li>
-        <li>
-          fix: typo in JsonnableWebAuthnIdentitiy, breaking change that requires users to update their imports to JsonnableWebAuthnIdentity when this type is used
         </li>
       </ul>
       <h2>Version 0.15.6</h2>

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -15,6 +15,9 @@
         <li>
           fix: finish all tasks before calling onSuccess auth callback in @dfinity/auth-client
         </li>
+        <li>
+          fix: typo in JsonnableWebAuthnIdentitiy, breaking change that requires users to update their imports to JsonnableWebAuthnIdentity when this type is used
+        </li>
       </ul>
       <h2>Version 0.15.6</h2>
       <ul>

--- a/packages/identity/src/identity/webauthn.ts
+++ b/packages/identity/src/identity/webauthn.ts
@@ -232,7 +232,7 @@ export class WebAuthnIdentity extends SignIdentity {
   /**
    * Allow for JSON serialization of all information needed to reuse this identity.
    */
-  public toJSON(): JsonnableWebAuthnIdentitiy {
+  public toJSON(): JsonnableWebAuthnIdentity {
     return {
       publicKey: toHexString(this._publicKey.getCose()),
       rawId: toHexString(this.rawId),
@@ -243,7 +243,7 @@ export class WebAuthnIdentity extends SignIdentity {
 /**
  * ReturnType<WebAuthnIdentity.toJSON>
  */
-export interface JsonnableWebAuthnIdentitiy {
+export interface JsonnableWebAuthnIdentity {
   // The hexadecimal representation of the DER encoded public key.
   publicKey: string;
   // The string representation of the local WebAuthn Credential.id (base64url encoded).


### PR DESCRIPTION
Fix typo in `JsonnableWebAuthnIdentitiy`, breaking change that requires users to update their imports to `JsonnableWebAuthnIdentity` when this type is used.


# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
