### PR TITLE
feat: replaces the `js-sha256` library with `@noble/hashes`

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,10 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>
+          feat: replaces the `js-sha256` library with `@noble/hashes` due to a breaking bug in
+          Chrome
+        </li>
         <li>Fix: add `@dfinity/principal` as a peerDependency to `assets` and `candid`.</li>
         <li>
           Feat: HttpAgent now uses a default address of https://icp-api.io. Users will be warned for

--- a/package-lock.json
+++ b/package-lock.json
@@ -2039,6 +2039,17 @@
         "darwin"
       ]
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -6880,13 +6891,13 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.17.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.3.tgz",
-      "integrity": "sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==",
+      "version": "12.17.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
+      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.11",
+        "@cypress/request": "2.88.12",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -6921,6 +6932,7 @@
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
@@ -13846,6 +13858,7 @@
     "node_modules/pkcs11js": {
       "version": "1.3.0",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "nan": "^2.15.0"
@@ -17706,9 +17719,9 @@
       "version": "0.18.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
         "borc": "^2.1.1",
-        "js-sha256": "0.9.0",
         "simple-cbor": "^0.4.1"
       },
       "devDependencies": {
@@ -17814,6 +17827,7 @@
       "version": "0.18.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^1.0.2",
         "mime": "^3.0.0"
       },
@@ -17835,8 +17849,7 @@
       },
       "peerDependencies": {
         "@dfinity/agent": "^0.18.1",
-        "@dfinity/principal": "^0.18.1",
-        "js-sha256": "0.9.0"
+        "@dfinity/principal": "^0.18.1"
       }
     },
     "packages/assets/node_modules/@types/mime": {
@@ -18166,7 +18179,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "borc": "^2.1.1",
-        "js-sha256": "^0.9.0",
         "tweetnacl": "^1.0.1"
       },
       "devDependencies": {
@@ -18199,6 +18211,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dfinity/agent": "^0.18.1",
+        "@noble/hashes": "^1.3.1",
         "bip39": "^3.0.4",
         "bs58check": "^2.1.2",
         "secp256k1": "^4.0.3"
@@ -18285,9 +18298,6 @@
       "name": "@dfinity/principal",
       "version": "0.18.1",
       "license": "Apache-2.0",
-      "dependencies": {
-        "js-sha256": "^0.9.0"
-      },
       "devDependencies": {
         "@types/jest": "^28.1.4",
         "@typescript-eslint/eslint-plugin": "^5.30.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17827,7 +17827,6 @@
       "version": "0.18.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^1.0.2",
         "mime": "^3.0.0"
       },
@@ -17849,7 +17848,8 @@
       },
       "peerDependencies": {
         "@dfinity/agent": "^0.18.1",
-        "@dfinity/principal": "^0.18.1"
+        "@dfinity/principal": "^0.18.1",
+        "@noble/hashes": "^1.3.1"
       }
     },
     "packages/assets/node_modules/@types/mime": {
@@ -18178,6 +18178,7 @@
       "version": "0.18.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@noble/hashes": "^1.3.1",
         "borc": "^2.1.1",
         "tweetnacl": "^1.0.1"
       },
@@ -18298,6 +18299,9 @@
       "name": "@dfinity/principal",
       "version": "0.18.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.3.1"
+      },
       "devDependencies": {
         "@types/jest": "^28.1.4",
         "@typescript-eslint/eslint-plugin": "^5.30.5",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -54,9 +54,9 @@
     "@dfinity/principal": "^0.18.1"
   },
   "dependencies": {
+    "@noble/hashes": "^1.3.1",
     "base64-arraybuffer": "^0.2.0",
     "borc": "^2.1.1",
-    "js-sha256": "0.9.0",
     "simple-cbor": "^0.4.1"
   },
   "devDependencies": {

--- a/packages/agent/src/request_id.ts
+++ b/packages/agent/src/request_id.ts
@@ -1,8 +1,8 @@
 import { lebEncode } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import borc from 'borc';
-import { sha256 as jsSha256 } from 'js-sha256';
-import { compare, concat } from './utils/buffer';
+import { sha256 } from '@noble/hashes/sha256';
+import { compare, concat, uint8ToBuf } from './utils/buffer';
 
 export type RequestId = ArrayBuffer & { __requestId__: void };
 
@@ -11,7 +11,7 @@ export type RequestId = ArrayBuffer & { __requestId__: void };
  * @param data - input to hash function
  */
 export function hash(data: ArrayBuffer): ArrayBuffer {
-  return jsSha256.create().update(new Uint8Array(data)).arrayBuffer();
+  return uint8ToBuf(sha256.create().update(new Uint8Array(data)).digest());
 }
 
 interface ToHashable {

--- a/packages/agent/src/utils/buffer.ts
+++ b/packages/agent/src/utils/buffer.ts
@@ -55,3 +55,12 @@ export function compare(b1: ArrayBuffer, b2: ArrayBuffer): number {
   }
   return 0;
 }
+
+/**
+ * Returns a true ArrayBuffer from a Uint8Array, as Uint8Array.buffer is unsafe.
+ * @param {Uint8Array} arr Uint8Array to convert
+ * @returns ArrayBuffer
+ */
+export function uint8ToBuf(arr: Uint8Array): ArrayBuffer {
+  return new DataView(arr.buffer, arr.byteOffset, arr.byteLength).buffer;
+}

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -51,10 +51,10 @@
   },
   "peerDependencies": {
     "@dfinity/agent": "^0.18.1",
-    "@dfinity/principal": "^0.18.1"
+    "@dfinity/principal": "^0.18.1",
+    "@noble/hashes": "^1.3.1"
   },
   "dependencies": {
-    "@noble/hashes": "^1.3.1",
     "base64-arraybuffer": "^1.0.2",
     "mime": "^3.0.0"
   },

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -51,10 +51,10 @@
   },
   "peerDependencies": {
     "@dfinity/agent": "^0.18.1",
-    "@dfinity/principal": "^0.18.1",
-    "js-sha256": "0.9.0"
+    "@dfinity/principal": "^0.18.1"
   },
   "dependencies": {
+    "@noble/hashes": "^1.3.1",
     "base64-arraybuffer": "^1.0.2",
     "mime": "^3.0.0"
   },

