### PR TITLE
feat: retry using replica time when receiving ingress expiry error

### DIFF
--- a/e2e/node/basic/mainnet.test.ts
+++ b/e2e/node/basic/mainnet.test.ts
@@ -229,6 +229,7 @@ test('it should throw an error when the clock is out of sync during an update', 
       const error = err as ReplicaTimeError;
       // use the replica time to sync the agent
       error.agent.replicaTime = error.replicaTime;
+      error.agent.overrideSystemTime = true;
       // retry the call
       const result = await actor.whoami();
       expect(Principal.from(result)).toBeInstanceOf(Principal);

--- a/e2e/node/basic/mainnet.test.ts
+++ b/e2e/node/basic/mainnet.test.ts
@@ -191,6 +191,7 @@ test('it should throw an error when the clock is out of sync during a query', as
       const error = err as ReplicaTimeError;
       // use the replica time to sync the agent
       error.agent.replicaTime = error.replicaTime;
+      error.agent.overrideSystemTime = true;
     }
   }
   // retry the call

--- a/package-lock.json
+++ b/package-lock.json
@@ -13154,7 +13154,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
       "dev": true,
       "license": "ISC"
     },
@@ -13268,7 +13270,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.40",
+      "version": "8.4.47",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
       "dev": true,
       "funding": [
         {
@@ -13287,8 +13291,8 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "picocolors": "^1.1.0",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -13296,6 +13300,8 @@
     },
     "node_modules/postcss/node_modules/nanoid": {
       "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
       "funding": [
         {
@@ -15431,7 +15437,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -16697,13 +16705,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.3.5",
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
+      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.39",
-        "rollup": "^4.13.0"
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -16722,6 +16732,7 @@
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
+        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
         "terser": "^5.4.0"
@@ -16737,6 +16748,9 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
           "optional": true
         },
         "stylus": {

--- a/packages/agent/src/__snapshots__/actor.test.ts.snap
+++ b/packages/agent/src/__snapshots__/actor.test.ts.snap
@@ -24,7 +24,7 @@ exports[`makeActor should enrich actor interface with httpDetails 2`] = `
       "__principal__": "2chl6-4hpzw-vqaaa-aaaaa-c",
     },
     "ingress_expiry": Expiry {
-      "_value": 1200000000000n,
+      "_value": 1260000000000n,
     },
     "method_name": "greet_update",
     "nonce": Uint8Array [],

--- a/packages/agent/src/actor.test.ts
+++ b/packages/agent/src/actor.test.ts
@@ -315,7 +315,7 @@ describe('makeActor', () => {
             "__principal__": "2chl6-4hpzw-vqaaa-aaaaa-c",
           },
           "ingress_expiry": Expiry {
-            "_value": 1200000000000n,
+            "_value": 1260000000000n,
           },
           "method_name": "greet",
           "request_type": "query",

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -540,8 +540,6 @@ function _createActorMethod(
         ? (agent as HttpAgent).replicaTime
         : undefined;
 
-      certTime;
-
       if (response.body && response.body.certificate) {
         const cert = response.body.certificate;
         certificate = await Certificate.create({

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -623,13 +623,14 @@ test('should adjust the Expiry if the clock is more than 30 seconds behind', asy
     .call(Principal.managementCanister(), {
       methodName: 'test',
       arg: new Uint8Array().buffer,
+      systemTimeOverride: agent.replicaTime.getTime(),
     })
     // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
     .catch(function (_) {});
 
   const requestBody: any = cbor.decode(mockFetch.mock.calls[0][1].body);
 
-  expect(requestBody.content.ingress_expiry).toMatchInlineSnapshot(`1260000000000`);
+  expect(requestBody.content.ingress_expiry).toMatchInlineSnapshot(`1320000000000`);
 
   jest.resetModules();
 });
@@ -660,13 +661,14 @@ test('should adjust the Expiry if the clock is more than 30 seconds ahead', asyn
     .call(Principal.managementCanister(), {
       methodName: 'test',
       arg: new Uint8Array().buffer,
+      systemTimeOverride: agent.replicaTime.getTime(),
     })
     // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
     .catch(function (_) {});
 
   const requestBody: any = cbor.decode(mockFetch.mock.calls[0][1].body);
 
-  expect(requestBody.content.ingress_expiry).toMatchInlineSnapshot(`1200000000000`);
+  expect(requestBody.content.ingress_expiry).toMatchInlineSnapshot(`1260000000000`);
 
   jest.resetModules();
 });

--- a/packages/agent/src/agent/http/http.test.ts
+++ b/packages/agent/src/agent/http/http.test.ts
@@ -618,12 +618,12 @@ test('should adjust the Expiry if the clock is more than 30 seconds behind', asy
   const agent = new HttpAgent({ host: HTTP_AGENT_HOST, fetch: mockFetch });
 
   await agent.syncTime();
+  agent.overrideSystemTime = true;
 
   await agent
     .call(Principal.managementCanister(), {
       methodName: 'test',
       arg: new Uint8Array().buffer,
-      systemTimeOverride: agent.replicaTime.getTime(),
     })
     // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
     .catch(function (_) {});
@@ -656,12 +656,12 @@ test('should adjust the Expiry if the clock is more than 30 seconds ahead', asyn
   const agent = new HttpAgent({ host: HTTP_AGENT_HOST, fetch: mockFetch });
 
   await agent.syncTime();
+  agent.overrideSystemTime = true;
 
   await agent
     .call(Principal.managementCanister(), {
       methodName: 'test',
       arg: new Uint8Array().buffer,
-      systemTimeOverride: agent.replicaTime.getTime(),
     })
     // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
     .catch(function (_) {});

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -564,6 +564,16 @@ export class HttpAgent implements Agent {
         );
       }
 
+      if ((error as ReplicaTimeError).message.includes('ingress_expiry')) {
+        this.log.warn('Agent time out of sync. Updating and retrying...');
+        this.replicaTime = (error as ReplicaTimeError).replicaTime;
+        return this.call(
+          canisterId,
+          options,
+          identity,
+        );
+      }
+
       this.log.error('Error while making call:', error as Error);
       throw error;
     }

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -564,6 +564,9 @@ export class HttpAgent implements Agent {
         );
       }
 
+      // If the error is due to the ingress expiry being misconfigured,
+      // sync this instance's replica time using the value provided in
+      // the error response and retry
       if ((error as ReplicaTimeError).message.includes('ingress_expiry')) {
         this.log.warn('Agent time out of sync. Updating and retrying...');
         this.replicaTime = (error as ReplicaTimeError).replicaTime;

--- a/packages/agent/src/agent/http/transforms.test.ts
+++ b/packages/agent/src/agent/http/transforms.test.ts
@@ -6,10 +6,10 @@ test('it should round down to the nearest minute', () => {
   jest.setSystemTime(new Date(1619459231314));
 
   const expiry = new Expiry(5 * 60 * 1000);
-  expect(expiry['_value']).toEqual(BigInt(1619459460000000000));
+  expect(expiry['_value']).toEqual(BigInt(1619459520000000000));
 
   const expiry_as_date_string = new Date(
     Number(expiry['_value'] / BigInt(1_000_000)),
   ).toISOString();
-  expect(expiry_as_date_string).toBe('2021-04-26T17:51:00.000Z');
+  expect(expiry_as_date_string).toBe('2021-04-26T17:52:00.000Z');
 });

--- a/packages/agent/src/agent/http/transforms.ts
+++ b/packages/agent/src/agent/http/transforms.ts
@@ -11,15 +11,13 @@ import {
 
 const NANOSECONDS_PER_MILLISECONDS = BigInt(1_000_000);
 
-const REPLICA_PERMITTED_DRIFT_MILLISECONDS = 60 * 1000;
-
 export class Expiry {
   private readonly _value: bigint;
 
-  constructor(deltaInMSec: number) {
+  constructor(deltaInMSec: number, systemTime: number = Date.now()) {
     // Use bigint because it can overflow the maximum number allowed in a double float.
     const raw_value =
-      BigInt(Math.floor(Date.now() + deltaInMSec - REPLICA_PERMITTED_DRIFT_MILLISECONDS)) *
+      BigInt(Math.floor(systemTime + deltaInMSec)) *
       NANOSECONDS_PER_MILLISECONDS;
 
     // round down to the nearest second


### PR DESCRIPTION
# Description

Attempt to retry an update call after receiving an `ingress_expiry` error after setting the replica time to the time provided in the error message.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
