### PR TITLE
chore: GitHub actions warning cleanup

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>chore: cleans up github actions linting warnings</li>
         <li>feat: replaces `secp256k1` npm package with `@noble/curves`</li>
         <li>feat: enhances `.from` methods on public key classes to support unknown types, including PublicKey instances, ArrayBuffer-like objects, DER encoded public keys, and hex strings. Also introduces a new `bufFromBufLike` util</li>
         <li>feat: introduces partial identities from public keys for authentication flows</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11382,9 +11382,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true,
       "funding": [
         {
@@ -16628,9 +16628,9 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.9.tgz",
-      "integrity": "sha512-sbn6mioS2w0lq1O6PpGtsv6Gy8roWM+o3o4Sqjd6DudrL/nOugY+KyJUimoWzHnf9OkO0T6broHFnYE/R05t9A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
+      "integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
       "dev": true,
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/**
+/*
  * @jest-environment node
  */
 import * as IDL from './idl';

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -1531,9 +1531,9 @@ export class ServiceClass extends ConstructType<PrincipalId> {
 }
 
 /**
- *
- * @param x
- * @returns {string}
+ * Takes an unknown value and returns a string representation of it.
+ * @param x - unknown value
+ * @returns {string} string representation of the value
  */
 function toReadableString(x: unknown): string {
   const str = JSON.stringify(x, (_key, value) =>
@@ -1547,9 +1547,9 @@ function toReadableString(x: unknown): string {
 
 /**
  * Encode a array of values
- * @param argTypes
- * @param args
- * @returns {Buffer} serialised value
+ * @param argTypes - array of Types
+ * @param args - array of values
+ * @returns {ArrayBuffer} serialised value
  */
 export function encode(argTypes: Array<Type<any>>, args: any[]): ArrayBuffer {
   if (args.length < argTypes.length) {

--- a/packages/candid/src/utils/buffer.ts
+++ b/packages/candid/src/utils/buffer.ts
@@ -50,13 +50,13 @@ export class PipeArrayBuffer {
    * @param length an optional amount of bytes to use for the length.
    */
   constructor(buffer?: ArrayBuffer, length = buffer?.byteLength || 0) {
-    this._buffer = buffer || new ArrayBuffer(0);
+    this._buffer = bufFromBufLike(buffer || new ArrayBuffer(0));
     this._view = new Uint8Array(this._buffer, 0, length);
   }
 
   get buffer(): ArrayBuffer {
     // Return a copy of the buffer.
-    return this._view.slice();
+    return bufFromBufLike(this._view.slice());
   }
 
   get byteLength(): number {
@@ -120,4 +120,33 @@ export class PipeArrayBuffer {
     this._buffer = b;
     this._view = v;
   }
+}
+
+/**
+ * Returns a true ArrayBuffer from a Uint8Array, as Uint8Array.buffer is unsafe.
+ * @param {Uint8Array} arr Uint8Array to convert
+ * @returns ArrayBuffer
+ */
+export function uint8ToBuf(arr: Uint8Array): ArrayBuffer {
+  return new DataView(arr.buffer, arr.byteOffset, arr.byteLength).buffer;
+}
+
+/**
+ * Returns a true ArrayBuffer from an ArrayBufferLike object.
+ * @param bufLike a buffer-like object
+ * @returns ArrayBuffer
+ */
+export function bufFromBufLike(
+  bufLike: ArrayBuffer | Uint8Array | DataView | ArrayBufferView | ArrayBufferLike,
+): ArrayBuffer {
+  if (bufLike instanceof Uint8Array) {
+    return uint8ToBuf(bufLike);
+  }
+  if (bufLike instanceof ArrayBuffer) {
+    return bufLike;
+  }
+  if ('buffer' in bufLike) {
+    return bufLike.buffer;
+  }
+  return new Uint8Array(bufLike);
 }

--- a/packages/candid/src/utils/hash.ts
+++ b/packages/candid/src/utils/hash.ts
@@ -1,7 +1,8 @@
 /**
  * Hashes a string to a number. Algorithm can be found here:
  * https://caml.inria.fr/pub/papers/garrigue-polymorphic_variants-ml98.pdf
- * @param s
+ * @param s - string to hash
+ * @returns number representing hashed string
  */
 function idlHash(s: string): number {
   const utf8encoder = new TextEncoder();

--- a/packages/candid/src/utils/leb128.ts
+++ b/packages/candid/src/utils/leb128.ts
@@ -26,7 +26,7 @@ export function safeRead(pipe: Pipe, num: number): ArrayBuffer {
 }
 
 /**
- * @param pipe
+ * @param pipe - PipeArrayBuffer simulating buffer-pipe api
  */
 export function safeReadUint8(pipe: Pipe): number {
   const byte = pipe.readUint8();
@@ -169,8 +169,9 @@ export function writeUIntLE(value: bigint | number, byteLength: number): ArrayBu
 
 /**
  *
- * @param value
- * @param byteLength
+ * @param value - bigint or number
+ * @param byteLength - number
+ * @returns ArrayBuffer
  */
 export function writeIntLE(value: bigint | number, byteLength: number): ArrayBuffer {
   value = BigInt(value);


### PR DESCRIPTION
# Description

We've had some warnings appearing in the files tab due to not strictly enforcing our linting in CI for issues such as jsdoc conventions. This PR cleans those up.

Also fixes an issue in leb128 where a returned value would be a Uint8Array when it is typed as an ArrayBuffer that I noticed while cleaning up the doc types.

Fixes #811 

# How Has This Been Tested?

Standard suite

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
