### PR TITLE
feat: add `github.dev` and `gitpod.io` to known hosts

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -18,6 +18,7 @@
         <li>feat: enhances `.from` methods on public key classes to support unknown types, including PublicKey instances, ArrayBuffer-like objects, DER encoded public keys, and hex strings. Also introduces a new `bufFromBufLike` util</li>
         <li>feat: introduces partial identities from public keys for authentication flows</li>
         <li>fix: honor disableIdle flag</li>
+        <li>fix: add `github.dev` and `gitpod.io` to known hosts</li>
       </ul>
       <h2>Version 0.20.2</h2>
       <ul>

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -733,7 +733,7 @@ describe('default host', () => {
     expect((agent as any)._host.hostname).toBe('icp-api.io');
   });
   it('should use the existing host if the agent is used on a known hostname', () => {
-    const knownHosts = ['ic0.app', 'icp0.io', '127.0.0.1', '127.0.0.1'];
+    const knownHosts = ['ic0.app', 'icp0.io', '127.0.0.1', 'localhost', 'github.dev', 'gitpod.io'];
     for (const host of knownHosts) {
       delete (window as any).location;
       (window as any).location = {
@@ -745,7 +745,7 @@ describe('default host', () => {
     }
   });
   it('should correctly handle subdomains on known hosts', () => {
-    const knownHosts = ['ic0.app', 'icp0.io', '127.0.0.1', '127.0.0.1'];
+    const knownHosts = ['ic0.app', 'icp0.io', '127.0.0.1', 'localhost', 'github.dev', 'gitpod.io'];
     for (const host of knownHosts) {
       delete (window as any).location;
       (window as any).location = {
@@ -757,8 +757,8 @@ describe('default host', () => {
       expect((agent as any)._host.hostname).toBe(host);
     }
   });
-  it('should handle port numbers for 127.0.0.1', () => {
-    const knownHosts = ['127.0.0.1', '127.0.0.1'];
+  it('should handle port numbers for 127.0.0.1 and localhost', () => {
+    const knownHosts = ['127.0.0.1', 'localhost'];
     for (const host of knownHosts) {
       delete (window as any).location;
       // hostname is different from host when port is specified

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -223,7 +223,7 @@ export class HttpAgent implements Agent {
           'Could not infer host from window.location, defaulting to mainnet gateway of https://icp-api.io. Please provide a host to the HttpAgent constructor to avoid this warning.',
         );
       }
-      // Mainnet and local will have the api route available
+      // Mainnet, local, and remote environments will have the api route available
       const knownHosts = [
         'ic0.app',
         'icp0.io',

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -224,7 +224,14 @@ export class HttpAgent implements Agent {
         );
       }
       // Mainnet and local will have the api route available
-      const knownHosts = ['ic0.app', 'icp0.io', '127.0.0.1', 'localhost'];
+      const knownHosts = [
+        'ic0.app',
+        'icp0.io',
+        '127.0.0.1',
+        'localhost',
+        'github.dev',
+        'gitpod.io',
+      ];
       const hostname = location?.hostname;
       let knownHost;
       if (hostname && typeof hostname === 'string') {


### PR DESCRIPTION
# Description

This PR includes `github.dev` and `gitpod.io` in the list of known `HttpAgent` hosts to support remote IDE development out of the box. The context for this change can be found in the internal `#poc-dev-env-in-5-mins` Slack channel as well as [this forum conversation](https://forum.dfinity.org/t/issue-with-candid-ui-and-online-ide-gitpod-codespaces/26148).

CC @chenyan-dfinity

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation. (NA)
