### PR TITLE
fix: pads date numbers in changelog automation

### DIFF
--- a/bin/roll-changelog.ts
+++ b/bin/roll-changelog.ts
@@ -6,7 +6,11 @@ if (!newVersion) {
   process.exit(1);
 }
 const now = new Date();
-const formattedDate = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`;
+const padNumber = (num: number) => num.toString().padStart(2, '0');
+
+const formattedDate = `${now.getFullYear()}-${padNumber(now.getMonth() + 1)}-${padNumber(
+  now.getDate(),
+)}`;
 
 const path: string = 'docs/CHANGELOG.md';
 const pattern: string = '## [Unreleased]';

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+* fix: pads date numbers in changelog automation. E.G. 2024-3-1 -> 2024-03-01
 * feat: allow passing `DBCreateOptions` to `IdbStorage` constructor
 
 ## [1.1.1] - 2024-03-19

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,11 +63,11 @@
     },
     "e2e/browser": {
       "name": "@do-not-publish/ic-cypress-e2e-tests",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
-        "@dfinity/agent": "^1.1.0",
-        "@dfinity/identity": "^1.1.0",
-        "@dfinity/principal": "^1.1.0",
+        "@dfinity/agent": "^1.1.1",
+        "@dfinity/identity": "^1.1.1",
+        "@dfinity/principal": "^1.1.1",
         "idb-keyval": "^6.2.0"
       },
       "devDependencies": {
@@ -155,12 +155,12 @@
     },
     "e2e/node": {
       "name": "@do-not-publish/ic-node-e2e-tests",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
-        "@dfinity/agent": "^1.1.0",
-        "@dfinity/assets": "^1.1.0",
-        "@dfinity/identity": "^1.1.0",
-        "@dfinity/principal": "^1.1.0",
+        "@dfinity/agent": "^1.1.1",
+        "@dfinity/assets": "^1.1.1",
+        "@dfinity/identity": "^1.1.1",
+        "@dfinity/principal": "^1.1.1",
         "whatwg-fetch": "^3.6.2"
       },
       "devDependencies": {
@@ -21967,7 +21967,7 @@
     },
     "packages/agent": {
       "name": "@dfinity/agent",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.2.0",
@@ -21994,8 +21994,8 @@
         "whatwg-fetch": "^3.0.0"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^1.1.0",
-        "@dfinity/principal": "^1.1.0"
+        "@dfinity/candid": "^1.1.1",
+        "@dfinity/principal": "^1.1.1"
       }
     },
     "packages/agent/node_modules/@typescript-eslint/eslint-plugin": {
@@ -22297,7 +22297,7 @@
     },
     "packages/assets": {
       "name": "@dfinity/assets",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2",
@@ -22317,8 +22317,8 @@
         "typedoc": "^0.22.11"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^1.1.0",
-        "@dfinity/principal": "^1.1.0",
+        "@dfinity/agent": "^1.1.1",
+        "@dfinity/principal": "^1.1.1",
         "@noble/hashes": "^1.3.1"
       }
     },
@@ -22628,7 +22628,7 @@
     },
     "packages/auth-client": {
       "name": "@dfinity/auth-client",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "idb": "^7.0.2"
@@ -22651,9 +22651,9 @@
         "whatwg-fetch": "^3.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^1.1.0",
-        "@dfinity/identity": "^1.1.0",
-        "@dfinity/principal": "^1.1.0"
+        "@dfinity/agent": "^1.1.1",
+        "@dfinity/identity": "^1.1.1",
+        "@dfinity/principal": "^1.1.1"
       }
     },
     "packages/auth-client/node_modules/@typescript-eslint/eslint-plugin": {
@@ -22955,7 +22955,7 @@
     },
     "packages/bls-verify": {
       "name": "@dfinity/bls-verify",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "amcl-js": "file:src/vendor/amcl-js"
@@ -23041,7 +23041,7 @@
     },
     "packages/candid": {
       "name": "@dfinity/candid",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.5",
@@ -23059,7 +23059,7 @@
         "whatwg-fetch": "^3.0.0"
       },
       "peerDependencies": {
-        "@dfinity/principal": "^1.1.0"
+        "@dfinity/principal": "^1.1.1"
       }
     },
     "packages/candid/node_modules/@typescript-eslint/eslint-plugin": {
@@ -23420,7 +23420,7 @@
     },
     "packages/identity": {
       "name": "@dfinity/identity",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.2.0",
@@ -23441,17 +23441,17 @@
         "whatwg-fetch": "^3.0.0"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^1.1.0",
-        "@dfinity/principal": "^1.1.0",
+        "@dfinity/agent": "^1.1.1",
+        "@dfinity/principal": "^1.1.1",
         "@peculiar/webcrypto": "^1.4.0"
       }
     },
     "packages/identity-secp256k1": {
       "name": "@dfinity/identity-secp256k1",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dfinity/agent": "^1.1.0",
+        "@dfinity/agent": "^1.1.1",
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.1",
         "asn1js": "^3.0.5",
@@ -23763,7 +23763,7 @@
     },
     "packages/principal": {
       "name": "@dfinity/principal",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.1"


### PR DESCRIPTION
# Description

pads date numbers in changelog automation. E.G. 2024-3-1 -> 2024-03-01

# Testing

Manually ran script

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
