### PR TITLE
feat: introduces partial identity

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>feat: introduces partial identities from public keys for authentication flows</li>
         <li>fix: honor disableIdle flag</li>
       </ul>
       <h2>Version 0.20.2</h2>

--- a/packages/identity/src/identity/delegation.ts
+++ b/packages/identity/src/identity/delegation.ts
@@ -10,6 +10,7 @@ import {
 } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import * as cbor from 'simple-cbor';
+import { PartialIdentity } from './partial';
 
 const domainSeparator = new TextEncoder().encode('\x1Aic-request-auth-delegation');
 const requestDomainSeparator = new TextEncoder().encode('\x0Aic-request');
@@ -310,6 +311,81 @@ export class DelegationIdentity extends SignIdentity {
         sender_pubkey: this._delegation.publicKey,
       },
     };
+  }
+}
+
+/**
+ * A partial delegated identity, representing a delegation chain and the public key that it targets
+ */
+export class PartialDelegationIdentity extends PartialIdentity {
+  #inner: PublicKey;
+  #delegation: DelegationChain;
+
+  /**
+   * The raw public key of this identity.
+   */
+  get rawKey(): ArrayBuffer | undefined {
+    return this.#inner.rawKey;
+  }
+
+  /**
+   * The DER-encoded public key of this identity.
+   */
+  get derKey(): ArrayBuffer | undefined {
+    return this.#inner.derKey;
+  }
+
+  /**
+   * The delegation chain of this identity.
+   */
+  get delegation(): DelegationChain {
+    return this.#delegation;
+  }
+
+  /**
+   * The DER-encoded public key of this identity.
+   */
+  public toDer(): ArrayBuffer {
+    return this.#inner.toDer();
+  }
+
+  /**
+   * The inner {@link PublicKey} used by this identity.
+   */
+  public getPublicKey(): PublicKey {
+    return this.#inner;
+  }
+
+  /**
+   * The {@link Principal} of this identity.
+   */
+  public getPrincipal(): Principal {
+    return Principal.from(this.#inner.rawKey);
+  }
+
+  /**
+   * Required for the Identity interface, but cannot implemented for just a public key.
+   */
+  public transformRequest(): Promise<never> {
+    throw new Error(
+      'Not implemented. You are attempting to use a partial identity to sign calls, but this identity only has access to the public key.To sign calls, use a DelegationIdentity instead.',
+    );
+  }
+
+  private constructor(inner: PublicKey, delegation: DelegationChain) {
+    super(inner);
+    this.#inner = inner;
+    this.#delegation = delegation;
+  }
+
+  /**
+   * Create a {@link PartialDelegationIdentity} from a {@link PublicKey} and a {@link DelegationChain}.
+   * @param key The {@link PublicKey} to delegate to.
+   * @param delegation a {@link DelegationChain} targeting the inner key.
+   * @constructs PartialDelegationIdentity
+   */
+  public static fromDelegation(key: PublicKey, delegation: DelegationChain) {
+    return new PartialDelegationIdentity(key, delegation);
   }
 }
 

--- a/packages/identity/src/identity/delegation.ts
+++ b/packages/identity/src/identity/delegation.ts
@@ -318,63 +318,17 @@ export class DelegationIdentity extends SignIdentity {
  * A partial delegated identity, representing a delegation chain and the public key that it targets
  */
 export class PartialDelegationIdentity extends PartialIdentity {
-  #inner: PublicKey;
   #delegation: DelegationChain;
 
   /**
-   * The raw public key of this identity.
-   */
-  get rawKey(): ArrayBuffer | undefined {
-    return this.#inner.rawKey;
-  }
-
-  /**
-   * The DER-encoded public key of this identity.
-   */
-  get derKey(): ArrayBuffer | undefined {
-    return this.#inner.derKey;
-  }
-
-  /**
-   * The delegation chain of this identity.
+   * The Delegation Chain of this identity.
    */
   get delegation(): DelegationChain {
     return this.#delegation;
   }
 
-  /**
-   * The DER-encoded public key of this identity.
-   */
-  public toDer(): ArrayBuffer {
-    return this.#inner.toDer();
-  }
-
-  /**
-   * The inner {@link PublicKey} used by this identity.
-   */
-  public getPublicKey(): PublicKey {
-    return this.#inner;
-  }
-
-  /**
-   * The {@link Principal} of this identity.
-   */
-  public getPrincipal(): Principal {
-    return Principal.from(this.#inner.rawKey);
-  }
-
-  /**
-   * Required for the Identity interface, but cannot implemented for just a public key.
-   */
-  public transformRequest(): Promise<never> {
-    throw new Error(
-      'Not implemented. You are attempting to use a partial identity to sign calls, but this identity only has access to the public key.To sign calls, use a DelegationIdentity instead.',
-    );
-  }
-
   private constructor(inner: PublicKey, delegation: DelegationChain) {
     super(inner);
-    this.#inner = inner;
     this.#delegation = delegation;
   }
 

--- a/packages/identity/src/identity/partial.test.ts
+++ b/packages/identity/src/identity/partial.test.ts
@@ -1,0 +1,35 @@
+import { HttpAgent } from '@dfinity/agent';
+import { Ed25519PublicKey } from '../identity/ed25519';
+import { PartialIdentity } from './partial';
+describe('Partial Identity', () => {
+  it('should create a partial identity from a public key', async () => {
+    const key = Ed25519PublicKey.fromRaw(new Uint8Array(32).fill(0));
+    const partial = new PartialIdentity(key);
+
+    const agent = new HttpAgent({ identity: partial });
+    expect((await agent.getPrincipal()).toText()).toBe(
+      'deffl-liaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-aaa',
+    );
+
+    const rawKey = partial.rawKey;
+    expect(rawKey).toBeDefined();
+
+    const derKey = partial.derKey;
+    expect(derKey).toBeDefined();
+
+    const toDer = partial.toDer();
+    expect(toDer).toBeDefined();
+    expect(toDer).toEqual(derKey);
+
+    const publicKey = partial.getPublicKey();
+    expect(publicKey).toBeDefined();
+    expect(publicKey).toEqual(key);
+  });
+  it('should throw an error when attempting to sign', async () => {
+    const key = Ed25519PublicKey.fromRaw(new Uint8Array(32).fill(0));
+    const partial = new PartialIdentity(key);
+    await partial.transformRequest().catch(e => {
+      expect(e).toContain('Not implemented.');
+    });
+  });
+});

--- a/packages/identity/src/identity/partial.ts
+++ b/packages/identity/src/identity/partial.ts
@@ -46,7 +46,7 @@ export class PartialIdentity implements Identity {
    * Required for the Identity interface, but cannot implemented for just a public key.
    */
   public transformRequest(): Promise<never> {
-    throw new Error(
+    return Promise.reject(
       'Not implemented. You are attempting to use a partial identity to sign calls, but this identity only has access to the public key.To sign calls, use a DelegationIdentity instead.',
     );
   }

--- a/packages/identity/src/identity/partial.ts
+++ b/packages/identity/src/identity/partial.ts
@@ -1,0 +1,57 @@
+import { Identity, PublicKey } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
+
+/**
+ * A partial delegated identity, representing a delegation chain and the public key that it targets
+ */
+export class PartialIdentity implements Identity {
+  #inner: PublicKey;
+
+  /**
+   * The raw public key of this identity.
+   */
+  get rawKey(): ArrayBuffer | undefined {
+    return this.#inner.rawKey;
+  }
+
+  /**
+   * The DER-encoded public key of this identity.
+   */
+  get derKey(): ArrayBuffer | undefined {
+    return this.#inner.derKey;
+  }
+
+  /**
+   * The DER-encoded public key of this identity.
+   */
+  public toDer(): ArrayBuffer {
+    return this.#inner.toDer();
+  }
+
+  /**
+   * The inner {@link PublicKey} used by this identity.
+   */
+  public getPublicKey(): PublicKey {
+    return this.#inner;
+  }
+
+  /**
+   * The {@link Principal} of this identity.
+   */
+  public getPrincipal(): Principal {
+    return Principal.from(this.#inner.rawKey);
+  }
+
+  /**
+   * Required for the Identity interface, but cannot implemented for just a public key.
+   */
+  public transformRequest(): Promise<never> {
+    throw new Error(
+      'Not implemented. You are attempting to use a partial identity to sign calls, but this identity only has access to the public key.To sign calls, use a DelegationIdentity instead.',
+    );
+  }
+
+  constructor(inner: PublicKey) {
+    this.#inner = inner;
+  }
+}


### PR DESCRIPTION
# Description

To get a delegation from Internet Identity, the Auth Client allowed the developer to initialize the client using an existing identity. However, since the delegation can target any public key, it can be useful to allow the client to accept a "partial" identity class without a private key.

Introduces the `PartialIdentity` and `PartialDelegationIdentity` classes in `@dfinity/identity`, which can now be passed into `AuthClient.create`

This will be useful to remove the limitations such as adding an intermediary identity, as used by our deep link example: https://github.com/dfinity/examples/blob/c62de1a928fa0bf6b8fdbbbf0e0204e7cf5d6dfb/native-apps/unity_ii_applink/ii_integration_dapp/src/greet_frontend/src/index.js#L49

# How Has This Been Tested?

New Unit tests

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
