### PR TITLE
wip: bigint decoding

### DIFF
--- a/packages/agent/src/cbor.test.ts
+++ b/packages/agent/src/cbor.test.ts
@@ -60,3 +60,43 @@ function buf2hex(buffer: Uint8Array) {
   // join the elements.
   return Array.prototype.map.call(buffer, x => ('00' + x.toString(16)).slice(-2)).join('');
 }
+
+describe('encode + decode numbers', () => {
+  it('should handle 0', () => {
+    expect(decode(encode(0))).toBe(0);
+  });
+  it('should handle 1', () => {
+    expect(decode(encode(1))).toBe(1);
+  });
+  it('should handle -1', () => {
+    expect(decode(encode(-1))).toBe(-1);
+  });
+  it('should handle 255', () => {
+    expect(decode(encode(255))).toBe(255);
+  });
+  it('should handle 256', () => {
+    expect(decode(encode(256))).toBe(256);
+  });
+  it('should handle 65535', () => {
+    expect(decode(encode(65535))).toBe(65535);
+  });
+  it('should handle 65536', () => {
+    expect(decode(encode(65536))).toBe(65536);
+  });
+  it('should handle 4294967295', () => {
+    expect(decode(encode(4294967295))).toBe(4294967295);
+  });
+  it('should handle 4294967296', () => {
+    expect(decode(encode(4294967296))).toBe(4294967296);
+  });
+  it('should handle 18446744073709551615n', () => {
+    expect(decode(encode(BigInt('18446744073709551615')))).toBe(BigInt('18446744073709551615'));
+  });
+  it('should encode 0n', () => {
+    expect(decode(encode(0n))).toBe(0n);
+  });
+  it('should encode 1n', () => {
+    // Is this valid?
+    expect(decode(encode(1n))).toBe(1);
+  });
+});


### PR DESCRIPTION
# Description

Currently, attempting to encode a small BigInt value throws errors, and makes serialization difficult.

This approach encodes numbers between positive and negative `Number.MAX_SAFE_INTEGER` as a Number when serializing to CBOR. However, this strategy doesn't allow them to be deserialized as BigInt. Is this a valid approach?

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
