### PR TITLE
feat: enhanced error message for missing canister id

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,7 +12,9 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
-        <li></li>
+        <li>
+          Adds more helpful error message for when principal is undefined during actor creation
+        </li>
       </ul>
       <h2>Version 0.19.2</h2>
       <ul>

--- a/packages/agent/src/actor.test.ts
+++ b/packages/agent/src/actor.test.ts
@@ -325,6 +325,18 @@ describe('makeActor', () => {
       );
     }
   });
+  it('should throw a helpful error if the canisterId is not set', async () => {
+    const httpAgent = new HttpAgent({ host: 'http://localhost' });
+    const actorInterface = () => {
+      return IDL.Service({
+        greet: IDL.Func([IDL.Text], [IDL.Text]),
+      });
+    };
+    const { Actor } = await importActor();
+    expect(() => Actor.createActor(actorInterface, { agent: httpAgent })).toThrowError(
+      'Canister ID is required, but recieved undefined instead. If you are using automatically generated declarations, this may be because your application is not setting the canister ID in process.env correctly.',
+    );
+  });
 });
 
 // TODO: tests for rejected, unknown time out

--- a/packages/agent/src/actor.test.ts
+++ b/packages/agent/src/actor.test.ts
@@ -6,6 +6,7 @@ import { CallRequest, SubmitRequestType, UnSigned } from './agent/http/types';
 import * as cbor from './cbor';
 import { requestIdOf } from './request_id';
 import * as pollingImport from './polling';
+import { ActorConfig } from './actor';
 
 const importActor = async (mockUpdatePolling?: () => void) => {
   jest.dontMock('./polling');
@@ -333,7 +334,8 @@ describe('makeActor', () => {
       });
     };
     const { Actor } = await importActor();
-    expect(() => Actor.createActor(actorInterface, { agent: httpAgent })).toThrowError(
+    const config = { agent: httpAgent } as any as ActorConfig;
+    expect(() => Actor.createActor(actorInterface, config)).toThrowError(
       'Canister ID is required, but recieved undefined instead. If you are using automatically generated declarations, this may be because your application is not setting the canister ID in process.env correctly.',
     );
   });

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -285,6 +285,10 @@ export class Actor {
       [x: string]: ActorMethod;
 
       constructor(config: ActorConfig) {
+        if (!config.canisterId)
+          throw new AgentError(
+            `Canister ID is required, but recieved ${typeof config.canisterId}} instead. If you are using automatically generated declarations, this may be because your application is not setting the canister ID in process.env correctly.`,
+          );
         const canisterId =
           typeof config.canisterId === 'string'
             ? Principal.fromText(config.canisterId)
@@ -316,6 +320,11 @@ export class Actor {
     interfaceFactory: IDL.InterfaceFactory,
     configuration: ActorConfig,
   ): ActorSubclass<T> {
+    if (!configuration.canisterId) {
+      throw new AgentError(
+        `Canister ID is required, but recieved ${typeof configuration.canisterId}} instead. If you are using automatically generated declarations, this may be because your application is not setting the canister ID in process.env correctly.`,
+      );
+    }
     return new (this.createActorClass(interfaceFactory))(
       configuration,
     ) as unknown as ActorSubclass<T>;

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -287,7 +287,7 @@ export class Actor {
       constructor(config: ActorConfig) {
         if (!config.canisterId)
           throw new AgentError(
-            `Canister ID is required, but recieved ${typeof config.canisterId}} instead. If you are using automatically generated declarations, this may be because your application is not setting the canister ID in process.env correctly.`,
+            `Canister ID is required, but recieved ${typeof config.canisterId} instead. If you are using automatically generated declarations, this may be because your application is not setting the canister ID in process.env correctly.`,
           );
         const canisterId =
           typeof config.canisterId === 'string'
@@ -322,7 +322,7 @@ export class Actor {
   ): ActorSubclass<T> {
     if (!configuration.canisterId) {
       throw new AgentError(
-        `Canister ID is required, but recieved ${typeof configuration.canisterId}} instead. If you are using automatically generated declarations, this may be because your application is not setting the canister ID in process.env correctly.`,
+        `Canister ID is required, but recieved ${typeof configuration.canisterId} instead. If you are using automatically generated declarations, this may be because your application is not setting the canister ID in process.env correctly.`,
       );
     }
     return new (this.createActorClass(interfaceFactory))(


### PR DESCRIPTION
# Description

As a common error, many users report getting `Impossible to convert undefined to Principal` without knowing what they need to do. This PR adds a more helpful error at the point of Actor creation, providing a more helpful suggestion for newer developers. For example: https://discord.com/channels/748416164832608337/748416164832608341/1145754858448756766

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
