### PR TITLE
fix: Work around credentials not being enumerable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* fix: work around `PublicKeyCredential` not being enumerable
+
 ## [1.1.0] - 2024-03-18
 
 ### Added

--- a/packages/identity/src/identity/webauthn.ts
+++ b/packages/identity/src/identity/webauthn.ts
@@ -112,7 +112,12 @@ async function _createCredential(
   }
 
   return {
-    ...creds,
+    // do _not_ use ...creds here, as creds is not enumerable in all cases
+    id: creds.id,
+    response: creds.response,
+    type: creds.type,
+    authenticatorAttachment: creds.authenticatorAttachment,
+    getClientExtensionResults: creds.getClientExtensionResults,
     // Some password managers will return a Uint8Array, so we ensure we return an ArrayBuffer.
     rawId: bufFromBufLike(creds.rawId),
   };


### PR DESCRIPTION
# Description

This PR fixes an issue that arises from assuming that the `PublicKeyCredential` returned from `navigators.credentials.create` is enumerable.

# How Has This Been Tested?

Manual testing.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
