### PR TITLE
feat: fetch root key before making calls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- shouldFetchRootKey option added to `HttpAgent` constructor
+
 ### Changed
 
 - chore: bumps .nvmrc and nodejs version in CI to 22
+- HttpAgent now awaits fetching rootkey before making network calls if `shouldFetchRootKey` is set
 
 ## [2.2.0] - 2024-12-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10761,7 +10761,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.11",
+      "version": "0.16.21",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.21.tgz",
+      "integrity": "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",
@@ -16470,7 +16472,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.8",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -531,9 +531,6 @@ function _createActorMethod(
       const ecid = effectiveCanisterId !== undefined ? Principal.from(effectiveCanisterId) : cid;
       const arg = IDL.encode(func.argTypes, args);
 
-      if (agent.rootKey == null)
-        throw new AgentError('Agent root key not initialized before making call');
-
       const { requestId, response, requestDetails } = await agent.call(cid, {
         methodName,
         arg,
@@ -542,6 +539,9 @@ function _createActorMethod(
       let reply: ArrayBuffer | undefined;
       let certificate: Certificate | undefined;
       if (response.body && (response.body as v3ResponseBody).certificate) {
+        if (agent.rootKey == null) {
+          throw new Error('Agent is missing root key');
+        }
         const cert = (response.body as v3ResponseBody).certificate;
         certificate = await Certificate.create({
           certificate: bufFromBufLike(cert),

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -250,7 +250,7 @@ other computations so that this class can stay as simple as possible while
 allowing extensions.
  */
 export class HttpAgent implements Agent {
-  public rootKey: ArrayBuffer | null = null;
+  public rootKey: ArrayBuffer | null;
   #rootKeyPromise: Promise<ArrayBuffer> | null = null;
   #shouldFetchRootKey: boolean = false;
   #identity: Promise<Identity> | null;
@@ -295,7 +295,15 @@ export class HttpAgent implements Agent {
     this.#fetchOptions = options.fetchOptions;
     this.#callOptions = options.callOptions;
     this.#shouldFetchRootKey = options.shouldFetchRootKey ?? false;
-    this.rootKey = options.rootKey ?? null;
+
+    // Use provided root key, otherwise fall back to IC_ROOT_KEY for mainnet or null if the key needs to be fetched
+    if (options.rootKey) {
+      this.rootKey = options.rootKey;
+    } else if (this.#shouldFetchRootKey) {
+      this.rootKey = null;
+    } else {
+      this.rootKey = fromHex(IC_ROOT_KEY);
+    }
 
     const host = determineHost(options.host);
     this.host = new URL(host);
@@ -1149,7 +1157,6 @@ export class HttpAgent implements Agent {
     // Hex-encoded version of the replica root key
     const rootKey = (status as JsonObject & { root_key: ArrayBuffer }).root_key;
     this.rootKey = rootKey;
-    rootKey;
 
     return rootKey;
   }

--- a/packages/agent/src/canisterStatus/index.ts
+++ b/packages/agent/src/canisterStatus/index.ts
@@ -145,6 +145,9 @@ export const request = async (options: {
         const response = await agent.readState(canisterId, {
           paths: [encodedPaths[index]],
         });
+        if (agent.rootKey == null) {
+          throw new Error('Agent is missing root key');
+        }
         const cert = await Certificate.create({
           certificate: response.certificate,
           rootKey: agent.rootKey,
@@ -153,6 +156,9 @@ export const request = async (options: {
 
         const lookup = (cert: Certificate, path: Path) => {
           if (path === 'subnet') {
+            if (agent.rootKey == null) {
+              throw new Error('Agent is missing root key');
+            }
             const data = fetchNodeKeys(response.certificate, canisterId, agent.rootKey);
             return {
               path: path,

--- a/packages/agent/src/certificate.test.ts
+++ b/packages/agent/src/certificate.test.ts
@@ -10,6 +10,7 @@ import { Principal } from '@dfinity/principal';
 import { decodeTime } from './utils/leb';
 import { readFileSync } from 'fs';
 import path from 'path';
+import { IC_ROOT_KEY } from './agent';
 
 function label(str: string): ArrayBuffer {
   return new TextEncoder().encode(str);
@@ -20,13 +21,6 @@ function pruned(str: string): ArrayBuffer {
 }
 
 (expect as any).addEqualityTesters([bufEquals]);
-
-// Root public key for the IC main net, encoded as hex
-const IC_ROOT_KEY =
-  '308182301d060d2b0601040182dc7c0503010201060c2b0601040182dc7c05030201036100814' +
-  'c0e6ec71fab583b08bd81373c255c3c371b2e84863c98a4f1e08b74235d14fb5d9c0cd546d968' +
-  '5f913a0c0b2cc5341583bf4b4392e467db96d65b9bb4cb717112f8472e0d5a4d14505ffd7484' +
-  'b01291091c5f87b98883463f98091a0baaae';
 
 test('hash tree', async () => {
   const cborEncode = fromHex(


### PR DESCRIPTION
# Description
Since the root key cannot be fetched inside a synchronous constructor, we should await the root key when the `shouldFetchRootKey` flag is set.

This PR adds a guard to the `HttpAgent` async calls to make sure the root key call has finished before making the call. It also modifies some checks for `rootKey` in the `canisterStatus` and `actor` utils that should instead wait for the call to be completed.

This shores up occasional inconsistencies with the agent during local development, and that have affected projects in our examples repostory

Fixes # SDK-1905

# How Has This Been Tested?

New tests added to the HttpAgent unit test suite

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
