### PR TITLE
chore: update management canister interface with wasm_memory_limit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - chore: updates agent error response to read "Gateway returns error" instead of "Server"`
 - chore: updates dfinity/conventional-pr-title-action to v4.0.0
 - chore: updates dfinity/conventional-pr-title-action to v3.2.0
+- update management canister interface with `wasm_memory_limit`
 
 ## [1.3.0] - 2024-05-01
 

--- a/packages/agent/src/canisters/management.did
+++ b/packages/agent/src/canisters/management.did
@@ -13,6 +13,7 @@ type canister_settings = record {
     freezing_threshold : opt nat;
     reserved_cycles_limit : opt nat;
     log_visibility : opt log_visibility;
+    wasm_memory_limit : opt nat;
 };
 
 type definite_canister_settings = record {
@@ -22,6 +23,7 @@ type definite_canister_settings = record {
     freezing_threshold : nat;
     reserved_cycles_limit : nat;
     log_visibility : log_visibility;
+    wasm_memory_limit : nat;
 };
 
 type change_origin = variant {

--- a/packages/agent/src/canisters/management_idl.ts
+++ b/packages/agent/src/canisters/management_idl.ts
@@ -124,6 +124,7 @@ export default ({ IDL }) => {
     controllers: IDL.Vec(IDL.Principal),
     reserved_cycles_limit: IDL.Nat,
     log_visibility: log_visibility,
+    wasm_memory_limit: IDL.Nat,
     memory_allocation: IDL.Nat,
     compute_allocation: IDL.Nat,
   });
@@ -152,6 +153,7 @@ export default ({ IDL }) => {
     controllers: IDL.Opt(IDL.Vec(IDL.Principal)),
     reserved_cycles_limit: IDL.Opt(IDL.Nat),
     log_visibility: IDL.Opt(log_visibility),
+    wasm_memory_limit: IDL.Opt(IDL.Nat),
     memory_allocation: IDL.Opt(IDL.Nat),
     compute_allocation: IDL.Opt(IDL.Nat),
   });

--- a/packages/agent/src/canisters/management_service.ts
+++ b/packages/agent/src/canisters/management_service.ts
@@ -88,6 +88,7 @@ export interface canister_settings {
   controllers: [] | [Array<Principal>];
   reserved_cycles_limit: [] | [bigint];
   log_visibility: [] | [log_visibility];
+  wasm_memory_limit: [] | [bigint];
   memory_allocation: [] | [bigint];
   compute_allocation: [] | [bigint];
 }
@@ -153,6 +154,7 @@ export interface definite_canister_settings {
   controllers: Array<Principal>;
   reserved_cycles_limit: bigint;
   log_visibility: log_visibility;
+  wasm_memory_limit: bigint;
   memory_allocation: bigint;
   compute_allocation: bigint;
 }


### PR DESCRIPTION
This updates the interface of the management canister to include the latest spec change:
https://github.com/dfinity/interface-spec/pull/278