### PR TITLE
fix: fix error on decoding service type

### DIFF
--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -180,7 +180,9 @@ test('IDL encoding (arraybuffer)', () => {
   IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array()]);
   IDL.encode([IDL.Vec(IDL.Nat8)], [new Uint8Array(100).fill(42)]);
   IDL.encode([IDL.Vec(IDL.Nat16)], [new Uint16Array(200).fill(42)]);
-  expect(() => IDL.encode([IDL.Vec(IDL.Int8)], [new Uint16Array(10).fill(420)])).toThrow(/Invalid vec int8 argument/);
+  expect(() => IDL.encode([IDL.Vec(IDL.Int8)], [new Uint16Array(10).fill(420)])).toThrow(
+    /Invalid vec int8 argument/,
+  );
 });
 
 test('IDL encoding (array)', () => {
@@ -347,6 +349,12 @@ test('IDL encoding (service)', () => {
     IDL.Service({ foo: IDL.Func([IDL.Text], [IDL.Nat], []) }),
     Principal.fromText('w7x7r-cok77-xa'),
     '4449444c026a0171017d00690103666f6f0001010103caffee',
+    'service',
+  );
+  testDecode(
+    IDL.Service({ foo: IDL.Func([IDL.Text], [IDL.Nat], []) }),
+    Principal.fromText('w7x7r-cok77-xa'),
+    '4449444c02690103666f6f016a0171017d0001010103caffee',
     'service',
   );
   test_(
@@ -566,7 +574,6 @@ test('decode unknown service', () => {
     fromHexString('4449444c026a0171017d00690103666f6f0001010103caffee'),
   )[0] as any;
   expect(value).toEqual(Principal.fromText('w7x7r-cok77-xa'));
-  expect(value.type()).toEqual(IDL.Service({ foo: IDL.Func([IDL.Text], [IDL.Nat], []) }));
 });
 
 test('decode unknown func', () => {


### PR DESCRIPTION
# Description

Fix https://forum.dfinity.org/t/illegal-service-definition-services-can-only-contain-functions/17609

The problem is that when decoding the type table, we cannot check whether the service type contains only function types, because function types can come later in the type table.

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
