### PR TITLE
chore: release v0.17.0

### DIFF
--- a/demos/sample-javascript/package.json
+++ b/demos/sample-javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dfinity/ic-agent-sample-javascript-app",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.17.0",
   "scripts": {
     "build": "webpack",
     "develop": "webpack-dev-server",
@@ -11,10 +11,10 @@
     "test": ""
   },
   "dependencies": {
-    "@dfinity/agent": "^0.16.0",
+    "@dfinity/agent": "^0.17.0",
     "@dfinity/authentication": "^0.14.1",
-    "@dfinity/identity": "^0.16.0",
-    "@dfinity/principal": "^0.16.0"
+    "@dfinity/identity": "^0.17.0",
+    "@dfinity/principal": "^0.17.0"
   },
   "devDependencies": {
     "assert": "^2.0.0",

--- a/e2e/browser/package.json
+++ b/e2e/browser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@do-not-publish/ic-cypress-e2e-tests",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "scripts": {
     "ci": "npm run e2e",
     "pree2e": "dfx deploy; dfx generate; pm2 --name parcel start npm -- start",
@@ -29,10 +29,10 @@
     "size-limit": "^8.1.0"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.16.0",
+    "@dfinity/agent": "^0.17.0",
     "@dfinity/authentication": "^0.14.1",
-    "@dfinity/identity": "^0.16.0",
-    "@dfinity/principal": "^0.16.0",
+    "@dfinity/identity": "^0.17.0",
+    "@dfinity/principal": "^0.17.0",
     "idb-keyval": "^6.2.0"
   }
 }

--- a/e2e/node/package.json
+++ b/e2e/node/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@do-not-publish/ic-node-e2e-tests",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "scripts": {
     "ci": "npm run e2e",
     "e2e": "jest --verbose",
@@ -16,11 +16,11 @@
     "test": ""
   },
   "dependencies": {
-    "@dfinity/agent": "^0.16.0",
-    "@dfinity/assets": "^0.16.0",
+    "@dfinity/agent": "^0.17.0",
+    "@dfinity/assets": "^0.17.0",
     "@dfinity/authentication": "^0.14.1",
-    "@dfinity/identity": "^0.16.0",
-    "@dfinity/principal": "^0.16.0",
+    "@dfinity/identity": "^0.17.0",
+    "@dfinity/principal": "^0.17.0",
     "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/agent-monorepo",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/agent-monorepo",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@jest/types": "28.1.3",
@@ -87,12 +87,12 @@
     },
     "demos/sample-javascript": {
       "name": "@dfinity/ic-agent-sample-javascript-app",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
-        "@dfinity/agent": "^0.16.0",
+        "@dfinity/agent": "^0.17.0",
         "@dfinity/authentication": "^0.14.1",
-        "@dfinity/identity": "^0.16.0",
-        "@dfinity/principal": "^0.16.0"
+        "@dfinity/identity": "^0.17.0",
+        "@dfinity/principal": "^0.17.0"
       },
       "devDependencies": {
         "assert": "^2.0.0",
@@ -111,12 +111,12 @@
     },
     "e2e/browser": {
       "name": "@do-not-publish/ic-cypress-e2e-tests",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
-        "@dfinity/agent": "^0.16.0",
+        "@dfinity/agent": "^0.17.0",
         "@dfinity/authentication": "^0.14.1",
-        "@dfinity/identity": "^0.16.0",
-        "@dfinity/principal": "^0.16.0",
+        "@dfinity/identity": "^0.17.0",
+        "@dfinity/principal": "^0.17.0",
         "idb-keyval": "^6.2.0"
       },
       "devDependencies": {
@@ -133,13 +133,13 @@
     },
     "e2e/node": {
       "name": "@do-not-publish/ic-node-e2e-tests",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
-        "@dfinity/agent": "^0.16.0",
-        "@dfinity/assets": "^0.16.0",
+        "@dfinity/agent": "^0.17.0",
+        "@dfinity/assets": "^0.17.0",
         "@dfinity/authentication": "^0.14.1",
-        "@dfinity/identity": "^0.16.0",
-        "@dfinity/principal": "^0.16.0",
+        "@dfinity/identity": "^0.17.0",
+        "@dfinity/principal": "^0.17.0",
         "whatwg-fetch": "^3.6.2"
       },
       "devDependencies": {
@@ -19095,7 +19095,7 @@
     },
     "packages/agent": {
       "name": "@dfinity/agent",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-arraybuffer": "^0.2.0",
@@ -19123,8 +19123,8 @@
         "whatwg-fetch": "^3.0.0"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.16.0",
-        "@dfinity/principal": "^0.16.0"
+        "@dfinity/candid": "^0.17.0",
+        "@dfinity/principal": "^0.17.0"
       }
     },
     "packages/agent/node_modules/brace-expansion": {
@@ -19208,7 +19208,7 @@
     },
     "packages/assets": {
       "name": "@dfinity/assets",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2",
@@ -19231,7 +19231,7 @@
         "typescript": "^4.7.4"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.16.0",
+        "@dfinity/agent": "^0.17.0",
         "js-sha256": "0.9.0"
       }
     },
