### PR TITLE
feat: make `IdbStorage` `get/set` methods generic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- feat: make `IdbStorage` `get` and `set` methods generic
+- feat: make `IdbStorage` `get/set` methods generic
 
 ## [1.2.0] - 2024-03-25
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- feat: make `IdbStorage` `get` and `set` methods generic
+
 ## [1.2.0] - 2024-03-25
 
 ### Added

--- a/packages/auth-client/src/storage.ts
+++ b/packages/auth-client/src/storage.ts
@@ -102,13 +102,13 @@ export class IdbStorage implements AuthClientStorage {
     });
   }
 
-  public async get<T>(key: string): Promise<T | null> {
+  public async get<T = string>(key: string): Promise<T | null> {
     const db = await this._db;
     return await db.get<T>(key);
     // return (await db.get<string>(key)) ?? null;
   }
 
-  public async set<T>(key: string, value: T): Promise<void> {
+  public async set<T = string>(key: string, value: T): Promise<void> {
     const db = await this._db;
     await db.set(key, value);
   }

--- a/packages/auth-client/src/storage.ts
+++ b/packages/auth-client/src/storage.ts
@@ -102,13 +102,13 @@ export class IdbStorage implements AuthClientStorage {
     });
   }
 
-  public async get(key: string): Promise<string | null> {
+  public async get<T extends StoredKey = StoredKey>(key: string): Promise<T | null> {
     const db = await this._db;
-    return await db.get<string>(key);
+    return await db.get<T>(key);
     // return (await db.get<string>(key)) ?? null;
   }
 
-  public async set(key: string, value: string): Promise<void> {
+  public async set<T extends StoredKey = StoredKey>(key: string, value: T): Promise<void> {
     const db = await this._db;
     await db.set(key, value);
   }

--- a/packages/auth-client/src/storage.ts
+++ b/packages/auth-client/src/storage.ts
@@ -102,13 +102,13 @@ export class IdbStorage implements AuthClientStorage {
     });
   }
 
-  public async get<T extends StoredKey = StoredKey>(key: string): Promise<T | null> {
+  public async get<T>(key: string): Promise<T | null> {
     const db = await this._db;
     return await db.get<T>(key);
     // return (await db.get<string>(key)) ?? null;
   }
 
-  public async set<T extends StoredKey = StoredKey>(key: string, value: T): Promise<void> {
+  public async set<T>(key: string, value: T): Promise<void> {
     const db = await this._db;
     await db.set(key, value);
   }


### PR DESCRIPTION
# Description

`IdbStorage` is a fairly lightweight wrapper around `IdbKeyVal`. `IdbKeyVal` exposes generic `get` and `set` methods whereas `IdbStorage` can only `get` and `set` strings. This seems like an unnecessary restriction and means developers must come up with hacky solutions to work with types other than strings, eg. `CryptoKeyPair`.

# How Has This Been Tested?

I have tested this with a local deployment of OpenChat where it has successfully stored and retrieved values of type string and CryptoKeyPair.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
