### PR TITLE
fix: honor disableIdle flag

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -11,7 +11,9 @@
 
     <section>
       <h2>Version x.x.x</h2>
-      <ul></ul>
+      <ul>
+        <li>fix: honor disableIdle flag</li>
+      </ul>
       <h2>Version 0.20.2</h2>
       <ul>
         <li>chore: lowering prettier version for CI</li>

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -340,7 +340,6 @@ export class AuthClient {
      */
     if (!idleOptions?.onIdle && !idleOptions?.disableDefaultIdleCallback) {
       this.idleManager?.registerCallback(() => {
-        console.log('User is idle. Logging out.');
         this.logout();
         location.reload();
       });

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -329,15 +329,19 @@ export class AuthClient {
     // The event handler for processing events from the IdP.
     private _eventHandler?: (event: MessageEvent) => void,
   ) {
-    const logout = this.logout.bind(this);
-    const idleOptions = _createOptions?.idleOptions;
+    this._registerDefaultIdleCallback();
+  }
+
+  private _registerDefaultIdleCallback() {
+    const idleOptions = this._createOptions?.idleOptions;
     /**
      * Default behavior is to clear stored identity and reload the page.
      * By either setting the disableDefaultIdleCallback flag or passing in a custom idle callback, we will ignore this config
      */
     if (!idleOptions?.onIdle && !idleOptions?.disableDefaultIdleCallback) {
       this.idleManager?.registerCallback(() => {
-        logout();
+        console.log('User is idle. Logging out.');
+        this.logout();
         location.reload();
       });
     }
@@ -372,17 +376,14 @@ export class AuthClient {
     this._identity = DelegationIdentity.fromDelegation(key, this._chain);
 
     this._idpWindow?.close();
-    if (!this.idleManager) {
-      const idleOptions = this._createOptions?.idleOptions;
+    const idleOptions = this._createOptions?.idleOptions;
+    // create the idle manager on a successful login if we haven't disabled it
+    // and it doesn't already exist.
+    if (!this.idleManager && !idleOptions?.disableIdle) {
       this.idleManager = IdleManager.create(idleOptions);
-
-      if (!idleOptions?.onIdle && !idleOptions?.disableDefaultIdleCallback) {
-        this.idleManager?.registerCallback(() => {
-          this.logout();
-          location.reload();
-        });
-      }
+      this._registerDefaultIdleCallback();
     }
+
     this._removeEventListener();
     delete this._idpWindow;
 


### PR DESCRIPTION
# Description

Correctly honor `disableIdle` flag for the idle manager.

Fixes # (576)

https://github.com/dfinity/agent-js/issues/576

# How Has This Been Tested?

Do not created the idle manager if `disableIdle` flag is passed on successful login. Tested this via usage in DSCVR.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