@@ -19341,7 +19341,7 @@
     },
     "packages/auth-client": {
       "name": "@dfinity/auth-client",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "idb": "^7.0.2"
@@ -19368,9 +19368,9 @@
         "whatwg-fetch": "^3.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.16.0",
-        "@dfinity/identity": "^0.16.0",
-        "@dfinity/principal": "^0.16.0"
+        "@dfinity/agent": "^0.17.0",
+        "@dfinity/identity": "^0.17.0",
+        "@dfinity/principal": "^0.17.0"
       }
     },
     "packages/auth-client/node_modules/brace-expansion": {
@@ -19464,7 +19464,7 @@
     },
     "packages/bls-verify": {
       "name": "@dfinity/bls-verify",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "amcl-js": "file:src/vendor/amcl-js"
@@ -19492,7 +19492,7 @@
     },
     "packages/candid": {
       "name": "@dfinity/candid",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^28.1.4",
@@ -19595,7 +19595,7 @@
     },
     "packages/identity": {
       "name": "@dfinity/identity",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "borc": "^2.1.1",
@@ -19621,8 +19621,8 @@
         "whatwg-fetch": "^3.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.16.0",
-        "@dfinity/principal": "^0.16.0",
+        "@dfinity/agent": "^0.17.0",
+        "@dfinity/principal": "^0.17.0",
         "@peculiar/webcrypto": "^1.4.0"
       }
     },
