### PR TITLE
fix: canisterStatus returns full list of controllers

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>fix: canisterStatus returns full list of controllers</li>
         <ul>
           <strong>feat!: node signature verification</strong
           ><br />

--- a/e2e/node/basic/mainnet.test.ts
+++ b/e2e/node/basic/mainnet.test.ts
@@ -118,6 +118,7 @@ describe('controllers', () => {
   it('should return the controllers of a canister with multiple controllers', async () => {
     const agent = new HttpAgent({ host: 'https://icp-api.io' });
     const status = await CanisterStatus.request({
+      // Whoami canister
       canisterId: Principal.from('ivcos-eqaaa-aaaab-qablq-cai'),
       agent: agent,
       paths: ['controllers'],
@@ -134,14 +135,28 @@ describe('controllers', () => {
   it('should return the controllers of a canister with one controller', async () => {
     const agent = new HttpAgent({ host: 'https://icp-api.io' });
     const status = await CanisterStatus.request({
+      // NNS Governance Canister
       canisterId: Principal.from('rrkah-fqaaa-aaaaa-aaaaq-cai'),
       agent: agent,
       paths: ['controllers'],
     });
+    // Should be root canister
     expect((status.get('controllers') as Principal[]).map(p => p.toText())).toMatchInlineSnapshot(`
     [
       "r7inp-6aaaa-aaaaa-aaabq-cai",
     ]
+  `);
+  });
+  it('should return the controllers of a canister with no controllers', async () => {
+    const agent = new HttpAgent({ host: 'https://icp-api.io' });
+    const status = await CanisterStatus.request({
+      // nomeata's capture-the-ic-token canister
+      canisterId: Principal.from('fj6bh-taaaa-aaaab-qaacq-cai'),
+      agent: agent,
+      paths: ['controllers'],
+    });
+    expect((status.get('controllers') as Principal[]).map(p => p.toText())).toMatchInlineSnapshot(`
+    []
   `);
   });
 });

--- a/e2e/node/basic/mainnet.test.ts
+++ b/e2e/node/basic/mainnet.test.ts
@@ -1,8 +1,8 @@
-import { Actor, AnonymousIdentity, HttpAgent, Identity } from '@dfinity/agent';
+import { Actor, AnonymousIdentity, HttpAgent, Identity, CanisterStatus } from '@dfinity/agent';
 import { IDL } from '@dfinity/candid';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { Principal } from '@dfinity/principal';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, test, vi } from 'vitest';
 import { makeAgent } from '../utils/agent';
 
 const createWhoamiActor = async (identity: Identity) => {
@@ -111,5 +111,37 @@ describe('certified query', () => {
         },
       ]
     `);
+  });
+});
+
+describe('controllers', () => {
+  it('should return the controllers of a canister with multiple controllers', async () => {
+    const agent = new HttpAgent({ host: 'https://icp-api.io' });
+    const status = await CanisterStatus.request({
+      canisterId: Principal.from('ivcos-eqaaa-aaaab-qablq-cai'),
+      agent: agent,
+      paths: ['controllers'],
+    });
+    expect((status.get('controllers') as Principal[]).map(p => p.toText())).toMatchInlineSnapshot(`
+    [
+      "hgfyw-myaaa-aaaab-qaaoa-cai",
+      "b73qn-rqaaa-aaaap-aazvq-cai",
+      "aux4w-bi6yf-a3bhr-zydhx-qvf2p-ymdeg-ddvg6-gmobi-ct4dk-wf4xd-nae",
+      "jhnlf-yu2dz-v7beb-c77gl-76tj7-shaqo-5qfvi-htvel-gzamb-bvzx6-yqe",
+    ]
+  `);
+  });
+  it('should return the controllers of a canister with one controller', async () => {
+    const agent = new HttpAgent({ host: 'https://icp-api.io' });
+    const status = await CanisterStatus.request({
+      canisterId: Principal.from('rrkah-fqaaa-aaaaa-aaaaq-cai'),
+      agent: agent,
+      paths: ['controllers'],
+    });
+    expect((status.get('controllers') as Principal[]).map(p => p.toText())).toMatchInlineSnapshot(`
+    [
+      "r7inp-6aaaa-aaaaa-aaabq-cai",
+    ]
+  `);
   });
 });

--- a/packages/agent/src/canisterStatus/__snapshots__/index.test.ts.snap
+++ b/packages/agent/src/canisterStatus/__snapshots__/index.test.ts.snap
@@ -3,6 +3,9 @@
 exports[`Canister Status utility should query canister controllers 1`] = `
 Array [
   Object {
+    "__principal__": "2vxsx-fae",
+  },
+  Object {
     "__principal__": "rwlgt-iiaaa-aaaaa-aaaaa-cai",
   },
 ]
@@ -24,6 +27,9 @@ exports[`Canister Status utility should support multiple requests 1`] = `2022-05
 
 exports[`Canister Status utility should support multiple requests 2`] = `
 Array [
+  Object {
+    "__principal__": "2vxsx-fae",
+  },
   Object {
     "__principal__": "rwlgt-iiaaa-aaaaa-aaaaa-cai",
   },

--- a/packages/agent/src/canisterStatus/index.ts
+++ b/packages/agent/src/canisterStatus/index.ts
@@ -349,10 +349,10 @@ const decodeUtf8 = (buf: ArrayBuffer): string => {
   return new TextDecoder().decode(buf);
 };
 
-// Controllers are CBOR-encoded buffers, starting with a Tag we don't need
+// Controllers are CBOR-encoded buffers
 const decodeControllers = (buf: ArrayBuffer): Principal[] => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [tag, ...controllersRaw] = decodeCbor(buf);
+  const controllersRaw = decodeCbor(buf);
   return controllersRaw.map((buf: ArrayBuffer) => {
     return Principal.fromUint8Array(new Uint8Array(buf));
   });


### PR DESCRIPTION
# Description

We had a bug noted where not all controllers were being reported. This fixes the issue and adds tests against mainnet

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
