### PR TITLE
feat: multi-actor config

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- feat: allow creation of multiple Actors in `useAuthClient` by passing a record to `actorOptions` with the actor name as the key, and `CreateActorOptions` as the value
 - feat: management canister interface updates for schnorr signatures
 - feat: ensure that identity-secp256k1 seed phrase must produce a 64 byte seed
 - docs: documentation and metadata for use-auth-client

--- a/package-lock.json
+++ b/package-lock.json
@@ -19403,7 +19403,7 @@
     "packages/use-auth-client": {
       "name": "@dfinity/use-auth-client",
       "version": "2.0.0",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/auth-client": "^2.0.0",

--- a/packages/use-auth-client/README.md
+++ b/packages/use-auth-client/README.md
@@ -36,6 +36,28 @@ const App = () => {
 }
 ```
 
+## Multiple Actors
+
+If you have multiple actors, you can pass a record of `actorOptions` to the `useAuthClient` hook. The keys of the record will be the names of the actors, and the values will be the `actorOptions` for that actor. It will look something like this: 
+
+```ts
+const { isAuthenticated, login, logout, actors } = useAuthClient({
+  actors: {
+    actor1: {
+      canisterId: canisterId1,
+      idlFactory: idlFactory1,
+    },
+    actor2: {
+      canisterId: canisterId2,
+      idlFactory: idlFactory2,
+    },
+  },
+});
+
+const { actor1, actor2 } = actors;
+
+```
+
 There is a live demo at https://5ibdo-haaaa-aaaab-qajia-cai.icp0.io/ 
 
 Additional generated documentaion is available at https://agent-js.icp.xyz/use-auth-client/index.html

--- a/packages/use-auth-client/examples/auth-demo/deps/candid/ivcos-eqaaa-aaaab-qablq-cai.did
+++ b/packages/use-auth-client/examples/auth-demo/deps/candid/ivcos-eqaaa-aaaab-qablq-cai.did
@@ -1,0 +1,3 @@
+service : {
+  whoami: () -> (principal) query;
+}

--- a/packages/use-auth-client/examples/auth-demo/deps/init.json
+++ b/packages/use-auth-client/examples/auth-demo/deps/init.json
@@ -1,0 +1,8 @@
+{
+  "canisters": {
+    "ivcos-eqaaa-aaaab-qablq-cai": {
+      "arg_str": null,
+      "arg_raw": null
+    }
+  }
+}

--- a/packages/use-auth-client/examples/auth-demo/deps/pulled.json
+++ b/packages/use-auth-client/examples/auth-demo/deps/pulled.json
@@ -1,0 +1,13 @@
+{
+  "canisters": {
+    "ivcos-eqaaa-aaaab-qablq-cai": {
+      "name": "whoami",
+      "wasm_hash": "a5af74d01aec228c5a717dfb43f773917e1a9138e512431aafcd225ad0001a8b",
+      "wasm_hash_download": "88f0162fa446ad32e08e7ee513a85a82f145d16a9ebb6d2adfa9bc5ff5605f74",
+      "init_guide": "null",
+      "init_arg": null,
+      "candid_args": "()",
+      "gzip": false
+    }
+  }
+}

--- a/packages/use-auth-client/examples/auth-demo/dfx.json
+++ b/packages/use-auth-client/examples/auth-demo/dfx.json
@@ -14,6 +14,10 @@
       "type": "assets",
       "workspace": "auth-demo-frontend"
     },
+    "whoami": {
+      "type": "pull",
+      "id": "ivcos-eqaaa-aaaab-qablq-cai"
+    },
     "internet_identity": {
       "candid": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did",
       "frontend": {},

--- a/packages/use-auth-client/examples/auth-demo/src/auth-demo-frontend/tsconfig.json
+++ b/packages/use-auth-client/examples/auth-demo/src/auth-demo-frontend/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client", "./src/vite-env.d.ts"]
   },
   "include": ["src"]
 }

--- a/packages/use-auth-client/test/use-auth-client.test.tsx
+++ b/packages/use-auth-client/test/use-auth-client.test.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import { useAuthClient } from '../src/use-auth-client';
-import { describe, it } from '@jest/globals';
+import { describe, it, jest, afterEach } from '@jest/globals';
+
+afterEach(cleanup);
 
 describe('useAuthClient', () => {
   it('should return an authClient object with the expected properties', async () => {
@@ -18,7 +20,6 @@ describe('useAuthClient', () => {
         </div>
       );
     };
-    // disable typescript
     render(<Component />);
 
     (
@@ -26,5 +27,57 @@ describe('useAuthClient', () => {
         toHaveTextContent: (str: string) => boolean;
       }
     ).toHaveTextContent('false');
+  });
+  it('should support configs for multiple actors', async () => {
+    interface Props {
+      children?: React.ReactNode;
+    }
+
+    const idlFactory = ({ IDL }) => {
+      return IDL.Service({ whoami: IDL.Func([], [IDL.Principal], ['query']) });
+    };
+    const Component: React.FC<Props> = () => {
+      const { actors } = useAuthClient({
+        actorOptions: {
+          actor1: {
+            agentOptions: {
+              fetch: jest.fn() as typeof globalThis.fetch,
+            },
+            canisterId: 'rrkah-fqaaa-aaaaa-aaaaq-cai',
+            idlFactory,
+          },
+          actor2: {
+            agentOptions: {
+              fetch: jest.fn() as typeof globalThis.fetch,
+            },
+            canisterId: 'rrkah-fqaaa-aaaaa-aaaaq-cai',
+            idlFactory,
+          },
+        },
+      });
+      return (
+        <div>
+          <div data-testid="actors">{JSON.stringify(actors)}</div>
+        </div>
+      );
+    };
+    render(<Component />);
+
+    (
+      expect(screen.getByTestId('actors')) as unknown as {
+        toHaveTextContent: (str: string) => boolean;
+      }
+    ).toHaveTextContent('{}');
+
+    jest.useRealTimers();
+
+    // wait for the actors to be set
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    (
+      expect(screen.getByTestId('actors')) as unknown as {
+        toHaveTextContent: (str: string) => boolean;
+      }
+    ).toHaveTextContent('{"actor1":{},"actor2":{}}');
   });
 });


### PR DESCRIPTION
# Description

As requested, allows the `useAuthClient` hook to create and manage multiple actors at once. I don't know how to infer the full typing, but that may be possible in a future version

Also adds example code for initializing multiple actors

# How Has This Been Tested?

new unit test and refactoring in the example app

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
