### PR TITLE
feat: Principal class serializes to JSON

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>feat: Principal class serializes to JSON</li>
         <li>
           feat: certificate checks validate that certificate time is not more than 5 minutes ahead
           of or behind system time.

--- a/packages/agent/src/canisterStatus/__snapshots__/index.test.ts.snap
+++ b/packages/agent/src/canisterStatus/__snapshots__/index.test.ts.snap
@@ -2,21 +2,7 @@
 
 exports[`Canister Status utility should query canister controllers 1`] = `
 Array [
-  Principal {
-    "_arr": Uint8Array [
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      1,
-      1,
-    ],
-    "_isPrincipal": true,
-  },
+  "rwlgt-iiaaa-aaaaa-aaaaa-cai",
 ]
 `;
 
@@ -36,21 +22,7 @@ exports[`Canister Status utility should support multiple requests 1`] = `2022-05
 
 exports[`Canister Status utility should support multiple requests 2`] = `
 Array [
-  Principal {
-    "_arr": Uint8Array [
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      1,
-      1,
-    ],
-    "_isPrincipal": true,
-  },
+  "rwlgt-iiaaa-aaaaa-aaaaa-cai",
 ]
 `;
 

--- a/packages/principal/src/index.test.ts
+++ b/packages/principal/src/index.test.ts
@@ -41,4 +41,15 @@ describe('Principal', () => {
     expect(anonymous.compareTo(principal1)).toBe('gt');
     expect(anonymous.compareTo(principal2)).toBe('gt');
   });
+
+  it('serializes to String constructor', () => {
+    const principal = Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai');
+    expect(principal.toString()).toBe('ryjl3-tyaaa-aaaaa-aaaba-cai');
+    expect(String(principal)).toBe('ryjl3-tyaaa-aaaaa-aaaba-cai');
+  });
+
+  it('serializes to JSON', () => {
+    const principal = Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai');
+    expect(JSON.stringify(principal)).toBe('"ryjl3-tyaaa-aaaaa-aaaba-cai"');
+  });
 });

--- a/packages/principal/src/index.ts
+++ b/packages/principal/src/index.ts
@@ -108,6 +108,14 @@ export class Principal {
   }
 
   /**
+   * Serializes to JSON
+   * @returns {string} string
+   */
+  public toJSON(): string {
+    return this.toText();
+  }
+
+  /**
    * Utility method taking a Principal to compare against. Used for determining canister ranges in certificate verification
    * @param {Principal} other - a {@link Principal} to compare
    * @returns {'lt' | 'eq' | 'gt'} `'lt' | 'eq' | 'gt'` a string, representing less than, equal to, or greater than


### PR DESCRIPTION
# Description

`JSON.stringify(principal)` currently uses `Uint8Array` encoding instead of `toString`. Adding the `toJSON` method resolves this

# How Has This Been Tested?

new unit tests

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
