### PR TITLE
chore: lock npm version for CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm
+      - run: npm install -g npm@9
 
       - run: npm install
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install -g npm
+      - run: npm install -g npm@9
       - run: npm install
       - run: npm run lint --workspaces --if-present

--- a/.github/workflows/mitm.yml
+++ b/.github/workflows/mitm.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm
+      - run: npm install -g npm@9
 
       - run: npm install
 

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install -g npm
+      - run: npm install -g npm@9
       - run: npm install prettier pretty-quick
       - run: npm run prettier:check
 

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -7,7 +7,7 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@v1
-      - run: npm install -g npm
+      - run: npm install -g npm@9
       # - run: npm run size-limit --workspaces --if-present
 
       # commented out until the job can be configured

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm
+      - run: npm install -g npm@9
 
       - run: npm ci
 

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>chore: limit npm version to 9 in ci for compatibility with node 16</li>
         <li>
           Adds more helpful error message for when principal is undefined during actor creation
         </li>


### PR DESCRIPTION
# Description

CI started failing after running `npm i -g npm` because version 10 is not compatible with node 16

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
