### PR TITLE
chore: Add context to errors thrown on cbor decode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - feat: make `IdbStorage` `get/set` methods generic
+- chore: add context to errors thrown when failing to decode CBOR values.
 
 ## [1.2.0] - 2024-03-25
 

--- a/packages/agent/src/cbor.ts
+++ b/packages/agent/src/cbor.ts
@@ -4,7 +4,7 @@ import borc from 'borc';
 import * as cbor from 'simple-cbor';
 import { CborEncoder, SelfDescribeCborSerializer } from 'simple-cbor';
 import { Principal } from '@dfinity/principal';
-import { concat, fromHex } from './utils/buffer';
+import { concat, fromHex, toHex } from './utils/buffer';
 
 // We are using hansl/simple-cbor for CBOR serialization, to avoid issues with
 // encoding the uint64 values that the HTTP handler of the client expects for
@@ -125,5 +125,9 @@ export function decode<T>(input: ArrayBuffer): T {
     },
   });
 
-  return decoder.decodeFirst(buffer);
+  try {
+    return decoder.decodeFirst(buffer);
+  } catch(e: unknown) {
+    throw new Error(`Failed to decode CBOR: ${e}, input: ${toHex(buffer)}`);
+  }
 }


### PR DESCRIPTION
We have the issue in Internet Identity that people complain about hard to diagnose issues. In particular, we regularly encounter users faced with the "failed to parse" message thrown out of `borc`. It would be very helpful to know what the input was that caused that error.

# How Has This Been Tested?

Against existing test suite.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
