### PR TITLE
chore: increases size limit for agent-js

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -13,6 +13,10 @@
       <h2>Version x.x.x</h2>
       <ul>
         <li>
+          chore: increases size limit for agent-js to allow for Ed25519 support for node key
+          signature verification
+        </li>
+        <li>
           feat!: replaces disableNonce feature with useQueryNonces. Going forward, updates will use
           nonces, but queries and readstate calls will not. Queries and readsatate calls will use
           nonces if `useQueryNonces` is set to true

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     {
       "name": "@dfinity/candid",
       "path": "./packages/candid/dist/index.js",
-      "limit": "2 kb"
+      "limit": "20 kb"
     },
     {
       "name": "@dfinity/principal",
@@ -112,7 +112,7 @@
     {
       "name": "@dfinity/identity-secp256k1",
       "path": "./packages/identity-secp256k1/dist/index.js",
-      "limit": "260 kB"
+      "limit": "260kb"
     }
   ],
   "release-it": {

--- a/package.json
+++ b/package.json
@@ -82,11 +82,12 @@
     {
       "name": "@dfinity/agent",
       "path": "./packages/agent/dist/index.js",
-      "limit": "100 kB"
+      "limit": "105 kB"
     },
     {
       "name": "@dfinity/candid",
-      "path": "./packages/candid/dist/index.js"
+      "path": "./packages/candid/dist/index.js",
+      "limit": "2 kb"
     },
     {
       "name": "@dfinity/principal",
@@ -111,7 +112,7 @@
     {
       "name": "@dfinity/identity-secp256k1",
       "path": "./packages/identity-secp256k1/dist/index.js",
-      "limit": "250 kB"
+      "limit": "260 kB"
     }
   ],
   "release-it": {


### PR DESCRIPTION
# Description

increases size limit for agent-js to allow for Ed25519 support for node key signature verification

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
