### PR TITLE
feat: expose boundary node http headers to calls

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -32,9 +32,11 @@
           in the type table
         </li>
         <li>
-          feat: support composite_query in candid
-          fix: fix a bug in decoding service types, when function types come after the service type in the type table
+          feat: support composite_query in candid fix: fix a bug in decoding service types, when
+          function types come after the service type in the type table
         </li>
+        <li>feat: include boundary node http details to query and update calls</li>
+        <li>feat: adds method for actor creation that includes boundary node http details</li>
       </ul>
       <h2>Version 0.15.7</h2>
       <ul>

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -31,9 +31,10 @@
           fix: fix a bug in decoding service types, when function types come after the service type
           in the type table
         </li>
+        <li>feat: support composite_query in candid</li>
         <li>
-          feat: support composite_query in candid fix: fix a bug in decoding service types, when
-          function types come after the service type in the type table
+          fix: fix a bug in decoding service types, when function types come after the service type
+          in the type table
         </li>
         <li>feat: include boundary node http details to query and update calls</li>
         <li>feat: adds method for actor creation that includes boundary node http details</li>

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -54,6 +54,12 @@ Actor.createActor(interfaceFactory: InterfaceFactory, configuration: ActorConfig
 
 The `interfaceFactory` is a function that returns a runtime interface that the Actor uses to strucure calls to a canister. The interfaceFactory can be written manually, but it is recommended to use the `dfx generate` command to generate the interface for your project, or to use the `didc` tool to generate the interface for your project.
 
+Actors can also be initialized to include the boundary node http headers, This is done by calling the `Actor.createActor` constructor:
+
+```
+Actor.createActorWithHttpDetails(interfaceFactory: InterfaceFactory, configuration: ActorConfig): ActorSubclass<ActorMethodMappedWithHttpDetails<T>>
+```
+
 ### Inspecting an actor's agent
 
 Use the `Actor.agentOf` method to get the agent of an actor:

--- a/packages/agent/src/actor.test.ts
+++ b/packages/agent/src/actor.test.ts
@@ -1,14 +1,22 @@
 import { IDL } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
-import { Actor, UpdateCallRejectedError } from './actor';
 import { HttpAgent, Nonce, SubmitResponse } from './agent';
 import { Expiry, makeNonceTransform } from './agent/http/transforms';
 import { CallRequest, SubmitRequestType, UnSigned } from './agent/http/types';
 import * as cbor from './cbor';
 import { requestIdOf } from './request_id';
+import * as pollingImport from './polling';
+
+const importActor = async (mockUpdatePolling?: () => void) => {
+  jest.dontMock('./polling');
+  mockUpdatePolling?.();
+
+  return await import('./actor');
+};
 
 const originalDateNowFn = global.Date.now;
 beforeEach(() => {
+  jest.resetModules();
   global.Date.now = jest.fn(() => new Date(1000000).getTime());
 });
 afterEach(() => {
@@ -18,6 +26,7 @@ afterEach(() => {
 describe('makeActor', () => {
   // TODO: update tests to be compatible with changes to Certificate
   it.skip('should encode calls', async () => {
+    const { Actor, UpdateCallRejectedError } = await importActor();
     const actorInterface = () => {
       return IDL.Service({
         greet: IDL.Func([IDL.Text], [IDL.Text]),
@@ -220,7 +229,82 @@ describe('makeActor', () => {
       body: cbor.encode(expectedErrorCallRequest),
     });
   });
+  it('should enrich actor interface with httpDetails', async () => {
+    const canisterDecodedReturnValue = 'Hello, World!';
+    const expectedReplyArg = IDL.encode([IDL.Text], [canisterDecodedReturnValue]);
+    const { Actor } = await importActor(() =>
+      jest.doMock('./polling', () => ({
+        ...pollingImport,
+        pollForResponse: jest.fn(() => expectedReplyArg),
+      })),
+    );
+
+    const mockFetch = jest.fn(resource => {
+      if (resource.endsWith('/call')) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 202,
+            statusText: 'accepted',
+          }),
+        );
+      }
+
+      return Promise.resolve(
+        new Response(
+          cbor.encode({
+            status: 'replied',
+            reply: {
+              arg: expectedReplyArg,
+            },
+          }),
+          {
+            status: 200,
+            statusText: 'ok',
+          },
+        ),
+      );
+    });
+
+    const actorInterface = () => {
+      return IDL.Service({
+        greet: IDL.Func([IDL.Text], [IDL.Text], ['query']),
+        greet_update: IDL.Func([IDL.Text], [IDL.Text]),
+        // todo: add method to test update call after Certificate changes have been adjusted
+      });
+    };
+    const httpAgent = new HttpAgent({ fetch: mockFetch, host: 'http://localhost' });
+    const canisterId = Principal.fromText('2chl6-4hpzw-vqaaa-aaaaa-c');
+    const actor = Actor.createActor(actorInterface, { canisterId, agent: httpAgent });
+    const actorWithHttpDetails = Actor.createActorWithHttpDetails(actorInterface, {
+      canisterId,
+      agent: httpAgent,
+    });
+
+    const reply = await actor.greet('test');
+    const replyUpdate = await actor.greet_update('test');
+    const replyWithHttpDetails = await actorWithHttpDetails.greet('test');
+    const replyUpdateWithHttpDetails = await actorWithHttpDetails.greet_update('test');
+
+    expect(reply).toEqual(canisterDecodedReturnValue);
+    expect(replyUpdate).toEqual(canisterDecodedReturnValue);
+    expect(replyWithHttpDetails.result).toEqual(canisterDecodedReturnValue);
+    expect(replyWithHttpDetails.httpDetails).toEqual({
+      ok: true,
+      status: 200,
+      statusText: 'ok',
+      headers: [],
+    });
+    expect(replyUpdateWithHttpDetails.result).toEqual(canisterDecodedReturnValue);
+    expect(replyUpdateWithHttpDetails.httpDetails).toEqual({
+      body: null,
+      ok: true,
+      status: 202,
+      statusText: 'accepted',
+      headers: [],
+    });
+  });
   it('should allow its agent to be invalidated', async () => {
+    const { Actor } = await importActor();
     const mockFetch = jest.fn();
     const actorInterface = () => {
       return IDL.Service({
@@ -231,7 +315,7 @@ describe('makeActor', () => {
     const canisterId = Principal.fromText('2chl6-4hpzw-vqaaa-aaaaa-c');
     const actor = Actor.createActor(actorInterface, { canisterId, agent: httpAgent });
 
-    Actor.agentOf(actor).invalidateIdentity();
+    httpAgent.invalidateIdentity();
 
     try {
       await actor.greet('test');

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -192,6 +192,10 @@ interface ActorMetadata {
 
 const metadataSymbol = Symbol.for('ic-agent-metadata');
 
+export interface CreateActorClassOpts {
+  httpDetails?: boolean;
+}
+
 /**
  * An actor base class. An actor is an object containing only functions that will
  * return a promise. These functions are derived from the IDL definition.
@@ -273,7 +277,7 @@ export class Actor {
 
   public static createActorClass(
     interfaceFactory: IDL.InterfaceFactory,
-    withHttpDetails = false,
+    options?: CreateActorClassOpts,
   ): ActorConstructor {
     const service = interfaceFactory({ IDL });
 
@@ -296,7 +300,7 @@ export class Actor {
         });
 
         for (const [methodName, func] of service._fields) {
-          if (withHttpDetails) {
+          if (options?.httpDetails) {
             func.annotations.push(ACTOR_METHOD_WITH_HTTP_DETAILS);
           }
 
@@ -312,7 +316,7 @@ export class Actor {
     interfaceFactory: IDL.InterfaceFactory,
     configuration: ActorConfig,
   ): ActorSubclass<T> {
-    return new (this.createActorClass(interfaceFactory, false))(
+    return new (this.createActorClass(interfaceFactory))(
       configuration,
     ) as unknown as ActorSubclass<T>;
   }
@@ -321,7 +325,7 @@ export class Actor {
     interfaceFactory: IDL.InterfaceFactory,
     configuration: ActorConfig,
   ): ActorSubclass<ActorMethodMappedWithHttpDetails<T>> {
-    return new (this.createActorClass(interfaceFactory, true))(
+    return new (this.createActorClass(interfaceFactory, { httpDetails: true }))(
       configuration,
     ) as unknown as ActorSubclass<ActorMethodMappedWithHttpDetails<T>>;
   }

--- a/packages/agent/src/agent/api.ts
+++ b/packages/agent/src/agent/api.ts
@@ -2,6 +2,7 @@ import { Principal } from '@dfinity/principal';
 import { RequestId } from '../request_id';
 import { JsonObject } from '@dfinity/candid';
 import { Identity } from '../auth';
+import { HttpHeaderField } from './http/types';
 
 /**
  * Codes used by the replica for rejecting a message.
@@ -34,6 +35,15 @@ export const enum QueryResponseStatus {
   Replied = 'replied',
   Rejected = 'rejected',
 }
+
+export interface HttpDetailsResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: HttpHeaderField[];
+}
+
+export type ApiQueryResponse = QueryResponse & { httpDetails: HttpDetailsResponse };
 
 export interface QueryResponseBase {
   status: QueryResponseStatus;
@@ -101,6 +111,7 @@ export interface SubmitResponse {
       reject_code: number;
       reject_message: string;
     } | null;
+    headers: HttpHeaderField[];
   };
 }
 
@@ -161,11 +172,16 @@ export interface Agent {
    * @param canisterId The Principal of the Canister to send the query to. Sending a query to
    *     the management canister is not supported (as it has no meaning from an agent).
    * @param options Options to use to create and send the query.
+   * @param identity Sender principal to use when sending the query.
    * @returns The response from the replica. The Promise will only reject when the communication
    *     failed. If the query itself failed but no protocol errors happened, the response will
    *     be of type QueryResponseRejected.
    */
-  query(canisterId: Principal | string, options: QueryFields): Promise<QueryResponse>;
+  query(
+    canisterId: Principal | string,
+    options: QueryFields,
+    identity?: Identity | Promise<Identity>,
+  ): Promise<ApiQueryResponse>;
 
   /**
    * By default, the agent is configured to talk to the main Internet Computer,

--- a/packages/agent/src/agent/http/__snapshots__/http.test.ts.snap
+++ b/packages/agent/src/agent/http/__snapshots__/http.test.ts.snap
@@ -5,16 +5,10 @@ Object {
   "requestId": ArrayBuffer [],
   "response": Object {
     "body": null,
+    "headers": Array [],
     "ok": true,
     "status": 200,
     "statusText": "success!",
   },
 }
-`;
-
-exports[`retry failures should throw errors immediately if retryTimes is set to 0 1`] = `
-"Server returned an error:
-  Code: 500 (Internal Server Error)
-  Body: Error
-"
 `;

--- a/packages/agent/src/agent/http/errors.ts
+++ b/packages/agent/src/agent/http/errors.ts
@@ -1,0 +1,7 @@
+export class AgentHTTPResponseError extends Error {
+  constructor(message: string, public readonly response: Response) {
+    super(message);
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/packages/agent/src/agent/http/errors.ts
+++ b/packages/agent/src/agent/http/errors.ts
@@ -1,5 +1,7 @@
+import { HttpDetailsResponse } from '../api';
+
 export class AgentHTTPResponseError extends Error {
-  constructor(message: string, public readonly response: Response) {
+  constructor(message: string, public readonly response: HttpDetailsResponse) {
     super(message);
     this.name = this.constructor.name;
     Object.setPrototypeOf(this, new.target.prototype);

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -356,7 +356,12 @@ export class HttpAgent implements Agent {
       return await this._requestAndRetry(request, tries + 1);
     }
 
-    throw new AgentHTTPResponseError(errorMessage, response);
+    throw new AgentHTTPResponseError(errorMessage, {
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      headers: httpHeadersTransform(response.headers),
+    });
   }
 
   public async query(

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -3,17 +3,18 @@ import { Principal } from '@dfinity/principal';
 import { AgentError } from '../../errors';
 import { AnonymousIdentity, Identity } from '../../auth';
 import * as cbor from '../../cbor';
-import { RequestId, requestIdOf } from '../../request_id';
+import { requestIdOf } from '../../request_id';
 import { fromHex } from '../../utils/buffer';
 import {
   Agent,
+  ApiQueryResponse,
   QueryFields,
   QueryResponse,
   ReadStateOptions,
   ReadStateResponse,
   SubmitResponse,
 } from '../api';
-import { Expiry, makeNonceTransform } from './transforms';
+import { Expiry, httpHeadersTransform, makeNonceTransform } from './transforms';
 import {
   CallRequest,
   Endpoint,
@@ -25,6 +26,7 @@ import {
   ReadRequestType,
   SubmitRequestType,
 } from './types';
+import { AgentHTTPResponseError } from './errors';
 
 export * from './transforms';
 export { Nonce, makeNonce } from './types';
@@ -153,15 +155,6 @@ function getDefaultFetch(): typeof fetch {
   );
 }
 
-type _RequestResponse = {
-  requestId: RequestId;
-  response: {
-    ok: Response['ok'];
-    status: Response['status'];
-    statusText: Response['statusText'];
-  };
-};
-
 // A HTTP agent allows users to interact with a client of the internet computer
 // using the available methods. It exposes an API that closely follows the
 // public view of the internet computer, and is not intended to be exposed
@@ -182,7 +175,7 @@ export class HttpAgent implements Agent {
   private readonly _host: URL;
   private readonly _credentials: string | undefined;
   private _rootKeyFetched = false;
-  private _retryTimes = 3; // Retry requests 3 times before erroring by default
+  private readonly _retryTimes; // Retry requests N times before erroring by default
   public readonly _isAgent = true;
 
   constructor(options: HttpAgentOptions = {}) {
@@ -216,10 +209,9 @@ export class HttpAgent implements Agent {
       }
       this._host = new URL(location + '');
     }
-    // Default is 3, only set if option is provided
-    if (options.retryTimes !== undefined) {
-      this._retryTimes = options.retryTimes;
-    }
+    // Default is 3, only set from option if greater or equal to 0
+    this._retryTimes =
+      options.retryTimes !== undefined && options.retryTimes >= 0 ? options.retryTimes : 3;
     // Rewrite to avoid redirects
     if (this._host.hostname.endsWith(IC0_SUB_DOMAIN)) {
       this._host.hostname = IC0_DOMAIN;
@@ -320,7 +312,6 @@ export class HttpAgent implements Agent {
 
     // Run both in parallel. The fetch is quite expensive, so we have plenty of time to
     // calculate the requestId locally.
-
     const request = this._requestAndRetry(() =>
       this._fetch('' + new URL(`/api/v2/canister/${ecid.toText()}/call`, this._host), {
         ...this._callOptions,
@@ -343,39 +334,36 @@ export class HttpAgent implements Agent {
         status: response.status,
         statusText: response.statusText,
         body: responseBody,
+        headers: httpHeadersTransform(response.headers),
       },
     };
   }
 
   private async _requestAndRetry(request: () => Promise<Response>, tries = 0): Promise<Response> {
-    if (tries > this._retryTimes && this._retryTimes !== 0) {
-      throw new Error(
-        `AgentError: Exceeded configured limit of ${this._retryTimes} retry attempts. Please check your network connection or try again in a few moments`,
-      );
-    }
     const response = await request();
-    if (!response.ok) {
-      const responseText = await response.clone().text();
-      const errorMessage =
-        `Server returned an error:\n` +
-        `  Code: ${response.status} (${response.statusText})\n` +
-        `  Body: ${responseText}\n`;
-      if (this._retryTimes > tries) {
-        console.warn(errorMessage + `  Retrying request.`);
-        return await this._requestAndRetry(request, tries + 1);
-      } else {
-        throw new Error(errorMessage);
-      }
+    if (response.ok) {
+      return response;
     }
 
-    return response;
+    const responseText = await response.clone().text();
+    const errorMessage =
+      `Server returned an error:\n` +
+      `  Code: ${response.status} (${response.statusText})\n` +
+      `  Body: ${responseText}\n`;
+
+    if (this._retryTimes > tries) {
+      console.warn(errorMessage + `  Retrying request.`);
+      return await this._requestAndRetry(request, tries + 1);
+    }
+
+    throw new AgentHTTPResponseError(errorMessage, response);
   }
 
   public async query(
     canisterId: Principal | string,
     fields: QueryFields,
     identity?: Identity | Promise<Identity>,
-  ): Promise<QueryResponse> {
+  ): Promise<ApiQueryResponse> {
     const id = await (identity !== undefined ? await identity : await this._identity);
     if (!id) {
       throw new IdentityInvalidError(
@@ -421,7 +409,17 @@ export class HttpAgent implements Agent {
       }),
     );
 
-    return cbor.decode(await response.arrayBuffer());
+    const queryResponse: QueryResponse = cbor.decode(await response.arrayBuffer());
+
+    return {
+      ...queryResponse,
+      httpDetails: {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        headers: httpHeadersTransform(response.headers),
+      },
+    };
   }
 
   public async createReadStateRequest(
@@ -493,7 +491,7 @@ export class HttpAgent implements Agent {
 
   /**
    * Allows agent to sync its time with the network. Can be called during intialization or mid-lifecycle if the device's clock has drifted away from the network time. This is necessary to set the Expiry for a request
-   * @param {PrincipalLike} canisterId - Pass a canister ID if you need to sync the time with a particular replica. Uses the management canister by default
+   * @param {Principal} canisterId - Pass a canister ID if you need to sync the time with a particular replica. Uses the management canister by default
    */
   public async syncTime(canisterId?: Principal): Promise<void> {
     const CanisterStatus = await import('../../canisterStatus');

--- a/packages/agent/src/agent/http/transforms.ts
+++ b/packages/agent/src/agent/http/transforms.ts
@@ -1,6 +1,13 @@
 import { lebEncode } from '@dfinity/candid';
 import * as cbor from 'simple-cbor';
-import { Endpoint, HttpAgentRequest, HttpAgentRequestTransformFn, makeNonce, Nonce } from './types';
+import {
+  Endpoint,
+  HttpAgentRequest,
+  HttpAgentRequestTransformFn,
+  HttpHeaderField,
+  makeNonce,
+  Nonce,
+} from './types';
 import { toHex } from '../../utils/buffer';
 
 const NANOSECONDS_PER_MILLISECONDS = BigInt(1_000_000);
@@ -57,4 +64,18 @@ export function makeExpiryTransform(delayInMilliseconds: number): HttpAgentReque
   return async (request: HttpAgentRequest) => {
     request.body.ingress_expiry = new Expiry(delayInMilliseconds);
   };
+}
+
+/**
+ * Maps the default fetch headers field to the serializable HttpHeaderField.
+ *
+ * @param headers Fetch definition of the headers type
+ * @returns array of header fields
+ */
+export function httpHeadersTransform(headers: Headers): HttpHeaderField[] {
+  const headerFields: HttpHeaderField[] = [];
+  headers.forEach((value, key) => {
+    headerFields.push([key, value]);
+  });
+  return headerFields;
 }

--- a/packages/agent/src/agent/http/types.ts
+++ b/packages/agent/src/agent/http/types.ts
@@ -1,6 +1,5 @@
 import type { Principal } from '@dfinity/principal';
 import { Expiry } from './transforms';
-import { lebEncode } from '@dfinity/candid';
 
 /**
  * @internal
@@ -22,6 +21,8 @@ export interface HttpAgentBaseRequest {
   readonly endpoint: Endpoint;
   request: RequestInit;
 }
+
+export type HttpHeaderField = [string, string];
 
 export interface HttpAgentSubmitRequest extends HttpAgentBaseRequest {
   readonly endpoint: Endpoint.Call;

--- a/packages/agent/src/agent/proxy.ts
+++ b/packages/agent/src/agent/proxy.ts
@@ -1,6 +1,7 @@
 import { JsonObject } from '@dfinity/candid';
 import {
   Agent,
+  ApiQueryResponse,
   CallOptions,
   QueryFields,
   QueryResponse,
@@ -224,12 +225,12 @@ export class ProxyAgent implements Agent {
     }) as Promise<JsonObject>;
   }
 
-  public query(canisterId: Principal | string, fields: QueryFields): Promise<QueryResponse> {
+  public query(canisterId: Principal | string, fields: QueryFields): Promise<ApiQueryResponse> {
     return this._sendAndWait({
       id: this._nextId++,
       type: ProxyMessageKind.Query,
       args: [canisterId.toString(), fields],
-    }) as Promise<QueryResponse>;
+    }) as Promise<ApiQueryResponse>;
   }
 
   private async _sendAndWait(msg: ProxyMessage): Promise<unknown> {


### PR DESCRIPTION
# Description

This PR extens the `query` and `call` method responses to include the boundary node http headers. Moreover, it introduces a new method to the actor creation that enriches the provide type to include the http details of call.

# How Has This Been Tested?

- http calls responses are tested with snapshots
- `requestAndRetry` logic is validated by using a custom error type `AgentHTTPResponseError `
- actor interface is tested by mocking the pollForResponse and testing that both `createActor` and `createActorWithHttpDetails` return the same decoded response and that the later also includes the expected `httpDetails`
- Linked locally with the service worker and manually validated the integration

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
