### PR TITLE
feat: ensure that seed phrase must produce a 64 byte seed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - feat: management canister interface updates for schnorr signatures
+- feat: ensure that identity-secp256k1 seed phrase must produce a 64 byte seed
 
 ### Changed
 - feat: replaces hdkey and bip32 implementations with `@scure/bip39` and `@scure/bip32` due to vulnerability and lack of maintenance for `elliptic`

--- a/packages/identity-secp256k1/src/secp256k1.test.ts
+++ b/packages/identity-secp256k1/src/secp256k1.test.ts
@@ -244,4 +244,17 @@ describe('public key serialization from various types', () => {
     const shouldFailHex = () => Secp256k1PublicKey.from('not a hex string');
     expect(shouldFailHex).toThrow('Invalid hexadecimal string');
   });
+
+  it('should throw an error serializing a too short seed phrase', () => {
+    const shouldFail = () => Secp256k1KeyIdentity.fromSeedPhrase('one two three');
+    expect(shouldFail).toThrow('Invalid mnemonic');
+  });
+
+  it('should throw an error serializing a too long seed phrase', () => {
+    const shouldFail = () =>
+      Secp256k1KeyIdentity.fromSeedPhrase(
+        'one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen',
+      );
+    expect(shouldFail).toThrow('Invalid mnemonic');
+  });
 });

--- a/packages/identity-secp256k1/src/secp256k1.ts
+++ b/packages/identity-secp256k1/src/secp256k1.ts
@@ -198,6 +198,10 @@ export class Secp256k1KeyIdentity extends SignIdentity {
     }
 
     const seed = bip39.mnemonicToSeedSync(phrase, password);
+    // Ensure the seed is 64 bytes long
+    if (seed.byteLength !== 64) {
+      throw new Error('Derived seed must be 64 bytes long.');
+    }
     const root = HDKey.fromMasterSeed(seed);
     const addrnode = root.derive("m/44'/223'/0'/0/0");
 


### PR DESCRIPTION
# Description

Throws an error if the seed returned by `mnemonicToSeedSync` is not 64 bytes long.

I could not find an example seed that produces the behavior, but added tests that ensure that invalid mnemonics are handled correctly

# How Has This Been Tested?

New unit tests

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
