### PR TITLE
feat: exports polling utilities from `@dfinity/agent`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,9 @@
 - docs: documentation and metadata for use-auth-client
 - feat: adds optional `rootKey` to `HttpAgentOptions` to allow for a custom root key to be used for verifying signatures from other networks
 - chore: npm audit bumping micromatch
+- feat: exports polling utilities from `@dfinity/agent` for use in other packages
+  - `pollForResponse` now uses the default strategy by default
+  - Updated the `bls-verify` jsdoc comment to accurately reflect that the default strategy now uses @noble/curves
 
 ### Changed
 - feat: replaces hdkey and bip32 implementations with `@scure/bip39` and `@scure/bip32` due to vulnerability and lack of maintenance for `elliptic`

--- a/packages/agent/src/certificate.ts
+++ b/packages/agent/src/certificate.ts
@@ -135,7 +135,7 @@ export interface CreateCertificateOptions {
    */
   canisterId: Principal;
   /**
-   * BLS Verification strategy. Default strategy uses wasm for performance, but that may not be available in all contexts.
+   * BLS Verification strategy. Default strategy uses bls12_381 from @noble/curves
    */
   blsVerify?: VerifyFunc;
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -29,6 +29,7 @@ import { Agent, HttpAgent } from './agent';
 import { IDL } from '@dfinity/candid';
 
 export * as Cbor from './cbor';
+export * from './polling';
 
 export interface GlobalInternetComputer {
   ic: {

--- a/packages/agent/src/polling/index.ts
+++ b/packages/agent/src/polling/index.ts
@@ -5,6 +5,7 @@ import { RequestId } from '../request_id';
 import { toHex } from '../utils/buffer';
 
 export * as strategy from './strategy';
+import { defaultStrategy } from './strategy';
 export { defaultStrategy } from './strategy';
 export type PollStrategy = (
   canisterId: Principal,
@@ -27,7 +28,7 @@ export async function pollForResponse(
   agent: Agent,
   canisterId: Principal,
   requestId: RequestId,
-  strategy: PollStrategy,
+  strategy: PollStrategy = defaultStrategy(),
   // eslint-disable-next-line
   request?: any,
   blsVerify?: CreateCertificateOptions['blsVerify'],


### PR DESCRIPTION
# Description

Noted by @peterpeterparker - the agent doesn't export the utilities out of the polling submodule.

At the same time, I've set the default polling strategy as an actual default, and the argument can now be omitted
# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
