### PR TITLE
feat: enhanced delegation enforcement checks

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm@9
+      - run: npm install -g npm
 
       - run: npm install
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm
+      - run: npm install -g npm@9
 
       - run: npm install
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         spec:
           - release-0.16 # https://github.com/dfinity-lab/ic-ref/tree/release-0.16
         node:
-          - 14
+          - 16
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install -g npm@9
+      - run: npm install -g npm
       - run: npm install
       - run: npm run lint --workspaces --if-present

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install -g npm
+      - run: npm install -g npm@9
       - run: npm install
       - run: npm run lint --workspaces --if-present

--- a/.github/workflows/mitm.yml
+++ b/.github/workflows/mitm.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm@9
+      - run: npm install -g npm
 
       - run: npm install
 

--- a/.github/workflows/mitm.yml
+++ b/.github/workflows/mitm.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm
+      - run: npm install -g npm@9
 
       - run: npm install
 

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -17,7 +17,7 @@ jobs:
         spec:
           - release-0.16 # https://github.com/dfinity-lab/ic-ref/tree/release-0.16
         node:
-          - 14
+          - 16
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install -g npm@9
+      - run: npm install -g npm
       - run: npm install prettier pretty-quick
       - run: npm run prettier:check
 

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install -g npm
+      - run: npm install -g npm@9
       - run: npm install prettier pretty-quick
       - run: npm run prettier:check
 

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -7,7 +7,7 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@v1
-      - run: npm install -g npm@9
+      - run: npm install -g npm
       # - run: npm run size-limit --workspaces --if-present
 
       # commented out until the job can be configured

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -7,7 +7,7 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@v1
-      - run: npm install -g npm
+      - run: npm install -g npm@9
       # - run: npm run size-limit --workspaces --if-present
 
       # commented out until the job can be configured

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm
+      - run: npm install -g npm@9
 
       - run: npm ci
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm
+      - run: npm install -g npm@9
 
       - run: npm ci
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,6 @@ jobs:
         spec:
           - '0.16.1'
         node:
-          - 14
           - 16
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm@9
+      - run: npm install -g npm
 
       - run: npm ci
 

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>chore: limit npm version to 9 in ci for compatibility with node 16</li>
         <li>
           Adds more helpful error message for when principal is undefined during actor creation
         </li>

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -16,6 +16,8 @@
         <li>
           Adds more helpful error message for when principal is undefined during actor creation
         </li>
