### PR TITLE
fix: updated outdated urls in sample

### DIFF
--- a/demos/sample-javascript/src/index.html
+++ b/demos/sample-javascript/src/index.html
@@ -5,7 +5,7 @@
       <h2>Sign In</h2>
       <div>
         <label for="idpUrl" style="display: inline-block; width: 120px">Identity Provider: </label>
-        <input type="text" id="idpUrl" value="https://identity.messaging.ic0.app/#authorize" />
+        <input type="text" id="idpUrl" value="https://identity.ic0.app/" />
       </div>
       <button id="signinBtn">Sign In</button>
       <button id="signoutBtn">Sign Out</button>
@@ -16,7 +16,7 @@
     <div>
       <h1>Contact the IC</h1>
       <label for="hostUrl" style="display: inline-block; width: 120px">Replica URL: </label>
-      <input type="text" id="hostUrl" value="https://gw.dfinity.network/" />
+      <input type="text" id="hostUrl" value="https://icp-api.io/" />
       <br />
       <label for="canisterId" style="display: inline-block; width: 120px">Canister ID: </label>
       <input type="text" id="canisterId" value="4k2wq-cqaaa-aaaab-qac7q-cai" />


### PR DESCRIPTION
# Description

The URLs used in the sample are outdated and do not work anymore. I replaced them with the current URLs. However, I couldn't fix the canister ID as I am not sure what canister it should be.

Fixes # (issue)

# How Has This Been Tested?

I updated it and ran it manually. Of course I got an error because the canister doesn't exist anymore, but at least it went through a boundary node and hit a replica.

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
