### PR TITLE
feat: support allow list for canister logs in agent-js

### DIFF
--- a/bin/update-management-idl.ts
+++ b/bin/update-management-idl.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 const main = async () => {
   const res = await fetch(
-    'https://raw.githubusercontent.com/dfinity/interface-spec/master/spec/_attachments/ic.did',
+    'https://raw.githubusercontent.com/dfinity/portal/refs/heads/master/docs/references/_attachments/ic.did',
   );
   res.text().then(async text => {
     const root = path.resolve(__dirname, '..');

--- a/packages/agent/src/canisters/management.did
+++ b/packages/agent/src/canisters/management.did
@@ -5,6 +5,7 @@ type snapshot_id = blob;
 type log_visibility = variant {
   controllers;
   public;
+  allowed_viewers : vec principal;
 };
 
 type canister_settings = record {
@@ -322,10 +323,17 @@ type schnorr_public_key_result = record {
   chain_code : blob;
 };
 
+type schnorr_aux = variant {
+  bip341 : record {
+    merkle_root_hash : blob;
+  };
+};
+
 type sign_with_schnorr_args = record {
   message : blob;
   derivation_path : vec blob;
   key_id : record { algorithm : schnorr_algorithm; name : text };
+  aux : opt schnorr_aux;
 };
 
 type sign_with_schnorr_result = record {
@@ -340,6 +348,14 @@ type node_metrics_history_args = record {
 type node_metrics_history_result = vec record {
   timestamp_nanos : nat64;
   node_metrics : vec node_metrics;
+};
+
+type subnet_info_args = record {
+  subnet_id : principal;
+};
+
+type subnet_info_result = record {
+  replica_version : text;
 };
 
 type provisional_create_canister_with_cycles_args = record {
@@ -443,6 +459,9 @@ service ic : {
 
   // metrics interface
   node_metrics_history : (node_metrics_history_args) -> (node_metrics_history_result);
+
+  // subnet info
+  subnet_info : (subnet_info_args) -> (subnet_info_result);
 
   // provisional interfaces for the pre-ledger world
   provisional_create_canister_with_cycles : (provisional_create_canister_with_cycles_args) -> (provisional_create_canister_with_cycles_result);

--- a/packages/agent/src/canisters/management_idl.ts
+++ b/packages/agent/src/canisters/management_idl.ts
@@ -113,6 +113,7 @@ export default ({ IDL }) => {
   const log_visibility = IDL.Variant({
     controllers: IDL.Null,
     public: IDL.Null,
+    allowed_viewers: IDL.Vec(IDL.Principal),
   });
   const definite_canister_settings = IDL.Record({
     freezing_threshold: IDL.Nat,
@@ -309,7 +310,11 @@ export default ({ IDL }) => {
   const sign_with_ecdsa_result = IDL.Record({
     signature: IDL.Vec(IDL.Nat8),
   });
+  const schnorr_aux = IDL.Variant({
+    bip341: IDL.Record({ merkle_root_hash: IDL.Vec(IDL.Nat8) }),
+  });
   const sign_with_schnorr_args = IDL.Record({
+    aux: IDL.Opt(schnorr_aux),
     key_id: IDL.Record({
       algorithm: schnorr_algorithm,
       name: IDL.Text,
@@ -324,6 +329,8 @@ export default ({ IDL }) => {
   const stop_canister_args = IDL.Record({ canister_id: canister_id });
   const stored_chunks_args = IDL.Record({ canister_id: canister_id });
   const stored_chunks_result = IDL.Vec(chunk_hash);
+  const subnet_info_args = IDL.Record({ subnet_id: IDL.Principal });
+  const subnet_info_result = IDL.Record({ replica_version: IDL.Text });
   const take_canister_snapshot_args = IDL.Record({
     replace_snapshot: IDL.Opt(snapshot_id),
     canister_id: canister_id,
@@ -393,6 +400,7 @@ export default ({ IDL }) => {
     start_canister: IDL.Func([start_canister_args], [], []),
     stop_canister: IDL.Func([stop_canister_args], [], []),
     stored_chunks: IDL.Func([stored_chunks_args], [stored_chunks_result], []),
+    subnet_info: IDL.Func([subnet_info_args], [subnet_info_result], []),
     take_canister_snapshot: IDL.Func(
       [take_canister_snapshot_args],
       [take_canister_snapshot_result],

--- a/packages/agent/src/canisters/management_service.ts
+++ b/packages/agent/src/canisters/management_service.ts
@@ -227,7 +227,10 @@ export interface load_canister_snapshot_args {
   sender_canister_version: [] | [bigint];
   snapshot_id: snapshot_id;
 }
-export type log_visibility = { controllers: null } | { public: null };
+export type log_visibility =
+  | { controllers: null }
+  | { public: null }
+  | { allowed_viewers: Array<Principal> };
 export type millisatoshi_per_byte = bigint;
 export interface node_metrics {
   num_block_failures_total: bigint;
@@ -262,6 +265,9 @@ export interface provisional_top_up_canister_args {
 export type raw_rand_result = Uint8Array | number[];
 export type satoshi = bigint;
 export type schnorr_algorithm = { ed25519: null } | { bip340secp256k1: null };
+export type schnorr_aux = {
+  bip341: { merkle_root_hash: Uint8Array | number[] };
+};
 export interface schnorr_public_key_args {
   key_id: { algorithm: schnorr_algorithm; name: string };
   canister_id: [] | [canister_id];
@@ -280,6 +286,7 @@ export interface sign_with_ecdsa_result {
   signature: Uint8Array | number[];
 }
 export interface sign_with_schnorr_args {
+  aux: [] | [schnorr_aux];
   key_id: { algorithm: schnorr_algorithm; name: string };
   derivation_path: Array<Uint8Array | number[]>;
   message: Uint8Array | number[];
@@ -303,6 +310,12 @@ export interface stored_chunks_args {
   canister_id: canister_id;
 }
 export type stored_chunks_result = Array<chunk_hash>;
+export interface subnet_info_args {
+  subnet_id: Principal;
+}
+export interface subnet_info_result {
+  replica_version: string;
+}
 export interface take_canister_snapshot_args {
   replace_snapshot: [] | [snapshot_id];
   canister_id: canister_id;
@@ -370,6 +383,7 @@ export default interface _SERVICE {
   start_canister: ActorMethod<[start_canister_args], undefined>;
   stop_canister: ActorMethod<[stop_canister_args], undefined>;
   stored_chunks: ActorMethod<[stored_chunks_args], stored_chunks_result>;
+  subnet_info: ActorMethod<[subnet_info_args], subnet_info_result>;
   take_canister_snapshot: ActorMethod<[take_canister_snapshot_args], take_canister_snapshot_result>;
   uninstall_code: ActorMethod<[uninstall_code_args], undefined>;
   update_settings: ActorMethod<[update_settings_args], undefined>;


### PR DESCRIPTION
# Description

Support allow list for canister logs in agent-js
1. Update `bin/update-management-idl.ts` to use the new URL for `ic.did` as the old repo has been archived.
2. Update the declarations.

Fixes # (issue)

[SDK-1801](https://dfinity.atlassian.net/browse/SDK-1801)

# How Has This Been Tested?

Manually ran unit tests and e2e tests.

# Checklist:

- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
