### PR TITLE
fix: restoring localhost to list of known hosts

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,10 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul></ul>
+      <h2>Version 0.20.2</h2>
+      <ul>
+        <li>fix: restoring localhost to list of known hosts</li>
+      </ul>
       <h2>Version 0.20.1</h2>
       <ul>
         <li>feat: retry query signature verification in case cache is stale</li>

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -224,7 +224,7 @@ export class HttpAgent implements Agent {
         );
       }
       // Mainnet and local will have the api route available
-      const knownHosts = ['ic0.app', 'icp0.io', '127.0.0.1', '127.0.0.1'];
+      const knownHosts = ['ic0.app', 'icp0.io', '127.0.0.1', '127.0.0.1', 'localhost'];
       const hostname = location?.hostname;
       let knownHost;
       if (hostname && typeof hostname === 'string') {

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -224,7 +224,7 @@ export class HttpAgent implements Agent {
         );
       }
       // Mainnet and local will have the api route available
-      const knownHosts = ['ic0.app', 'icp0.io', '127.0.0.1', '127.0.0.1', 'localhost'];
+      const knownHosts = ['ic0.app', 'icp0.io', '127.0.0.1', 'localhost'];
       const hostname = location?.hostname;
       let knownHost;
       if (hostname && typeof hostname === 'string') {


### PR DESCRIPTION
# Description

It's unclear where this regression began, but obviously `localhost` should have been in the list instead of a duplicated `127.0.0.1`. Resolves the mysterious `subnet_not_found` error from local development while using `localhost` domain

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
