### PR TITLE
feat: HttpAgent uses anonymous identity to make syncTime call

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- feat: HttpAgent uses anonymous identity to make syncTime call, which can allow readState calls to work beyond 5 minutes
 - chore: bumps .nvmrc and nodejs version in CI to 22
 - HttpAgent now awaits fetching rootkey before making network calls if `shouldFetchRootKey` is set
 - chore: npm audit fixes

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -1111,16 +1111,28 @@ export class HttpAgent implements Agent {
           'Syncing time with the IC. No canisterId provided, so falling back to ryjl3-tyaaa-aaaaa-aaaba-cai',
         );
       }
+
+      const anonymousAgent = HttpAgent.createSync({
+        identity: new AnonymousIdentity(),
+        host: this.host.toString(),
+        fetch: this.#fetch,
+        retryTimes: 0,
+      });
+
       const status = await CanisterStatus.request({
         // Fall back with canisterId of the ICP Ledger
         canisterId: canisterId ?? Principal.from('ryjl3-tyaaa-aaaaa-aaaba-cai'),
-        agent: this,
+        agent: anonymousAgent,
         paths: ['time'],
       });
 
       const replicaTime = status.get('time');
       if (replicaTime) {
         this.#timeDiffMsecs = Number(replicaTime as bigint) - Number(callTime);
+        this.log.notify({
+          message: `Syncing time: offset of ${this.#timeDiffMsecs}`,
+          level: 'info',
+        });
       }
     } catch (error) {
       this.log.error('Caught exception while attempting to sync time', error as AgentError);

--- a/packages/agent/src/canisterStatus/index.ts
+++ b/packages/agent/src/canisterStatus/index.ts
@@ -152,6 +152,7 @@ export const request = async (options: {
           certificate: response.certificate,
           rootKey: agent.rootKey,
           canisterId: canisterId,
+          disableTimeVerification: true,
         });
 
         const lookup = (cert: Certificate, path: Path) => {


### PR DESCRIPTION
which can allow readState calls to work beyond 5 minutes

# Description

Because we’ve added to the specification a feature that the check of the ingress_expiry is [skipped](https://github.com/dfinity/ic/pull/1768) for anonymous read_state requests (see [spec](https://github.com/dfinity/interface-spec/pull/343)), we can add this logic to the agent.

Fixes SDK-1953

# How Has This Been Tested?

New e2e test against mainnet

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
