### PR TITLE
ci: npm cache and cypress action

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,7 +72,6 @@ jobs:
         with:
           install: false
           project: ./e2e/browser
-          working-directory: e2e/browser
           start: |
             npm run e2e
           wait-on: 'http://localhost:1234'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -73,7 +73,7 @@ jobs:
           install: false
           project: ./e2e/browser
           start: |
-            npm run e2e
+            npm run e2e --workspace e2e/node
           wait-on: 'http://localhost:1234'
           wait-on-timeout: 120
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,12 +62,13 @@ jobs:
         id: setup
         run: npm run setup --workspaces --if-present
 
-      # - run: npm run e2e --workspace e2e/node
-      #   env:
-      #     CI: true
-      #     REPLICA_PORT: 4943
+      - name: Node.js e2e tests
+        run: npm run e2e --workspace e2e/node
+        env:
+          CI: true
+          REPLICA_PORT: 4943
 
-      - name: Cypress run
+      - name: Cypress e2e tests
         uses: cypress-io/github-action@v6
         with:
           install: false

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,9 +28,23 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install -g npm
-
-      - run: npm install
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: npm list
 
       # build monorepo incl. each subpackage
       - run: npm run build --workspaces --if-present
@@ -42,14 +56,26 @@ jobs:
         run: |
           dfx start --background
 
-      - name: setup
-        id: setup
-        run: npm run setup --workspaces --if-present
+      # - name: setup
+      #   id: setup
+      #   run: npm run setup --workspaces --if-present
 
-      - run: npm run e2e --workspaces --if-present
-        env:
-          CI: true
-          REPLICA_PORT: 4943
+      # - run: npm run e2e --workspace e2e/node
+      #   env:
+      #     CI: true
+      #     REPLICA_PORT: 4943
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v6
+        with:
+          install: false
+          project: ./e2e/browser
+          working-directory: e2e/browser
+          start: |
+            npm run setup
+            npm run e2e
+          wait-on: 'http://localhost:1234'
+          wait-on-timeout: 120
 
   aggregate:
     name: e2e:required

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -58,9 +58,9 @@ jobs:
         run: |
           dfx start --background
 
-      # - name: setup
-      #   id: setup
-      #   run: npm run setup --workspaces --if-present
+      - name: setup
+        id: setup
+        run: npm run setup --workspaces --if-present
 
       # - run: npm run e2e --workspace e2e/node
       #   env:
@@ -74,7 +74,6 @@ jobs:
           project: ./e2e/browser
           working-directory: e2e/browser
           start: |
-            npm run setup
             npm run e2e
           wait-on: 'http://localhost:1234'
           wait-on-timeout: 120

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,6 +45,8 @@ jobs:
         name: List the state of node modules
         continue-on-error: true
         run: npm list
+      - run: npm ci
+      - run: npm run build -ws
 
       # build monorepo incl. each subpackage
       - run: npm run build --workspaces --if-present

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- ci: using cypress github action for e2e tests
+
 ## [1.4.0] - 2024-06-17
 
 ### Added

--- a/e2e/node/basic/mainnet.test.ts
+++ b/e2e/node/basic/mainnet.test.ts
@@ -110,7 +110,7 @@ describe('certified query', () => {
         },
       ]
     `);
-  });
+  }, 20_000);
 });
 
 describe('controllers', () => {

--- a/e2e/node/basic/mainnet.test.ts
+++ b/e2e/node/basic/mainnet.test.ts
@@ -110,7 +110,7 @@ describe('certified query', () => {
         },
       ]
     `);
-  }, 20_000);
+  }, 30_000);
 });
 
 describe('controllers', () => {


### PR DESCRIPTION
# Description

Fixes an issue where Cypress CI stopped working for e2e tests by using the cypress github action

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
