### PR TITLE
fix: handle new update call errors (IC-1462)

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,7 +13,7 @@
       <h2>Version x.x.x</h2>
       <ul>
         <li>
-          fix: handle new update call errors (<a
+          feat!: handle new update call errors (<a
             href="https://github.com/dfinity/interface-spec/pull/143"
             >IC-1462</a
           >)

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,7 +13,7 @@
       <h2>Version x.x.x</h2>
       <ul>
         <li>
-          feat!: handle new update call errors (<a
+          fix: handle new update call errors (<a
             href="https://github.com/dfinity/interface-spec/pull/143"
             >IC-1462</a
           >)

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,15 +13,23 @@
       <h2>Version x.x.x</h2>
       <ul>
         <li>
+          fix: handle new update call errors (<a
+            href="https://github.com/dfinity/interface-spec/pull/143"
+            >IC-1462</a
+          >)
+        </li>
+        <li>
           chore: updates engines in package.json and recommended node version for development in
           nvmrc to support node 18+
         </li>
         <li>chore: corrections to publishing docs</li>
         <li>
-          fix: typo in JsonnableWebAuthnIdentitiy, breaking change that requires users to update their imports to JsonnableWebAuthnIdentity when this type is used
+          fix: typo in JsonnableWebAuthnIdentitiy, breaking change that requires users to update
+          their imports to JsonnableWebAuthnIdentity when this type is used
         </li>
         <li>
-          fix: fix a bug in decoding service types, when function types come after the service type in the type table
+          fix: fix a bug in decoding service types, when function types come after the service type
+          in the type table
         </li>
       </ul>
       <h2>Version 0.15.7</h2>

--- a/packages/agent/src/actor.test.ts
+++ b/packages/agent/src/actor.test.ts
@@ -1,7 +1,7 @@
 import { IDL } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
-import { Actor } from './actor';
-import { HttpAgent, Nonce } from './agent';
+import { Actor, UpdateCallRejectedError } from './actor';
+import { HttpAgent, Nonce, SubmitResponse } from './agent';
 import { Expiry, makeNonceTransform } from './agent/http/transforms';
 import { CallRequest, SubmitRequestType, UnSigned } from './agent/http/types';
 import * as cbor from './cbor';
@@ -63,9 +63,23 @@ describe('makeActor', () => {
             status: 200,
           }),
         );
+      })
+      .mockImplementationOnce((resource, init) => {
+        const body = cbor.encode(<SubmitResponse['response']['body']>{
+          error_code: 'IC0503',
+          reject_code: 5,
+          reject_message:
+            'Canister (...) trapped explicitly: canister_inspect_message explicitly refused message',
+        });
+        return Promise.resolve(
+          new Response(body, {
+            status: 200,
+          }),
+        );
       });
 
     const methodName = 'greet';
+    const errorMethodName = 'error';
     const argValue = 'Name';
 
     const arg = IDL.encode([IDL.Text], [argValue]);
@@ -94,6 +108,18 @@ describe('makeActor', () => {
       },
     } as UnSigned<CallRequest>;
 
+    const expectedErrorCallRequest = {
+      content: {
+        request_type: SubmitRequestType.Call,
+        canister_id: canisterId,
+        method_name: errorMethodName,
+        arg,
+        nonce: nonces[0],
+        sender,
+        ingress_expiry: new Expiry(300000),
+      },
+    } as UnSigned<CallRequest>;
+
     const expectedCallRequestId = await requestIdOf(expectedCallRequest.content);
 
     let nonceCount = 0;
