### PR TITLE
feat: support composite_query in candid

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -20,6 +20,9 @@
         <li>
           fix: typo in JsonnableWebAuthnIdentitiy, breaking change that requires users to update their imports to JsonnableWebAuthnIdentity when this type is used
         </li>
+        <li>
+          feat: support composite_query in candid
+        </li>
       </ul>
       <h2>Version 0.15.7</h2>
       <ul>

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -180,7 +180,9 @@ test('IDL encoding (arraybuffer)', () => {
   IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array()]);
   IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array(100).fill(42)]);
   IDL.encode([IDL.Vec(IDL.Nat16)], [new Uint16Array(200).fill(42)]);
-  expect(() => IDL.encode([IDL.Vec(IDL.Int8)], [new Uint16Array(10).fill(420)])).toThrow(/Invalid vec int8 argument/);
+  expect(() => IDL.encode([IDL.Vec(IDL.Int8)], [new Uint16Array(10).fill(420)])).toThrow(
+    /Invalid vec int8 argument/,
+  );
 });
 
 test('IDL encoding (array)', () => {
@@ -339,6 +341,12 @@ test('IDL encoding (function)', () => {
     '4449444c016a0171017d01010100010103caffee03666f6f',
     'query function',
   );
+  test_(
+    IDL.Func([IDL.Text], [IDL.Nat], ['composite_query']),
+    [Principal.fromText('w7x7r-cok77-xa'), 'foo'],
+    '4449444c016a0171017d01030100010103caffee03666f6f',
+    'composite_query function',
+  );
 });
 
 test('IDL encoding (service)', () => {
@@ -353,6 +361,12 @@ test('IDL encoding (service)', () => {
     IDL.Service({ foo: IDL.Func([IDL.Text], [IDL.Nat], ['query']) }),
     Principal.fromText('w7x7r-cok77-xa'),
     '4449444c026a0171017d0101690103666f6f0001010103caffee',
+    'service',
+  );
+  test_(
+    IDL.Service({ foo: IDL.Func([IDL.Text], [IDL.Nat], ['composite_query']) }),
+    Principal.fromText('w7x7r-cok77-xa'),
+    '4449444c026a0171017d0103690103666f6f0001010103caffee',
     'service',
   );
   test_(

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -1469,6 +1469,8 @@ export class FuncClass extends ConstructType<[PrincipalId, string]> {
       return new Uint8Array([1]);
     } else if (ann === 'oneway') {
       return new Uint8Array([2]);
+    } else if (ann === 'composite_query') {
+      return new Uint8Array([3]);
     } else {
       throw new Error('Illegal function annotation');
     }
@@ -1643,6 +1645,10 @@ export function decode(retTypes: Type[], bytes: ArrayBuffer): JsonValue[] {
               }
               case 2: {
                 annotations.push('oneway');
+                break;
+              }
+              case 3: {
+                annotations.push('composite_query');
                 break;
               }
               default:


### PR DESCRIPTION
This change adds a new query type: `composite_query` in idl.ts.

It corresponds to the following changes in the upstream candid:
- https://github.com/dfinity/candid/pull/420 (spec change)
- https://github.com/dfinity/candid/pull/435 (rust change)
