### PR TITLE
chore: removes message warning in auth-client

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- chore: Removes warning that users found unhelpful, when a message originates from other sources than the identity provider in `AuthClient` during authentication. 
+
 ## [2.1.3] - 2024-10-23
 
 ### Added

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -502,9 +502,7 @@ export class AuthClient {
   private _getEventHandler(identityProviderUrl: URL, options?: AuthClientLoginOptions) {
     return async (event: MessageEvent) => {
       if (event.origin !== identityProviderUrl.origin) {
-        console.warn(
-          `WARNING: expected origin '${identityProviderUrl.origin}', got '${event.origin}' (ignoring)`,
-        );
+        // Ignore any event that is not from the identity provider
         return;
       }
 


### PR DESCRIPTION
# Description

Removes a warning that users found unhelpful, when a message originates from other sources than the identity provider in `AuthClient` during authentication. 

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
