### PR TITLE
fix: Remove ArrayBuffer checks from WebAuthnIdentity

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * feat: adds `fromPem` method for `identity-secp256k1`
 * feat: HttpAgent tracks a watermark from the latest readState call. Queries with signatures made before the watermark will be automatically retried, and rejected if they are still behind.
+* fix: remove `ArrrayBuffer` checks from `WebAuthnIdentity` to resolve issues with the Bitwarden password manager
 
 ## [1.0.1] - 2024-02-20
 

--- a/packages/identity/src/identity/webauthn.ts
+++ b/packages/identity/src/identity/webauthn.ts
@@ -10,6 +10,7 @@ import {
 } from '@dfinity/agent';
 import borc from 'borc';
 import { randomBytes } from '@noble/hashes/utils';
+import { bufFromBufLike } from '@dfinity/candid';
 
 function _coseToDerEncodedBlob(cose: ArrayBuffer): DerEncodedPublicKey {
   return wrapDER(cose, DER_COSE_OID).buffer as DerEncodedPublicKey;
@@ -104,8 +105,17 @@ async function _createCredential(
         },
       },
     },
-  )) as PublicKeyCredentialWithAttachment;
-  return creds;
+  )) as PublicKeyCredentialWithAttachment | null;
+
+  if (creds === null) {
+    return null;
+  }
+
+  return {
+    ...creds,
+    // Some password managers will return a Uint8Array, so we ensure we return an ArrayBuffer.
+    rawId: bufFromBufLike(creds.rawId),
+  };
 }
 
 // See https://www.iana.org/assignments/cose/cose.xhtml#algorithms for a complete

--- a/packages/identity/src/identity/webauthn.ts
+++ b/packages/identity/src/identity/webauthn.ts
@@ -157,6 +157,9 @@ export class WebAuthnIdentity extends SignIdentity {
     }
 
     const response = creds.response as AuthenticatorAttestationResponse;
+    if (response.attestationObject === undefined) {
+      throw new Error('Was expecting an attestation response.');
+    }
 
     // Parse the attestationObject as CBOR.
     const attObject = borc.decodeFirst(new Uint8Array(response.attestationObject));


### PR DESCRIPTION
# Description

This PR removes `instanceof ArrayBuffer` checks from the `WebAuthnIdentity`. The reason is that these checks hide errors and cause problem in conjunction with the BitWarden password manager (which sets these fields to `Uint8Array`). See also this issue: https://github.com/dfinity/internet-identity/issues/2235

Simply removing the checks solved the issue entirely, as the fields that supposedly need to be `ArrayBuffer` are converted to `Uint8Array` anyway.


# How Has This Been Tested?

This change was manually tested with Internet Identity and the BitWarden extension in Chrome.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
