### PR TITLE
fix: bigint toJson trailing space

### DIFF
--- a/packages/identity/src/identity/delegation.ts
+++ b/packages/identity/src/identity/delegation.ts
@@ -205,7 +205,7 @@ export class DelegationChain {
       return {
         delegation: new Delegation(
           _parseBlob(pubkey),
-          BigInt(`0x${expiration}`), // expiration in JSON is an hexa string (See toJSON() below).
+          BigInt('0x' + expiration), // expiration in JSON is an hexa string (See toJSON() below).
           targets &&
             targets.map((t: unknown) => {
               if (typeof t !== 'string') {


### PR DESCRIPTION
Template literal was compiling incorrectly, causing a space to be added in the middle of the BigInt conversion of DelegationChain.fromJson(), causing a throw on AuthClient.create(), causing _deleteStorage() to be called, preventing some users from remaining authenticated to call anything after connecting.

# Description

...

Fixes # (issue)

Users not being able to make calls after an otherwise successful connect.

# How Has This Been Tested?

Chrome v116, manual e2e testing found the error on connecting to stoic wallet with affected version of Chrome, the pathway of the throw explains the condition users not being able to make calls, unverified if it solves the problem but it looks like it should. Chrome v117 (beta) does not have this issue on most devices.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
