### PR TITLE
Kyle/hostname bug

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,17 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li></li>
+      </ul>
+      <h2>Version 0.19.2</h2>
+      <ul>
+        <li>
+          fix: subdomains on icp0.io and ic0.app were incorrectly sending requests to icp-api and
+          encountering CSP issues
+        </li>
+      </ul>
+      <h2>Version 0.19.1</h2>
+      <ul>
         <li>fix: default host logic fixed and tests added</li>
       </ul>
       <h2>Version 0.19.0</h2>

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -783,4 +783,16 @@ describe('default host', () => {
       expect((agent as any)._host.hostname).toBe(host);
     }
   });
+  it('should correctly handle subdomains on known hosts', () => {
+    const knownHosts = ['ic0.app', 'icp0.io', 'localhost', '127.0.0.1'];
+    for (const host of knownHosts) {
+      delete window.location;
+      window.location = {
+        hostname: `rrkah-fqaaa-aaaaa-aaaaq-cai.${host}`,
+        protocol: 'https:',
+      } as any;
+      const agent = new HttpAgent({ fetch: jest.fn() });
+      expect((agent as any)._host.hostname).toBe(host);
+    }
+  });
 });

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -788,8 +788,24 @@ describe('default host', () => {
     for (const host of knownHosts) {
       delete window.location;
       window.location = {
+        host: `foo.${host}`,
         hostname: `rrkah-fqaaa-aaaaa-aaaaq-cai.${host}`,
         protocol: 'https:',
+      } as any;
+      const agent = new HttpAgent({ fetch: jest.fn() });
+      expect((agent as any)._host.hostname).toBe(host);
+    }
+  });
+  it('should handle port numbers for localhost', () => {
+    const knownHosts = ['localhost', '127.0.0.1'];
+    for (const host of knownHosts) {
+      delete window.location;
+      // hostname is different from host when port is specified
+      window.location = {
+        host: `${host}:4943`,
+        hostname: `${host}`,
+        protocol: 'http:',
+        port: '4943',
       } as any;
       const agent = new HttpAgent({ fetch: jest.fn() });
       expect((agent as any)._host.hostname).toBe(host);

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -763,7 +763,6 @@ test('should fetch with given call options and fetch options', async () => {
 describe('default host', () => {
   it('should use a default host of icp-api.io', () => {
     const agent = new HttpAgent({ fetch: jest.fn() });
-    window.location.hostname; //?
     expect((agent as any)._host.hostname).toBe('icp-api.io');
   });
   it('should use a default of icp-api.io if location is not available', () => {

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -212,9 +212,11 @@ export class HttpAgent implements Agent {
       }
       // Mainnet and local will have the api route available
       const knownHosts = ['ic0.app', 'icp0.io', 'localhost', '127.0.0.1'];
-      if (location && knownHosts.includes(location.hostname)) {
+
+      const knownHost = knownHosts.find(host => location?.hostname.endsWith(host));
+      if (location && knownHost) {
         // If the user is on a boundary-node provided host, we can use the same host for the agent
-        this._host = new URL(location + '');
+        this._host = new URL(`${location.protocol}//${knownHost}`);
       } else {
         this._host = new URL('https://icp-api.io');
         console.warn(

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -212,11 +212,15 @@ export class HttpAgent implements Agent {
       }
       // Mainnet and local will have the api route available
       const knownHosts = ['ic0.app', 'icp0.io', 'localhost', '127.0.0.1'];
-
       const knownHost = knownHosts.find(host => location?.hostname.endsWith(host));
+      location;
       if (location && knownHost) {
         // If the user is on a boundary-node provided host, we can use the same host for the agent
-        this._host = new URL(`${location.protocol}//${knownHost}`);
+        knownHost;
+        this._host = new URL(
+          `${location.protocol}//${knownHost}${location.port ? ':' + location.port : ''}`,
+        );
+        this._host; //?
       } else {
         this._host = new URL('https://icp-api.io');
         console.warn(

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -213,14 +213,11 @@ export class HttpAgent implements Agent {
       // Mainnet and local will have the api route available
       const knownHosts = ['ic0.app', 'icp0.io', 'localhost', '127.0.0.1'];
       const knownHost = knownHosts.find(host => location?.hostname.endsWith(host));
-      location;
       if (location && knownHost) {
         // If the user is on a boundary-node provided host, we can use the same host for the agent
-        knownHost;
         this._host = new URL(
           `${location.protocol}//${knownHost}${location.port ? ':' + location.port : ''}`,
         );
-        this._host; //?
       } else {
         this._host = new URL('https://icp-api.io');
         console.warn(


### PR DESCRIPTION
# Description

With the recent change to the default host in 0.19.1, the parsing logic was incorrectly not handling subdomains or ports correctly when determining whether the agent should use the current `location` as a host. 

This led to applications using a default asset canister configuration to make calls to icp-api.io, which is currently not configured under the content security policy in ic-assets.json.

These changes improve the logic and correctly use the host on local and network deployment when no `host` is specified.

# How Has This Been Tested?

New unit test cases. Also, was manually tested by installing a build to a fresh `dfx new` project and deploying locally and to mainnet.


# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
