### PR TITLE
fix: decrease the ingress expiry to 3 min

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ## [2.1.2] - 2024-09-30
+- Decrease the ingress_expiry to 3 min
 - fix: revert https://github.com/dfinity/agent-js/pull/923 allow option to set agent replica time
 
 ## [2.1.1] - 2024-09-13

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -53,8 +53,8 @@ export enum RequestStatusResponseStatus {
   Done = 'done',
 }
 
-// Default delta for ingress expiry is 5 minutes.
-const DEFAULT_INGRESS_EXPIRY_DELTA_IN_MSECS = 5 * 60 * 1000;
+// Default delta for ingress expiry is 3 minutes.
+const DEFAULT_INGRESS_EXPIRY_DELTA_IN_MSECS = 3 * 60 * 1000;
 
 // Root public key for the IC, encoded as hex
 export const IC_ROOT_KEY =

--- a/packages/agent/src/agent/http/transforms.test.ts
+++ b/packages/agent/src/agent/http/transforms.test.ts
@@ -5,7 +5,7 @@ test('it should round down to the nearest minute', () => {
   // 2021-04-26T17:47:11.314Z - high precision
   jest.setSystemTime(new Date(1619459231314));
 
-  const expiry = new Expiry(5 * 60 * 1000);
+  const expiry = new Expiry(3 * 60 * 1000);
   expect(expiry['_value']).toEqual(BigInt(1619459460000000000));
 
   const expiry_as_date_string = new Date(


### PR DESCRIPTION
3 Minutes are more than enough for the IC to process a request and start executing it. No point in having a bigger timeout.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
