### PR TITLE
fix: Principal JSON is compatible with @dfinity/utils jsonReviver helper

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>fix: Principal JSON is compatible with @dfinity/utils jsonReviver helper</li>
         <li>feat: Principal class serializes to JSON</li>
         <li>
           feat: certificate checks validate that certificate time is not more than 5 minutes ahead

--- a/package-lock.json
+++ b/package-lock.json
@@ -771,6 +771,17 @@
       "resolved": "packages/principal",
       "link": true
     },
+    "node_modules/@dfinity/utils": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.22.tgz",
+      "integrity": "sha512-NmMyNik0Lz5QFil+9BSfKOsCaUIWqwMsjxkyknfBOh12dAltDxc9xvyZmYh7Ug/0Bpw6qQEZMcCjnXce61MARQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@dfinity/agent": "^0.19.2",
+        "@dfinity/candid": "^0.19.2",
+        "@dfinity/principal": "^0.19.2"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "dev": true,
@@ -17725,6 +17736,7 @@
         "simple-cbor": "^0.4.1"
       },
       "devDependencies": {
+        "@dfinity/utils": "^0.0.22",
         "@peculiar/webcrypto": "^1.4.3",
         "@trust/webcrypto": "^0.9.2",
         "@types/jest": "^28.1.4",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -60,6 +60,7 @@
     "simple-cbor": "^0.4.1"
   },
   "devDependencies": {
+    "@dfinity/utils": "^0.0.22",
     "@peculiar/webcrypto": "^1.4.3",
     "@trust/webcrypto": "^0.9.2",
     "@types/jest": "^28.1.4",

--- a/packages/agent/src/canisterStatus/__snapshots__/index.test.ts.snap
+++ b/packages/agent/src/canisterStatus/__snapshots__/index.test.ts.snap
@@ -2,7 +2,9 @@
 
 exports[`Canister Status utility should query canister controllers 1`] = `
 Array [
-  "rwlgt-iiaaa-aaaaa-aaaaa-cai",
+  Object {
+    "__principal__": "rwlgt-iiaaa-aaaaa-aaaaa-cai",
+  },
 ]
 `;
 
@@ -22,7 +24,9 @@ exports[`Canister Status utility should support multiple requests 1`] = `2022-05
 
 exports[`Canister Status utility should support multiple requests 2`] = `
 Array [
-  "rwlgt-iiaaa-aaaaa-aaaaa-cai",
+  Object {
+    "__principal__": "rwlgt-iiaaa-aaaaa-aaaaa-cai",
+  },
 ]
 `;
 

--- a/packages/principal/src/index.test.ts
+++ b/packages/principal/src/index.test.ts
@@ -60,4 +60,11 @@ describe('Principal', () => {
 
     expect(JSON.parse(stringified, jsonReviver)).toEqual(principal);
   });
+
+  it('serializes from JSON string', () => {
+    const principal = Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai');
+    const json = JSON.stringify(principal);
+    json;
+    expect(Principal.from(json)).toEqual(principal);
+  });
 });

--- a/packages/principal/src/index.test.ts
+++ b/packages/principal/src/index.test.ts
@@ -1,4 +1,5 @@
 import { Principal } from '.';
+import { jsonReviver } from '@dfinity/utils';
 
 describe('Principal', () => {
   it('encodes properly', () => {
@@ -50,6 +51,13 @@ describe('Principal', () => {
 
   it('serializes to JSON', () => {
     const principal = Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai');
-    expect(JSON.stringify(principal)).toBe('"ryjl3-tyaaa-aaaaa-aaaba-cai"');
+
+    const json = principal.toJSON();
+    expect(json).toEqual({ __principal__: 'ryjl3-tyaaa-aaaaa-aaaba-cai' });
+
+    const stringified = JSON.stringify(principal);
+    expect(stringified).toEqual('{"__principal__":"ryjl3-tyaaa-aaaaa-aaaba-cai"}');
+
+    expect(JSON.parse(stringified, jsonReviver)).toEqual(principal);
   });
 });


### PR DESCRIPTION
# Description

@peterpeterparker brought up compatibility with `@dfinity/utils` in #766, and I agreed that we should use that standard for more concrete serialization. Instead of the string, will instead return an object,
```
{"__principal__":"ryjl3-tyaaa-aaaaa-aaaba-cai"}
```
matching a newly exported key, `JSON_KEY_PRINCIPAL`, and a returning a new type, `JsonnablePrincipal`.

Also extends the `fromText` and `from` constructors to support strings using the JSON-serialized principals

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
