### PR TITLE
feat: support for restricting II auth methods

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
     * New login option: `allowPinAuthentication?: boolean;`
     * Response from II includes `authnMethod: 'passkey' | 'pin' | 'recovery';`
     * OnSuccess now optionally passes the message directly from the IDP provider
+    * Support for arbitrary login values passed to IDP through `customValues` option
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+
+* feat!: support for restricting II auth methods
+    * New login option: `allowPinAuthentication?: boolean;`
+    * Response from II includes `authnMethod: 'passkey' | 'pin' | 'recovery';`
+    * OnSuccess now optionally passes the message directly from the IDP provider
+
 ### Added
 
 * feat: adds `fromPem` method for `identity-secp256k1`

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -476,10 +476,8 @@ export class AuthClient {
      * Callback once login has completed
      */
     onSuccess?:
-      | (() => void)
-      | ((message?: InternetIdentityAuthResponseSuccess) => void)
-      | (() => Promise<void>)
-      | ((message?: InternetIdentityAuthResponseSuccess) => Promise<void>);
+      | (() => void | Promise<void>)
+      | (message: IIAuthResponse) => void | Promise<void>);
     /**
      * Callback in case authentication fails
      */

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -476,7 +476,9 @@ export class AuthClient {
      * Callback once login has completed
      */
     onSuccess?:
+      | (() => void)
       | ((message?: InternetIdentityAuthResponseSuccess) => void)
+      | (() => Promise<void>)
       | ((message?: InternetIdentityAuthResponseSuccess) => Promise<void>);
     /**
      * Callback in case authentication fails


### PR DESCRIPTION
# Description

Adds new security features from the II login flow for restricting authentication types: https://github.com/dfinity/internet-identity/blob/6c345912457ca93bf3175ce3382a1ddf8ff46eca/docs/ii-spec.md#client-authentication-protocol

New Login method allows developers to restrict users from authenticating using a PIN
![image](https://github.com/dfinity/agent-js/assets/16298804/fdd9e55c-f1d4-47d7-a08f-8760f1a06734)

Also allows `onSuccess` to pass through the message from the IDP provider, allowing developers to access the new `authnMethod` field

<img width="501" alt="image" src="https://github.com/dfinity/agent-js/assets/16298804/458c4b99-a240-46c8-a932-1b6786ab4b44">


Fixes # (issue)

# How Has This Been Tested?

Tested manually after building and installing in https://github.com/krpeacock/auth-client-demo

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
