### PR TITLE
fix: adds npm run build to publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,7 @@ jobs:
         continue-on-error: true
         run: npm list
       - run: npm ci
+      - run: npm run build -ws
       - run: npm audit
       - run: npm publish -ws
         env:

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,6 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
+        <li>fix: adds npm run build to publish script</li>
         <li>feat: new CustomPath class, better docs, and deprecating metadata path type for CanisterStatus</li>
         <li>chore: adding new controller to snapshot for e2e canister status</li>
       </ul>


### PR DESCRIPTION
# Description

Fixes an issue that we encountered during the last agent-js publish workflow, where the packages weren't built before publishing

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
