### PR TITLE
chore: export `AuthClientStorage` to aid with custom implementations

### DIFF
--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -12,7 +12,7 @@
     <section>
       <h2>Version x.x.x</h2>
       <ul>
-        <li>chore: export `AuthClientStorage` to support custom implementations</li>
+        <li>chore: export `AuthClientStorage` to aid with custom implementations</li>
       </ul>
       <h2>Version 1.0.0</h2>
       <ul>

--- a/docs/generated/changelog.html
+++ b/docs/generated/changelog.html
@@ -11,7 +11,9 @@
 
     <section>
       <h2>Version x.x.x</h2>
-      <ul></ul>
+      <ul>
+        <li>chore: export `AuthClientStorage` to support custom implementations</li>
+      </ul>
       <h2>Version 1.0.0</h2>
       <ul>
         <li>chore: npm audit fix</li>

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -28,7 +28,7 @@ import {
 } from './storage';
 import { PartialIdentity } from '@dfinity/identity/lib/cjs/identity/partial';
 
-export { IdbStorage, LocalStorage, KEY_STORAGE_DELEGATION, KEY_STORAGE_KEY } from './storage';
+export { AuthClientStorage, IdbStorage, LocalStorage, KEY_STORAGE_DELEGATION, KEY_STORAGE_KEY } from './storage';
 export { IdbKeyVal, DBCreateOptions } from './db';
 
 const IDENTITY_PROVIDER_DEFAULT = 'https://identity.ic0.app';


### PR DESCRIPTION
# Description

By exporting the `AuthClientStorage` interface, users can easily create custom implementations of it.

# How Has This Been Tested?

It doesn't need to be tested given that all it does is export a type which was previously private.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