@@ -105,6 +131,8 @@ describe('makeActor', () => {
     const reply = await actor.greet(argValue);
 
     expect(reply).toEqual(IDL.decode([IDL.Text], expectedReplyArg)[0]);
+
+    await expect(async () => actor.error()).rejects.toThrow(UpdateCallRejectedError);
 
     const { calls } = mockFetch.mock;
 
@@ -180,6 +208,15 @@ describe('makeActor', () => {
           ingress_expiry: new Expiry(300000),
         },
       }),
+    });
+
+    expect(calls[5][0]).toBe('http://localhost/api/v1/call');
+    expect(calls[5][1]).toEqual({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/cbor',
+      },
+      body: cbor.encode(expectedErrorCallRequest),
     });
   });
   it('should allow its agent to be invalidated', async () => {

--- a/packages/agent/src/actor.test.ts
+++ b/packages/agent/src/actor.test.ts
@@ -65,6 +65,7 @@ describe('makeActor', () => {
         );
       })
       .mockImplementationOnce((resource, init) => {
+        // IC-1462 update call error
         const body = cbor.encode(<SubmitResponse['response']['body']>{
           error_code: 'IC0503',
           reject_code: 5,

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -58,13 +58,13 @@ export class UpdateCallRejectedError extends ActorCallError {
   ) {
     super(canisterId, methodName, 'update', {
       'Request ID': toHex(requestId),
-      ...(response.body?.error_code
-        ? {
-            'Error code': response.body.error_code,
-          }
-        : {}),
       ...(response.body
         ? {
+            ...(response.body.error_code
+              ? {
+                  'Error code': response.body.error_code,
+                }
+              : {}),
             'Reject code': String(response.body.reject_code),
             'Reject message': response.body.reject_message,
           }

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -58,9 +58,13 @@ export class UpdateCallRejectedError extends ActorCallError {
   ) {
     super(canisterId, methodName, 'update', {
       'Request ID': toHex(requestId),
-      ...(response.body
+      ...(response.body?.error_code
         ? {
             'Error code': response.body.error_code,
+          }
+        : {}),
+      ...(response.body
+        ? {
             'Reject code': String(response.body.reject_code),
             'Reject message': response.body.reject_message,
           }

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -61,7 +61,7 @@ export class UpdateCallRejectedError extends ActorCallError {
       ...(response.body
         ? {
             'Error code': response.body.error_code,
-            'Reject code': response.body.reject_code,
+            'Reject code': String(response.body.reject_code),
             'Reject message': response.body.reject_message,
           }
         : {

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -58,8 +58,16 @@ export class UpdateCallRejectedError extends ActorCallError {
   ) {
     super(canisterId, methodName, 'update', {
       'Request ID': toHex(requestId),
-      'HTTP status code': response.status.toString(),
-      'HTTP status text': response.statusText,
+      ...(response.body
+        ? {
+            'Error code': response.body.error_code,
+            'Reject code': response.body.reject_code,
+            'Reject message': response.body.reject_message,
+          }
+        : {
+            'HTTP status code': response.status.toString(),
+            'HTTP status text': response.statusText,
+          }),
     });
   }
 }
@@ -364,7 +372,7 @@ function _createActorMethod(
         effectiveCanisterId: ecid,
       });
 
-      if (!response.ok) {
+      if (!response.ok || response.body /* IC-1462 */) {
         throw new UpdateCallRejectedError(cid, methodName, requestId, response);
       }
 

--- a/packages/agent/src/agent/api.ts
+++ b/packages/agent/src/agent/api.ts
@@ -98,7 +98,7 @@ export interface SubmitResponse {
     statusText: string;
     body: {
       error_code: string;
-      reject_code: string;
+      reject_code: number;
       reject_message: string;
     } | null;
   };

--- a/packages/agent/src/agent/api.ts
+++ b/packages/agent/src/agent/api.ts
@@ -96,6 +96,11 @@ export interface SubmitResponse {
     ok: boolean;
     status: number;
     statusText: string;
+    body: {
+      error_code: string;
+      reject_code: string;
+      reject_message: string;
+    } | null;
   };
 }
 

--- a/packages/agent/src/agent/api.ts
+++ b/packages/agent/src/agent/api.ts
@@ -97,7 +97,7 @@ export interface SubmitResponse {
     status: number;
     statusText: string;
     body: {
-      error_code: string;
+      error_code?: string;
       reject_code: number;
       reject_message: string;
     } | null;

--- a/packages/agent/src/agent/http/__snapshots__/http.test.ts.snap
+++ b/packages/agent/src/agent/http/__snapshots__/http.test.ts.snap
@@ -4,6 +4,7 @@ exports[`retry failures should succeed after multiple failures within the config
 Object {
   "requestId": ArrayBuffer [],
   "response": Object {
+    "body": null,
     "ok": true,
     "status": 200,
     "statusText": "success!",

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -566,7 +566,7 @@ describe('retry failures', () => {
     let calls = 0;
     const mockFetch: jest.Mock = jest.fn(() => {
       if (calls === 3) {
-        return new Response('test', {
+        return new Response(null, {
           status: 200,
           statusText: 'success!',
         });

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -736,31 +736,3 @@ test('should fetch with given call options and fetch options', async () => {
   expect(calls[0][1].reactNative).toStrictEqual({ textStreaming: true });
   expect(calls[1][1].reactNative.__nativeResponseType).toBe('base64');
 });
-
-test('should handle IC-1462 update call errors', async () => {
-  const mockFetch: jest.Mock = jest.fn(() => {
-    const body = cbor.encode(<SubmitResponse['response']['body']>{
-      error_code: 'IC0503',
-      reject_code: 5,
-      reject_message:
-        'Canister (...) trapped explicitly: canister_inspect_message explicitly refused message',
-    });
-    return Promise.resolve(
-      new Response(body, {
-        status: 200,
-      }),
-    );
-  });
-
-  const canisterId: Principal = Principal.fromText('2chl6-4hpzw-vqaaa-aaaaa-c');
-  const httpAgent = new HttpAgent({
-    fetch: mockFetch,
-  });
-
-  expect(async () => {
-    await httpAgent.call(canisterId, {
-      methodName: 'greet',
-      arg: new Uint8Array([]),
-    });
-  }).toThrow(UpdateCallRejectedError);
-});

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -13,7 +13,7 @@ import { Principal } from '@dfinity/principal';
 import { requestIdOf } from '../../request_id';
 
 import { JSDOM } from 'jsdom';
-import { AnonymousIdentity, SignIdentity } from '../..';
+import { AnonymousIdentity, SignIdentity, SubmitResponse, UpdateCallRejectedError } from '../..';
 import { Ed25519KeyIdentity } from '../../../../identity/src/identity/ed25519';
 import { toHexString } from '../../../../identity/src/buffer';
 import { AgentError } from '../../errors';
@@ -735,4 +735,32 @@ test('should fetch with given call options and fetch options', async () => {
 
   expect(calls[0][1].reactNative).toStrictEqual({ textStreaming: true });
   expect(calls[1][1].reactNative.__nativeResponseType).toBe('base64');
+});
+
+test('should handle IC-1462 update call errors', async () => {
+  const mockFetch: jest.Mock = jest.fn(() => {
+    const body = cbor.encode(<SubmitResponse['response']['body']>{
+      error_code: 'IC0503',
+      reject_code: 5,
+      reject_message:
+        'Canister (...) trapped explicitly: canister_inspect_message explicitly refused message',
+    });
+    return Promise.resolve(
+      new Response(body, {
+        status: 200,
+      }),
+    );
+  });
+
+  const canisterId: Principal = Principal.fromText('2chl6-4hpzw-vqaaa-aaaaa-c');
+  const httpAgent = new HttpAgent({
+    fetch: mockFetch,
+  });
+
+  expect(async () => {
+    await httpAgent.call(canisterId, {
+      methodName: 'greet',
+      arg: new Uint8Array([]),
+    });
+  }).toThrow(UpdateCallRejectedError);
 });

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -331,12 +331,17 @@ export class HttpAgent implements Agent {
 
     const [response, requestId] = await Promise.all([request, requestIdOf(submit)]);
 
+    const responseBody = response.body
+      ? (cbor.decode(await response.arrayBuffer()) as SubmitResponse['response']['body'])
+      : null;
+
     return {
       requestId,
       response: {
         ok: response.ok,
         status: response.status,
         statusText: response.statusText,
+        body: responseBody,
       },
     };
   }

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -333,7 +333,7 @@ export class HttpAgent implements Agent {
 
     const responseBuffer = await response.arrayBuffer();
     const responseBody = (
-      responseBuffer.byteLength > 0 ? cbor.decode(responseBuffer) : null
+      response.status === 200 && responseBuffer.byteLength > 0 ? cbor.decode(responseBuffer) : null
     ) as SubmitResponse['response']['body'];
 
     return {

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -331,9 +331,10 @@ export class HttpAgent implements Agent {
 
     const [response, requestId] = await Promise.all([request, requestIdOf(submit)]);
 
-    const responseBody = response.body
-      ? (cbor.decode(await response.arrayBuffer()) as SubmitResponse['response']['body'])
-      : null;
+    const responseBuffer = await response.arrayBuffer();
+    const responseBody = (
+      responseBuffer.byteLength > 0 ? cbor.decode(responseBuffer) : null
+    ) as SubmitResponse['response']['body'];
 
     return {
       requestId,


### PR DESCRIPTION
# Description

Handles the new update call error messages introduced in [IC-1462](https://github.com/dfinity/interface-spec/pull/143). 

Corresponds to https://github.com/dfinity/agent-rs/pull/422. 

# How Has This Been Tested?

This PR includes a unit test for the new update call behavior. 

I also ran a local sanity check using the setup described in [this forum post](https://forum.dfinity.org/t/not-calling-accept-message-in-inspect-message-not-rejecting-immediately-in-dfx-0-14-2-beta-2/21105), replacing Candid UI with a simple webapp pointing to a local `agent-js` installation. 

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation. (N/A)


[IC-1462]: https://dfinity.atlassian.net/browse/IC-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