--- a/packages/identity-secp256k1/package.json
+++ b/packages/identity-secp256k1/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@dfinity/agent": "^0.18.1",
+    "@noble/hashes": "^1.3.1",
     "bip39": "^3.0.4",
     "bs58check": "^2.1.2",
     "secp256k1": "^4.0.3"

--- a/packages/identity-secp256k1/src/secp256k1.test.ts
+++ b/packages/identity-secp256k1/src/secp256k1.test.ts
@@ -1,7 +1,7 @@
 import { DerEncodedPublicKey, PublicKey } from '@dfinity/agent';
 import { toHexString } from '@dfinity/candid/lib/cjs/utils/buffer';
 import { randomBytes } from 'crypto';
-import { sha256 } from 'js-sha256';
+import { sha256 } from '@noble/hashes/sha256';
 import Secp256k1 from 'secp256k1';
 import { Secp256k1KeyIdentity, Secp256k1PublicKey } from './secp256k1';
 

--- a/packages/identity-secp256k1/src/secp256k1.ts
+++ b/packages/identity-secp256k1/src/secp256k1.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { DerEncodedPublicKey, KeyPair, Signature } from '@dfinity/agent';
 import Secp256k1 from 'secp256k1';
-import { sha256 } from 'js-sha256';
+import { sha256 } from '@noble/hashes/sha256';
 import { randomBytes } from 'tweetnacl';
 import hdkey from './hdkey';
 import { mnemonicToSeedSync } from 'bip39';
@@ -201,7 +201,7 @@ export class Secp256k1KeyIdentity extends SignIdentity {
    */
   public async sign(challenge: ArrayBuffer): Promise<Signature> {
     const hash = sha256.create();
-    hash.update(challenge);
+    hash.update(new Uint8Array(challenge));
     const signature = Secp256k1.ecdsaSign(
       new Uint8Array(hash.digest()),
       new Uint8Array(this._privateKey),

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -51,6 +51,7 @@
     "@peculiar/webcrypto": "^1.4.0"
   },
   "dependencies": {
+    "@noble/hashes": "^1.3.1",
     "borc": "^2.1.1",
     "tweetnacl": "^1.0.1"
   },

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "borc": "^2.1.1",
-    "js-sha256": "^0.9.0",
     "tweetnacl": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/identity/src/identity/ecdsa.test.ts
+++ b/packages/identity/src/identity/ecdsa.test.ts
@@ -1,4 +1,4 @@
-import { sha256 } from 'js-sha256';
+import { sha256 } from '@noble/hashes/sha256';
 import { ECDSAKeyIdentity } from './ecdsa';
 import { Crypto } from '@peculiar/webcrypto';
 

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -50,8 +50,8 @@
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "esbuild": "^0.15.16",
-    "eslint-plugin-jsdoc": "^39.3.3",
     "eslint": "^8.19.0",
+    "eslint-plugin-jsdoc": "^39.3.3",
     "jest": "^28.1.2",
     "size-limit": "^8.2.6",
     "text-encoding": "^0.7.0",
@@ -61,9 +61,6 @@
     "typedoc": "^0.22.11",
     "typescript": "^4.2.3",
     "whatwg-fetch": "^3.0.0"
-  },
-  "dependencies": {
-    "js-sha256": "^0.9.0"
   },
   "size-limit": [
     {

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -68,5 +68,8 @@
       "limit": "100 kB",
       "webpack": false
     }
-  ]
+  ],
+  "dependencies": {
+    "@noble/hashes": "^1.3.1"
+  }
 }

--- a/packages/principal/src/utils/sha224.ts
+++ b/packages/principal/src/utils/sha224.ts
@@ -1,11 +1,9 @@
-import { sha224 as jsSha224 } from 'js-sha256';
+import { sha224 as jsSha224 } from '@noble/hashes/sha256';
 
 /**
  * Returns the SHA224 hash of the buffer.
  * @param data Arraybuffer to encode
  */
 export function sha224(data: ArrayBuffer): Uint8Array {
-  const shaObj = jsSha224.create();
-  shaObj.update(data);
-  return new Uint8Array(shaObj.array());
+  return jsSha224.create().update(new Uint8Array(data)).digest();
 }


### PR DESCRIPTION
# Description

Due to an ongoing incident where the js-sha256 library is breaking on new versions of Chrome, we are replacing it with the industry standard library, @noble/hashes

This is a compact, audited, pure JS library, and it is able to produce hashes synchronously, which makes it easier to drop into our library than the WebCrypto.subtle.digest api, which is promise-based.

Fixes # (issue)

# How Has This Been Tested?

Updates to a few unit tests, and running against existing golden canonical hashes and e2e test suite

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
