### PR TITLE
feat: retry query signature verification in case cache is stale

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,10 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>feat: retry query signature verification in case cache is stale</li>
+      </ul> 
+      <h2>Version 0.20.0</h2>
+      <ul>
         <li>feat: uses expirable map for subnet keys in agent-js, with a timeout of 1 hour</li>
         <li>chore: cleanup for node 20 development in agent-js</li>
         <li>fix: canisterStatus returns full list of controllers</li>

--- a/e2e/node/basic/mitm.test.ts
+++ b/e2e/node/basic/mitm.test.ts
@@ -6,19 +6,19 @@ let mitmTest: TestAPI | typeof test.skip = test;
 if (!process.env['MITM']) {
   mitmTest = test.skip;
 }
-mitmTest(
-  'mitm greet',
-  async () => {
-    const counter = await createActor('tnnnb-2yaaa-aaaab-qaiiq-cai', {
-      agent: await makeAgent({
-        host: 'http://127.0.0.1:8888',
-      }),
-    });
-    await expect(counter.greet('counter')).rejects.toThrow(/Invalid certificate/);
-    expect(await counter.queryGreet('counter')).toEqual('Hullo, counter!');
-  },
-  { timeout: 30000 },
-);
+// mitmTest(
+//   'mitm greet',
+//   async () => {
+//     const counter = await createActor('tnnnb-2yaaa-aaaab-qaiiq-cai', {
+//       agent: await makeAgent({
+//         host: 'http://127.0.0.1:8888',
+//       }),
+//     });
+//     await expect(counter.greet('counter')).rejects.toThrow(/Invalid certificate/);
+//     expect(await counter.queryGreet('counter')).toEqual('Hullo, counter!');
+//   },
+//   { timeout: 30000 },
+// );
 
 mitmTest('mitm with query verification', async () => {
   const counter = await createActor('tnnnb-2yaaa-aaaab-qaiiq-cai', {

--- a/e2e/node/basic/mitm.test.ts
+++ b/e2e/node/basic/mitm.test.ts
@@ -6,19 +6,19 @@ let mitmTest: TestAPI | typeof test.skip = test;
 if (!process.env['MITM']) {
   mitmTest = test.skip;
 }
-// mitmTest(
-//   'mitm greet',
-//   async () => {
-//     const counter = await createActor('tnnnb-2yaaa-aaaab-qaiiq-cai', {
-//       agent: await makeAgent({
-//         host: 'http://127.0.0.1:8888',
-//       }),
-//     });
-//     await expect(counter.greet('counter')).rejects.toThrow(/Invalid certificate/);
-//     expect(await counter.queryGreet('counter')).toEqual('Hullo, counter!');
-//   },
-//   { timeout: 30000 },
-// );
+mitmTest(
+  'mitm greet',
+  async () => {
+    const counter = await createActor('tnnnb-2yaaa-aaaab-qaiiq-cai', {
+      agent: await makeAgent({
+        host: 'http://127.0.0.1:8888',
+      }),
+    });
+    await expect(counter.greet('counter')).rejects.toThrow(/Invalid certificate/);
+    expect(await counter.queryGreet('counter')).toEqual('Hullo, counter!');
+  },
+  { timeout: 30000 },
+);
 
 mitmTest('mitm with query verification', async () => {
   const counter = await createActor('tnnnb-2yaaa-aaaab-qaiiq-cai', {

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -790,3 +790,5 @@ test('retry requests that fail due to a network failure', async () => {
     expect(mockFetch.mock.calls.length).toBe(4);
   }
 });
+
+test.todo('retry query signature validation after refreshing the subnet node keys');


### PR DESCRIPTION
# Description

Because a node can be upgraded while the cache is stale, we should retry a failed query signature verification once, after refreshing the cache

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
