### PR TITLE
fix: fix composite query support in actor.ts

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>fix: fix composite query in actor.ts</li>
         <li>
           fix: handle new update call errors (<a
             href="https://github.com/dfinity/interface-spec/pull/143"

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -367,7 +367,7 @@ function _createActorMethod(
   blsVerify?: CreateCertificateOptions['blsVerify'],
 ): ActorMethod {
   let caller: (options: CallConfig, ...args: unknown[]) => Promise<unknown>;
-  if (func.annotations.includes('query')) {
+  if (func.annotations.includes('query') || func.annotations.includes('composite_query')) {
     caller = async (options, ...args) => {
       // First, if there's a config transformation, call it.
       options = {


### PR DESCRIPTION
# Description

We cannot call composite query from agent-js at the moment, because it's been categorized as update call.

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