+        <li>feat: DelegationChain audits for delegation targets and maximum delegations during
+          initialization</li>
       </ul>
       <h2>Version 0.19.2</h2>
       <ul>

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -704,10 +704,14 @@ describe('Migration from Ed25519Key', () => {
     jest.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
 
     // two days ago
-    const expiration = new Date('2019-12-30T00:00:00.000Z');
+    const properExpiration = new Date('2020-01-03T00:00:00.000Z');
+    const expiredExpiration = new Date('2019-12-30T00:00:00.000Z');
 
     const key = await Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
-    const chain = DelegationChain.create(key, key.getPublicKey(), expiration);
+    const chain = await DelegationChain.create(key, key.getPublicKey(), properExpiration);
+    // Override the expiration to be expired before storing
+    (chain.delegations[0].delegation as any).expiration =
+      BigInt(Number(expiredExpiration)) * BigInt(10000);
     const fakeStore: Record<any, any> = {};
     fakeStore[KEY_STORAGE_DELEGATION] = JSON.stringify((await chain).toJSON());
     fakeStore[KEY_STORAGE_KEY] = JSON.stringify(testSecrets);

--- a/packages/identity/src/identity/__snapshots__/delegation.test.ts.snap
+++ b/packages/identity/src/identity/__snapshots__/delegation.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Delegation can include multiple targets 1`] = `
+Object {
+  "expiration": "176bb3e7000",
+  "pubkey": "010203",
+  "targets": Array [
+    "00000000002000030101",
+    "000000000020008E0101",
+  ],
+}
+`;

--- a/packages/identity/src/identity/delegation.test.ts
+++ b/packages/identity/src/identity/delegation.test.ts
@@ -164,3 +164,29 @@ test('Delegation targets cannot exceed 1_000', () => {
     'Delegation targets cannot exceed 1000',
   );
 });
+
+test('Delegation chains cannot repeat public keys', async () => {
+  const root = createIdentity(0);
+  const middle = createIdentity(1);
+  const bottom = createIdentity(2);
+
+  const rootToMiddle = await DelegationChain.create(
+    root,
+    middle.getPublicKey(),
+    new Date(1609459200000),
+  );
+  const middleToBottom = await DelegationChain.create(
+    middle,
+    bottom.getPublicKey(),
+    new Date(1609459200000),
+    {
+      previous: rootToMiddle,
+    },
+  );
+
+  expect(
+    DelegationChain.create(bottom, root.getPublicKey(), new Date(1609459200000), {
+      previous: middleToBottom,
+    }),
+  ).rejects.toThrow('Delegation chain cannot repeat public keys');
+});

--- a/packages/identity/src/identity/delegation.test.ts
+++ b/packages/identity/src/identity/delegation.test.ts
@@ -2,7 +2,6 @@ import { SignIdentity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import { Delegation, DelegationChain } from './delegation';
 import { Ed25519KeyIdentity } from './ed25519';
-import { toHexString } from '../buffer';
 
 function createIdentity(seed: number): SignIdentity {
   const s = new Uint8Array([seed, ...new Array(31).fill(0)]);
@@ -163,14 +162,14 @@ test('Delegation chains cannot repeat public keys', async () => {
     DelegationChain.create(middle, bottom.getPublicKey(), expiry_date, {
       previous: middleToBottom,
     }),
-  ).rejects.toThrow('Cannot repeat public keys in a delegation chain.');
+  ).rejects.toThrow('Delegation target cannot be repeated in the chain.');
 
   // Repeating root's public key in the delegation chain should throw an error.
   expect(
     DelegationChain.create(root, bottom.getPublicKey(), expiry_date, {
       previous: middleToBottom,
     }),
-  ).rejects.toThrow('Cannot repeat public keys in a delegation chain.');
+  ).rejects.toThrow('Delegation target cannot be repeated in the chain.');
 });
 
 test('Cannot create a delegation chain with an outdated expiry', async () => {

--- a/packages/identity/src/identity/delegation.test.ts
+++ b/packages/identity/src/identity/delegation.test.ts
@@ -198,7 +198,7 @@ test('Cannot create a delegation chain with an outdated delegation', async () =>
   (rootToMiddle.delegations[0].delegation as any).expiration = BigInt(0);
 
   expect(
-    DelegationChain.create(middle, bottom.getPublicKey(), new Date(0), {
+    DelegationChain.create(middle, bottom.getPublicKey(), expiry_date, {
       previous: rootToMiddle,
     }),
   ).rejects.toThrow('Previous delegation in the chain has expired.');

--- a/packages/identity/src/identity/delegation.ts
+++ b/packages/identity/src/identity/delegation.ts
@@ -212,7 +212,7 @@ export class DelegationChain {
 
       // Ensure that public keys are not repeated in the chain.
       const usedPublicKeys = new Set<ArrayBuffer>();
-      let currentPublicKey = to.toDer();
+      usedPublicKeys.add(to.toDer());
 
       for (const delegation of options.previous.delegations) {
         // Ensure that previous delegations have not expired.

--- a/packages/identity/src/identity/delegation.ts
+++ b/packages/identity/src/identity/delegation.ts
@@ -225,8 +225,7 @@ export class DelegationChain {
         if (usedPublicKeys.has(currentPublicKey)) {
           throw new DelegationError('Delegation target cannot be repeated in the chain.');
         }
-        usedPublicKeys.add(currentPublicKey);
-        currentPublicKey = delegation.delegation.pubkey;
+        usedPublicKeys.add(delegation.delegation.pubkey);
       }
 
       // Ensure that the last public key in the chain not repeated.

--- a/packages/identity/src/identity/delegation.ts
+++ b/packages/identity/src/identity/delegation.ts
@@ -228,13 +228,6 @@ export class DelegationChain {
         usedPublicKeys.add(delegation.delegation.pubkey);
       }
 
-      // Ensure that the last public key in the chain not repeated.
-      if (usedPublicKeys.has(currentPublicKey)) {
-        throw new DelegationError('Error: Cannot repeat public keys in a delegation chain.', {
-          currentPublicKey,
-          usedPublicKeys,
-        });
-      }
     }
 
     const delegation = await _createSingleDelegation(from, to, expiration, options.targets);

--- a/packages/identity/src/identity/delegation.ts
+++ b/packages/identity/src/identity/delegation.ts
@@ -222,7 +222,7 @@ export class DelegationChain {
             delegation.delegation.expiration,
           );
         }
-        if (usedPublicKeys.has(currentPublicKey)) {
+        if (usedPublicKeys.has(delegation.delegation.pubkey)) {
           throw new DelegationError('Delegation target cannot be repeated in the chain.');
         }
         usedPublicKeys.add(delegation.delegation.pubkey);

--- a/packages/identity/src/identity/errors.ts
+++ b/packages/identity/src/identity/errors.ts
@@ -6,8 +6,11 @@ export class IdentityError extends Error {
 }
 
 export class DelegationError extends IdentityError {
-  constructor(public readonly message: string) {
+  constructor(public readonly message: string, loggedValue?: unknown) {
     super(message);
     Object.setPrototypeOf(this, DelegationError.prototype);
+    if (loggedValue) {
+      console.error(loggedValue);
+    }
   }
 }

--- a/packages/identity/src/identity/errors.ts
+++ b/packages/identity/src/identity/errors.ts
@@ -1,0 +1,13 @@
+export class IdentityError extends Error {
+  constructor(public readonly message: string) {
+    super(message);
+    Object.setPrototypeOf(this, IdentityError.prototype);
+  }
+}
+
+export class DelegationError extends IdentityError {
+  constructor(public readonly message: string) {
+    super(message);
+    Object.setPrototypeOf(this, DelegationError.prototype);
+  }
+}


### PR DESCRIPTION
# Description

So far, the JavaScript agent has not enforced checks around delegation constraints. This meant that developers had to encounter errors later in the development process, often with less helpful certificate errors. 

These changes introduce the following constraints, which now throw errors during the creation of a delegation chain:

- Expiration
- Max number of targets
- Max delegation chain length
- No longer allows repeats of public keys in the chain

This complies with the constraints indicated in the [Internet Computer Interface Specification](https://internetcomputer.org/docs/current/references/ic-interface-spec/#authentication)

Fixes # (issue)

# How Has This Been Tested?

New and updated unit tests

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
