### PR TITLE
feat: release automation changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm list
       - run: npm ci
       - run: npm audit
-      - run: npm publish
+      - run: npm publish -ws
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/bin/version.ts
+++ b/bin/version.ts
@@ -5,6 +5,7 @@
 import fs from 'fs';
 import path from 'path';
 import { exec } from 'child_process';
+import prettier from 'prettier';
 import process from 'process';
 
 console.time('script duration');
@@ -52,8 +53,12 @@ workspaces.forEach(async workspace => {
     json.devDependencies = updateDeps(json.devDependencies);
   }
 
+  const formatted = prettier.format(JSON.stringify(json), {
+    parser: 'json-stringify',
+  });
+
   // Write file
-  fs.writeFileSync(packagePath, JSON.stringify(json));
+  fs.writeFileSync(packagePath, formatted);
 });
 
 function updateDeps(dependencies: Record<string, string>) {

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>feat: release automation changes</li>
         <li>fix: distinguish remote dev environments from known hosts</li>
       </ul>
       <h2>Version 0.21.2</h2>

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
         "git push --set-upstream origin release/${version}"
       ],
       "after:release": [
-        "gh pr create --base main --title 'chore: release ${version}' --body 'GitHub Release: ${releaseUrl}\nNPM release: https://www.npmjs.com/package/@dfinity/agent/v/${version}'"
+        "gh pr create --base main --title 'chore: release ${version}' --body 'GitHub Release: ${releaseUrl}\nNPM release: https://www.npmjs.com/package/@dfinity/agent/v/${version}'`n[ ] Check this box to trigger CI"
       ]
     },
     "git": {


### PR DESCRIPTION
# Description

* runs prettier on json files before writing during release PR
* creates a checkbox that hopefully will trigger CI in the automated release PR
* adds the `-ws` flag to `npm publish`

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
