### PR TITLE
feat: Export AgentHTTPResponseError

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>chore: exporting http errors</li>
         <li>chore: cleaning up lint warnings</li>
         <li>chore: cleans up github actions linting warnings</li>
         <li>feat: replaces `secp256k1` npm package with `@noble/curves`</li>

--- a/packages/agent/src/agent/index.ts
+++ b/packages/agent/src/agent/index.ts
@@ -3,6 +3,7 @@ import { Agent } from './api';
 
 export * from './api';
 export * from './http';
+export * from './http/errors';
 export * from './proxy';
 
 declare const window: GlobalInternetComputer;


### PR DESCRIPTION
# Description

`AgentHTTPResponseError` is not exported from the agent library. It would be nice if it was.

# How Has This Been Tested?

Not tested.
