### PR TITLE
chore: replaces global npm install with setup-node

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -7,7 +7,10 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@v1
-      - run: npm install -g npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
       # - run: npm run size-limit --workspaces --if-present
 
       # commented out until the job can be configured

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - feat: make `IdbStorage` `get/set` methods generic
 - chore: add context to errors thrown when failing to decode CBOR values.
+- chore: replaces globle npm install with setup-node for size-limit action
 
 ## [1.2.0] - 2024-03-25
 


### PR DESCRIPTION
# Description

replaces globle npm install with setup-node because of a [bug](https://github.com/actions/runner-images/issues/9644) that started happening recently

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
