### PR TITLE
feat: call returns raw certificate, if requested

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- feat: make actor calls return raw certificate, if requested
+- fix: `pollForResponse` invalid parameters order in update calls 
+
 ## [1.2.1] - 2024-04-25
 
 ### Changed

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -14,7 +14,7 @@ import { pollForResponse, PollStrategyFactory, strategy } from './polling';
 import { Principal } from '@dfinity/principal';
 import { RequestId } from './request_id';
 import { toHex } from './utils/buffer';
-import { Certificate, CreateCertificateOptions } from './certificate';
+import { CreateCertificateOptions } from './certificate';
 import managementCanisterIdl from './canisters/management_idl';
 import _SERVICE, { canister_settings } from './canisters/management_service';
 
@@ -184,7 +184,7 @@ export interface ActorMethodWithHttpDetails<Args extends unknown[] = unknown[], 
   (...args: Args): Promise<{
     httpDetails: HttpDetailsResponse;
     result: Ret;
-    cert: Certificate | undefined;
+    cert: ArrayBuffer | undefined;
   }>;
 }
 


### PR DESCRIPTION
# Description

It is possible to speed up inter-canister calls in some scenarios, if delegate making the call and transferring the response to the user. For example, you've make an ICRC-1 token transfer to some dApp. This dApp, instead of making its own inter-canister call to token's index canister, would ask the user itself to fetch the block from the index and pass the certified response back to one of its own canisters, which can then verify the response.

Such an optimization requires being able to make a call and simultaneously retrieve the raw certificate client-side. This PR adds this feature in a clean non-breaking way.

Also, there was an accidentally discovered bug related to `pollForResponse` function. It was invoked with `blsVerify` parameter in place of `request` parameter. Maybe it did nothing, but it seemed suspicious. This wasn't catched by Typescript, because `request` parameter is of type `any`. 

## Note

1. The certificate is only returned when `CallConfig.returnCertificate` is set to `true`. In that case, instead of just `reply` the method will return `{ result: reply, cert: rawCertificate }`. If `CallConfig.returnCertificate` is unset of `false` - nothing changes, everything works as usual.
2. The certificate is only returned for `update` calls. For `query` calls empty buffer is returned like this `{ result: reply, cert: emptyBuf }`. This is done to: a) comply with method signature change (ActorMethod interface is the same for query and update calls); b) enable replica signature/certificate to be returned the same way for queries in future.
3. I was not able to run e2e tests - could not find any scripts mentioned in the docs. Also, docs on local development seem outdated. Please, take action.

# How Has This Been Tested?

Added a unit-test to `actor.test.ts` testcase.