@@ -19638,10 +19638,10 @@
     },
     "packages/identity-secp256k1": {
       "name": "@dfinity/identity-secp256k1",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dfinity/agent": "^0.16.0",
+        "@dfinity/agent": "^0.17.0",
         "bip39": "^3.0.4",
         "bs58check": "^2.1.2",
         "secp256k1": "^4.0.3"
@@ -19732,7 +19732,7 @@
     },
     "packages/principal": {
       "name": "@dfinity/principal",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "js-sha256": "^0.9.0"
@@ -20736,10 +20736,10 @@
     "@dfinity/ic-agent-sample-javascript-app": {
       "version": "file:demos/sample-javascript",
       "requires": {
-        "@dfinity/agent": "^0.16.0",
+        "@dfinity/agent": "^0.17.0",
         "@dfinity/authentication": "^0.14.1",
-        "@dfinity/identity": "^0.16.0",
-        "@dfinity/principal": "^0.16.0",
+        "@dfinity/identity": "^0.17.0",
+        "@dfinity/principal": "^0.17.0",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "esbuild": "^0.15.16",
@@ -20844,7 +20844,7 @@
     "@dfinity/identity-secp256k1": {
       "version": "file:packages/identity-secp256k1",
       "requires": {
-        "@dfinity/agent": "^0.16.0",
+        "@dfinity/agent": "^0.17.0",
         "@types/bs58check": "^2.1.0",
         "@types/secp256k1": "^4.0.3",
         "bip39": "^3.0.4",
@@ -20945,10 +20945,10 @@
     "@do-not-publish/ic-cypress-e2e-tests": {
       "version": "file:e2e/browser",
       "requires": {
-        "@dfinity/agent": "^0.16.0",
+        "@dfinity/agent": "^0.17.0",
         "@dfinity/authentication": "^0.14.1",
-        "@dfinity/identity": "^0.16.0",
-        "@dfinity/principal": "^0.16.0",
+        "@dfinity/identity": "^0.17.0",
+        "@dfinity/principal": "^0.17.0",
         "@types/cypress": "^1.1.3",
         "@types/node": "^18.0.6",
         "concurrently": "^7.3.0",
@@ -20964,11 +20964,11 @@
     "@do-not-publish/ic-node-e2e-tests": {
       "version": "file:e2e/node",
       "requires": {
-        "@dfinity/agent": "^0.16.0",
-        "@dfinity/assets": "^0.16.0",
+        "@dfinity/agent": "^0.17.0",
+        "@dfinity/assets": "^0.17.0",
         "@dfinity/authentication": "^0.14.1",
-        "@dfinity/identity": "^0.16.0",
-        "@dfinity/principal": "^0.16.0",
+        "@dfinity/identity": "^0.17.0",
+        "@dfinity/principal": "^0.17.0",
         "@peculiar/webcrypto": "^1.4.0",
         "@trust/webcrypto": "^0.9.2",
         "@tsconfig/node16": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/agent-monorepo",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "description": "Use an Agent to interact with the Internet Computer from your JavaScript program.",
   "workspaces": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/agent",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to interact with the Internet Computer",
@@ -50,8 +50,8 @@
     "tslint": "tslint --project tsconfig.json --config tslint.json"
   },
   "peerDependencies": {
-    "@dfinity/candid": "^0.16.0",
-    "@dfinity/principal": "^0.16.0"
+    "@dfinity/candid": "^0.17.0",
+    "@dfinity/principal": "^0.17.0"
   },
   "dependencies": {
     "base64-arraybuffer": "^0.2.0",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/assets",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to manage assets on the Internet Computer",
@@ -50,7 +50,7 @@
     "test:coverage": "jest --verbose --collectCoverage"
   },
   "peerDependencies": {
-    "@dfinity/agent": "^0.16.0",
+    "@dfinity/agent": "^0.17.0",
     "js-sha256": "0.9.0"
   },
   "dependencies": {

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/auth-client",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to provide a simple integration with an IC Internet Identity",
@@ -47,9 +47,9 @@
     "test:coverage": "jest --verbose --collectCoverage"
   },
   "peerDependencies": {
-    "@dfinity/agent": "^0.16.0",
-    "@dfinity/identity": "^0.16.0",
-    "@dfinity/principal": "^0.16.0"
+    "@dfinity/agent": "^0.17.0",
+    "@dfinity/identity": "^0.17.0",
+    "@dfinity/principal": "^0.17.0"
   },
   "dependencies": {
     "idb": "^7.0.2"

--- a/packages/bls-verify/package.json
+++ b/packages/bls-verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/bls-verify",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "bls verification strategy in JavaScript",

--- a/packages/candid/package.json
+++ b/packages/candid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/candid",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to work with candid interfaces",

--- a/packages/identity-secp256k1/package.json
+++ b/packages/identity-secp256k1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/identity-secp256k1",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to manage Secp256k1KeyIdentities for use with the Internet Computer",
@@ -14,7 +14,7 @@
     "test:coverage": "jest --verbose --collectCoverage"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.16.0",
+    "@dfinity/agent": "^0.17.0",
     "bip39": "^3.0.4",
     "bs58check": "^2.1.2",
     "secp256k1": "^4.0.3"

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/identity",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to manage identity with the Internet Computer",
@@ -46,8 +46,8 @@
     "test:coverage": "jest --verbose --collectCoverage"
   },
   "peerDependencies": {
-    "@dfinity/agent": "^0.16.0",
-    "@dfinity/principal": "^0.16.0",
+    "@dfinity/agent": "^0.17.0",
+    "@dfinity/principal": "^0.17.0",
     "@peculiar/webcrypto": "^1.4.0"
   },
   "dependencies": {

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/principal",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "description": "JavaScript and TypeScript library to work with Internet Computer principals",


### PR DESCRIPTION
Release agent-js 0.17.0 to incorporate a [bug fix](https://github.com/dfinity/agent-js/pull/734) and [support for the new `composite_query` keyword](https://github.com/dfinity/agent-js/pull/730).
