### PR TITLE
fix: ObservableLog no longer extends Function

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- fix: ObservableLog no longer extends Function and class instance can no longer be called. Fixes an issue when running in a browser extension context.
 - chore: updates dfinity/conventional-pr-title-action to v3.2.0
 
 ## [1.3.0] - 2024-05-01

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - fix: ObservableLog no longer extends Function and class instance can no longer be called. Fixes an issue when running in a browser extension context.
+- feat!: ObservableLog's `log` method is renamed to `print` to avoind calling `log.log`.
 - chore: updates dfinity/conventional-pr-title-action to v3.2.0
 
 ## [1.3.0] - 2024-05-01

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -409,7 +409,7 @@ export class HttpAgent implements Agent {
 
     const body = cbor.encode(transformedRequest.body);
 
-    this.log.log(
+    this.log.print(
       `fetching "/api/v2/canister/${ecid.toText()}/call" with request:`,
       transformedRequest,
     );
@@ -458,7 +458,7 @@ export class HttpAgent implements Agent {
     const { ecid, transformedRequest, body, requestId, backoff, tries } = args;
 
     const delay = tries === 0 ? 0 : backoff.next();
-    this.log.log(`fetching "/api/v2/canister/${ecid.toString()}/query" with tries:`, {
+    this.log.print(`fetching "/api/v2/canister/${ecid.toString()}/query" with tries:`, {
       tries,
       backoff,
       delay,
@@ -479,7 +479,7 @@ export class HttpAgent implements Agent {
     let response: ApiQueryResponse;
     // Make the request and retry if it throws an error
     try {
-      this.log.log(
+      this.log.print(
         `fetching "/api/v2/canister/${ecid.toString()}/query" with request:`,
         transformedRequest,
       );
@@ -544,7 +544,7 @@ export class HttpAgent implements Agent {
     // Convert the timestamp to milliseconds
     const timeStampInMs = Number(BigInt(timestamp) / BigInt(1_000_000));
 
-    this.log.log('watermark and timestamp', {
+    this.log.print('watermark and timestamp', {
       waterMark: this.waterMark,
       timestamp: timeStampInMs,
     });
@@ -638,8 +638,8 @@ export class HttpAgent implements Agent {
       ? Principal.from(fields.effectiveCanisterId)
       : Principal.from(canisterId);
 
-    this.log.log(`ecid ${ecid.toString()}`);
-    this.log.log(`canisterId ${canisterId.toString()}`);
+    this.log.print(`ecid ${ecid.toString()}`);
+    this.log.print(`canisterId ${canisterId.toString()}`);
     const makeQuery = async () => {
       const id = await (identity !== undefined ? await identity : await this._identity);
       if (!id) {
@@ -709,7 +709,7 @@ export class HttpAgent implements Agent {
     // Make query and fetch subnet keys in parallel
     const [query, subnetStatus] = await Promise.all([makeQuery(), getSubnetStatus()]);
 
-    this.log.log('Query response:', query);
+    this.log.print('Query response:', query);
     // Skip verification if the user has disabled it
     if (!this.#verifyQuerySignatures) {
       return query;
@@ -855,7 +855,7 @@ export class HttpAgent implements Agent {
     const transformedRequest = request ?? (await this.createReadStateRequest(fields, identity));
     const body = cbor.encode(transformedRequest.body);
 
-    this.log.log(
+    this.log.print(
       `fetching "/api/v2/canister/${canister}/read_state" with request:`,
       transformedRequest,
     );
@@ -885,10 +885,10 @@ export class HttpAgent implements Agent {
     }
     const decodedResponse: ReadStateResponse = cbor.decode(await response.arrayBuffer());
 
-    this.log.log('Read state response:', decodedResponse);
+    this.log.print('Read state response:', decodedResponse);
     const parsedTime = await this.parseTimeFromResponse(decodedResponse);
     if (parsedTime > 0) {
-      this.log.log('Read state response time:', parsedTime);
+      this.log.print('Read state response time:', parsedTime);
       this.#waterMark = parsedTime;
     }
 
@@ -913,8 +913,8 @@ export class HttpAgent implements Agent {
         throw new Error('Time was not found in the response or was not in its expected format.');
       }
       const date = decodeTime(bufFromBufLike(timeLookup));
-      this.log.log('Time from response:', date);
-      this.log.log('Time from response in milliseconds:', Number(date));
+      this.log.print('Time from response:', date);
+      this.log.print('Time from response in milliseconds:', Number(date));
       return Number(date);
     } else {
       this.log.warn('No certificate found in response');
@@ -931,7 +931,7 @@ export class HttpAgent implements Agent {
     const callTime = Date.now();
     try {
       if (!canisterId) {
-        this.log.log(
+        this.log.print(
           'Syncing time with the IC. No canisterId provided, so falling back to ryjl3-tyaaa-aaaaa-aaaba-cai',
         );
       }
@@ -958,7 +958,7 @@ export class HttpAgent implements Agent {
         }
       : {};
 
-    this.log.log(`fetching "/api/v2/status"`);
+    this.log.print(`fetching "/api/v2/status"`);
     const backoff = this.#backoffStrategy();
     const response = await this.#requestAndRetry({
       backoff,

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -409,7 +409,10 @@ export class HttpAgent implements Agent {
 
     const body = cbor.encode(transformedRequest.body);
 
-    this.log(`fetching "/api/v2/canister/${ecid.toText()}/call" with request:`, transformedRequest);
+    this.log.log(
+      `fetching "/api/v2/canister/${ecid.toText()}/call" with request:`,
+      transformedRequest,
+    );
 
     // Run both in parallel. The fetch is quite expensive, so we have plenty of time to
     // calculate the requestId locally.
@@ -455,7 +458,7 @@ export class HttpAgent implements Agent {
     const { ecid, transformedRequest, body, requestId, backoff, tries } = args;
 
     const delay = tries === 0 ? 0 : backoff.next();
-    this.log(`fetching "/api/v2/canister/${ecid.toString()}/query" with tries:`, {
+    this.log.log(`fetching "/api/v2/canister/${ecid.toString()}/query" with tries:`, {
       tries,
       backoff,
       delay,
@@ -476,7 +479,7 @@ export class HttpAgent implements Agent {
     let response: ApiQueryResponse;
     // Make the request and retry if it throws an error
     try {
-      this.log(
+      this.log.log(
         `fetching "/api/v2/canister/${ecid.toString()}/query" with request:`,
         transformedRequest,
       );
@@ -541,7 +544,7 @@ export class HttpAgent implements Agent {
     // Convert the timestamp to milliseconds
     const timeStampInMs = Number(BigInt(timestamp) / BigInt(1_000_000));
 
-    this.log('watermark and timestamp', {
+    this.log.log('watermark and timestamp', {
       waterMark: this.waterMark,
       timestamp: timeStampInMs,
     });
@@ -635,8 +638,8 @@ export class HttpAgent implements Agent {
       ? Principal.from(fields.effectiveCanisterId)
       : Principal.from(canisterId);
 
-    this.log(`ecid ${ecid.toString()}`);
-    this.log(`canisterId ${canisterId.toString()}`);
+    this.log.log(`ecid ${ecid.toString()}`);
+    this.log.log(`canisterId ${canisterId.toString()}`);
     const makeQuery = async () => {
       const id = await (identity !== undefined ? await identity : await this._identity);
       if (!id) {
@@ -706,7 +709,7 @@ export class HttpAgent implements Agent {
     // Make query and fetch subnet keys in parallel
     const [query, subnetStatus] = await Promise.all([makeQuery(), getSubnetStatus()]);
 
-    this.log('Query response:', query);
+    this.log.log('Query response:', query);
     // Skip verification if the user has disabled it
     if (!this.#verifyQuerySignatures) {
       return query;
@@ -852,7 +855,7 @@ export class HttpAgent implements Agent {
     const transformedRequest = request ?? (await this.createReadStateRequest(fields, identity));
     const body = cbor.encode(transformedRequest.body);
 
-    this.log(
+    this.log.log(
       `fetching "/api/v2/canister/${canister}/read_state" with request:`,
       transformedRequest,
     );
@@ -882,10 +885,10 @@ export class HttpAgent implements Agent {
     }
     const decodedResponse: ReadStateResponse = cbor.decode(await response.arrayBuffer());
 
-    this.log('Read state response:', decodedResponse);
+    this.log.log('Read state response:', decodedResponse);
     const parsedTime = await this.parseTimeFromResponse(decodedResponse);
     if (parsedTime > 0) {
-      this.log('Read state response time:', parsedTime);
+      this.log.log('Read state response time:', parsedTime);
       this.#waterMark = parsedTime;
     }
 
@@ -910,8 +913,8 @@ export class HttpAgent implements Agent {
         throw new Error('Time was not found in the response or was not in its expected format.');
       }
       const date = decodeTime(bufFromBufLike(timeLookup));
-      this.log('Time from response:', date);
-      this.log('Time from response in milliseconds:', Number(date));
+      this.log.log('Time from response:', date);
+      this.log.log('Time from response in milliseconds:', Number(date));
       return Number(date);
     } else {
       this.log.warn('No certificate found in response');
@@ -928,7 +931,7 @@ export class HttpAgent implements Agent {
     const callTime = Date.now();
     try {
       if (!canisterId) {
-        this.log(
+        this.log.log(
           'Syncing time with the IC. No canisterId provided, so falling back to ryjl3-tyaaa-aaaaa-aaaba-cai',
         );
       }
@@ -955,7 +958,7 @@ export class HttpAgent implements Agent {
         }
       : {};
 
-    this.log(`fetching "/api/v2/status"`);
+    this.log.log(`fetching "/api/v2/status"`);
     const backoff = this.#backoffStrategy();
     const response = await this.#requestAndRetry({
       backoff,

--- a/packages/agent/src/observable.test.ts
+++ b/packages/agent/src/observable.test.ts
@@ -42,7 +42,7 @@ describe('ObservableLog', () => {
     const observer2 = jest.fn();
     observable.subscribe(observer1);
     observable.subscribe(observer2);
-    observable.log('info');
+    observable.print('info');
     expect(observer1).toHaveBeenCalledWith({ message: 'info', level: 'info' });
     expect(observer2).toHaveBeenCalledWith({ message: 'info', level: 'info' });
     observable.warn('warning');
@@ -59,7 +59,7 @@ describe('ObservableLog', () => {
     const observer1 = jest.fn();
     const observer2 = jest.fn();
     observable.subscribe(observer1);
-    observable.log('info');
+    observable.print('info');
     expect(observer1).toHaveBeenCalledWith({ message: 'info', level: 'info' });
     expect(observer2).not.toHaveBeenCalled();
   });
@@ -71,7 +71,7 @@ describe('ObservableLog', () => {
     observable.subscribe(observer1);
     observable.subscribe(observer2);
     observable.unsubscribe(observer2);
-    observable.log('info');
+    observable.print('info');
     expect(observer1).toHaveBeenCalledWith({ message: 'info', level: 'info' });
     expect(observer2).not.toHaveBeenCalled();
   });

--- a/packages/agent/src/observable.test.ts
+++ b/packages/agent/src/observable.test.ts
@@ -10,9 +10,6 @@ describe('Observable', () => {
     observable.notify(42);
     expect(observer1).toHaveBeenCalledWith(42);
     expect(observer2).toHaveBeenCalledWith(42);
-    observable(24);
-    expect(observer1).toHaveBeenCalledWith(24);
-    expect(observer2).toHaveBeenCalledWith(24);
   });
 
   it('should notify only subscribed observers', () => {

--- a/packages/agent/src/observable.ts
+++ b/packages/agent/src/observable.ts
@@ -9,10 +9,6 @@ export class Observable<T> {
     this.observers = [];
   }
 
-  #call(message: T, ...rest: unknown[]) {
-    this.notify(message, ...rest);
-  }
-
   subscribe(func: ObserveFunction<T>) {
     this.observers.push(func);
   }
@@ -41,7 +37,7 @@ export class ObservableLog extends Observable<AgentLog> {
   constructor() {
     super();
   }
-  log(message: string, ...rest: unknown[]) {
+  print(message: string, ...rest: unknown[]) {
     this.notify({ message, level: 'info' }, ...rest);
   }
   warn(message: string, ...rest: unknown[]) {
@@ -49,8 +45,5 @@ export class ObservableLog extends Observable<AgentLog> {
   }
   error(message: string, error: AgentError, ...rest: unknown[]) {
     this.notify({ message, level: 'error', error }, ...rest);
-  }
-  #call(message: string, ...rest: unknown[]) {
-    this.log(message, ...rest);
   }
 }

--- a/packages/agent/src/observable.ts
+++ b/packages/agent/src/observable.ts
@@ -2,15 +2,11 @@ import { AgentError } from './errors';
 
 export type ObserveFunction<T> = (data: T, ...rest: unknown[]) => void;
 
-export class Observable<T> extends Function {
+export class Observable<T> {
   observers: ObserveFunction<T>[];
 
   constructor() {
-    super();
     this.observers = [];
-    return new Proxy(this, {
-      apply: (target, _, args) => target.#call(args[0], ...args.slice(1)),
-    });
   }
 
   #call(message: T, ...rest: unknown[]) {
@@ -44,9 +40,6 @@ export type AgentLog =
 export class ObservableLog extends Observable<AgentLog> {
   constructor() {
     super();
-    return new Proxy(this, {
-      apply: (target, _, args) => target.#call(args[0], ...args.slice(1)),
-    });
   }
   log(message: string, ...rest: unknown[]) {
     this.notify({ message, level: 'info' }, ...rest);


### PR DESCRIPTION
# Description

Funded app reported that in Chrome browser extensions, the Function / Proxy implementation was being rejected under rules blocking the use of `eval`. 

# How Has This Been Tested?

Once Funded has tested the changes in their extension, this can be merged

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
