### PR TITLE
fix: build paths on use-auth-client

### DIFF
--- a/packages/use-auth-client/tsconfig.json
+++ b/packages/use-auth-client/tsconfig.json
@@ -8,6 +8,8 @@
     "moduleResolution": "node",
     "lib": ["es5", "es2015", "dom"],
     "jsx": "react",
+    "rootDir": "./src",
+    "baseUrl": "./",
     "declaration": true,
     "outDir": "lib/esm"
   },


### PR DESCRIPTION
# Description

It's impossible to use `@dfinity/use-auth-client` right now because it points to a non-existing path, the package.json points to `lib/(esm|cjs)/index.js`

![image](https://github.com/user-attachments/assets/0226aaeb-0b5e-4cc4-8b58-9c473f63165a)

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
