### PR TITLE
feat: HttpAgent now uses a default address

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,6 +13,10 @@
       <h2>Version x.x.x</h2>
       <ul>
         <li>
+          Feat: HttpAgent now uses a default address of https://icp-api.io. Users will be warned for
+          not setting a host, but the code will default to mainnet.
+        </li>
+        <li>
           Feat: use webcrypto or node crypto instead of Math.random for nonce generation if
           available
         </li>

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -205,7 +205,10 @@ export class HttpAgent implements Agent {
     } else {
       const location = typeof window !== 'undefined' ? window.location : undefined;
       if (!location) {
-        throw new Error('Must specify a host to connect to.');
+        this._host = new URL('https://icp-api.io');
+        console.warn(
+          'Could not infer host from window.location, defaulting to mainnet gateway of https://icp-api.io. Please provide a host to the HttpAgent constructor to avoid this warning.',
+        );
       }
       this._host = new URL(location + '');
     }


### PR DESCRIPTION
# Description

To ease the pain of development, sets a default host of https://icp-api.io for HttpAgent if none can be inferred, and none is provided.

Logs a warning encouraging the developer to set a host in the HttpAgent options


# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
