### PR TITLE
feat: expose inner certificate in Certificate

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- feat: expose inner certificate in `Certificate` for inspection or use in raw calls. `Certificate.cert` is now a public property
 - feat: allow creation of multiple Actors in `useAuthClient` by passing a record to `actorOptions` with the actor name as the key, and `CreateActorOptions` as the value
 - feat: sync_call support in HttpAgent and Actor
   - Skips polling if the sync call succeeds and provides a certificate

--- a/packages/agent/src/certificate.ts
+++ b/packages/agent/src/certificate.ts
@@ -149,7 +149,7 @@ export interface CreateCertificateOptions {
 }
 
 export class Certificate {
-  private readonly cert: Cert;
+  public cert: Cert;
 
   /**
    * Create a new instance of a certificate, automatically verifying it. Throws a


### PR DESCRIPTION
# Description

Exposes the raw certificate from the `Certificate` class as `Certificate.cert`. 

Partially fixes SDK-1828

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
