### PR TITLE
fix: add backtracking to opt decoding

### DIFF
--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -717,12 +717,12 @@ test('IDL opt variant decoding', () => {
     IDL.Record({a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null }))}),
     {a: [{ x: null }]},
     '4449444c036c0161016e026b03787f797f7a7f01000100', // Motoko: {a = ?#x} : {a : ?{#x;#y;#z}}
-    'extended variant under opt existing',
+    'extended variant under opt expected tag',
   );
   testDecode(
     IDL.Record({a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null }))}),
     {a: []},
     '4449444c036c0161016e026b03787f797f7a7f01000102', // Motoko: {a = ?#z} : {a : ?{#x;#y;#z}}
-    'extended variant under opt new - defaulting',
+    'extended variant under opt unexpected tag - defaulting',
   );
 });

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -698,3 +698,31 @@ test('should decode matching optional fields if wire type contains additional fi
     b: ['123'],
   });
 });
+
+
+test('IDL opt variant decoding', () => {
+  testDecode(
+    IDL.Record({a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null, z: IDL.Null }))}),
+    {a: [{ x: null }]},
+    '4449444c036c0161016e026b03787f797f7a7f01000100', // Motoko: {a = ?#x} : {a : ?{#x;#y;#z}}
+    'same variant under opt x',
+  );
+  testDecode(
+    IDL.Record({a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null, z: IDL.Null }))}),
+    {a: [{ z: null}]},
+    '4449444c036c0161016e026b03787f797f7a7f01000102', // Motoko: {a = ?#z} : {a : ?{#x;#y;#z}}
+    'same variant under opt z',
+  );
+  testDecode(
+    IDL.Record({a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null }))}),
+    {a: [{ x: null }]},
+    '4449444c036c0161016e026b03787f797f7a7f01000100', // Motoko: {a = ?#x} : {a : ?{#x;#y;#z}}
+    'extended variant under opt existing',
+  );
+  testDecode(
+    IDL.Record({a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null }))}),
+    {a: []},
+    '4449444c036c0161016e026b03787f797f7a7f01000102', // Motoko: {a = ?#z} : {a : ?{#x;#y;#z}}
+    'extended variant under opt new - defaulting',
+  );
+});

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -703,7 +703,7 @@ test('should decode matching optional fields if wire type contains additional fi
 describe('IDL opt variant decoding', () => {
   it('should handle the first of three variants', () => {
     testDecode(
-      Record({ a: Opt(Variant({ x: Null, y: Null, z: Null })) }),
+      IDL.Record({ a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null, z: IDL.Null })) }),
       { a: [{ x: null }] },
       '4449444c036c0161016e026b03787f797f7a7f01000100', // Motoko: {a = ?#x} : {a : ?{#x;#y;#z}},
       'same variant under opt x',
@@ -711,7 +711,7 @@ describe('IDL opt variant decoding', () => {
   });
   it('should handle the third of three variants', () => {
     testDecode(
-      Record({ a: Opt(Variant({ x: Null, y: Null, z: Null })) }),
+      IDL.Record({ a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null, z: IDL.Null })) }),
       { a: [{ z: null }] },
       '4449444c036c0161016e026b03787f797f7a7f01000102', // Motoko: {a = ?#z} : {a : ?{#x;#y;#z}}
       'same variant under opt z',
@@ -719,7 +719,7 @@ describe('IDL opt variant decoding', () => {
   });
   it('should handle the first of two variants', () => {
     testDecode(
-      Record({ a: Opt(Variant({ x: Null, y: Null })) }),
+      IDL.Record({ a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null })) }),
       { a: [{ x: null }] },
       '4449444c036c0161016e026b03787f797f7a7f01000100', // Motoko: {a = ?#x} : {a : ?{#x;#y;#z}}
       'extended variant under opt expected tag',
@@ -727,7 +727,7 @@ describe('IDL opt variant decoding', () => {
   });
   it('should handle the option when the option is empty', () => {
     testDecode(
-      Record({ a: Opt(Variant({ x: Null, y: Null })) }),
+      IDL.Record({ a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null })) }),
       { a: [] },
       '4449444c036c0161016e026b03787f797f7a7f01000102', // Motoko: {a = ?#z} : {a : ?{#x;#y;#z}}
       'extended variant under opt unexpected tag - defaulting',

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -700,29 +700,37 @@ test('should decode matching optional fields if wire type contains additional fi
 });
 
 
-test('IDL opt variant decoding', () => {
-  testDecode(
-    IDL.Record({a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null, z: IDL.Null }))}),
-    {a: [{ x: null }]},
-    '4449444c036c0161016e026b03787f797f7a7f01000100', // Motoko: {a = ?#x} : {a : ?{#x;#y;#z}}
-    'same variant under opt x',
-  );
-  testDecode(
-    IDL.Record({a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null, z: IDL.Null }))}),
-    {a: [{ z: null}]},
-    '4449444c036c0161016e026b03787f797f7a7f01000102', // Motoko: {a = ?#z} : {a : ?{#x;#y;#z}}
-    'same variant under opt z',
-  );
-  testDecode(
-    IDL.Record({a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null }))}),
-    {a: [{ x: null }]},
-    '4449444c036c0161016e026b03787f797f7a7f01000100', // Motoko: {a = ?#x} : {a : ?{#x;#y;#z}}
-    'extended variant under opt expected tag',
-  );
-  testDecode(
-    IDL.Record({a: IDL.Opt(IDL.Variant({ x: IDL.Null, y: IDL.Null }))}),
-    {a: []},
-    '4449444c036c0161016e026b03787f797f7a7f01000102', // Motoko: {a = ?#z} : {a : ?{#x;#y;#z}}
-    'extended variant under opt unexpected tag - defaulting',
-  );
+describe('IDL opt variant decoding', () => {
+  it('should handle the first of three variants', () => {
+    testDecode(
+      Record({ a: Opt(Variant({ x: Null, y: Null, z: Null })) }),
+      { a: [{ x: null }] },
+      '4449444c036c0161016e026b03787f797f7a7f01000100', // Motoko: {a = ?#x} : {a : ?{#x;#y;#z}},
+      'same variant under opt x',
+    );
+  });
+  it('should handle the third of three variants', () => {
+    testDecode(
+      Record({ a: Opt(Variant({ x: Null, y: Null, z: Null })) }),
+      { a: [{ z: null }] },
+      '4449444c036c0161016e026b03787f797f7a7f01000102', // Motoko: {a = ?#z} : {a : ?{#x;#y;#z}}
+      'same variant under opt z',
+    );
+  });
+  it('should handle the first of two variants', () => {
+    testDecode(
+      Record({ a: Opt(Variant({ x: Null, y: Null })) }),
+      { a: [{ x: null }] },
+      '4449444c036c0161016e026b03787f797f7a7f01000100', // Motoko: {a = ?#x} : {a : ?{#x;#y;#z}}
+      'extended variant under opt expected tag',
+    );
+  });
+  it('should handle the option when the option is empty', () => {
+    testDecode(
+      Record({ a: Opt(Variant({ x: Null, y: Null })) }),
+      { a: [] },
+      '4449444c036c0161016e026b03787f797f7a7f01000102', // Motoko: {a = ?#z} : {a : ?{#x;#y;#z}}
+      'extended variant under opt unexpected tag - defaulting',
+    );
+  });
 });

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -922,7 +922,16 @@ export class OptClass<T> extends ConstructType<[T] | []> {
       case 0:
         return [];
       case 1:
-        return [this._type.decodeValue(b, opt._type)];
+        let checkpoint = b.save();
+        try {
+          let v = this._type.decodeValue(b, opt._type)
+          return [v];
+        } catch (e : any) {
+          b.restore(checkpoint);
+          // skip value at wire typ (to advance b)
+          let v = opt._type.decodeValue(b, opt._type)
+          return [];
+        };
       default:
         throw new Error('Not an option value');
     }

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -928,8 +928,9 @@ export class OptClass<T> extends ConstructType<[T] | []> {
           return [v];
         } catch (e : any) {
           b.restore(checkpoint);
-          // skip value at wire typ (to advance b)
+          // skip value at wire type (to advance b)
           let v = opt._type.decodeValue(b, opt._type)
+	  // retun none
           return [];
         };
       default:

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -922,15 +922,19 @@ export class OptClass<T> extends ConstructType<[T] | []> {
       case 0:
         return [];
       case 1: {
+        // Save the current state of the Pipe `b` to allow rollback in case of an error
         const checkpoint = b.save();
         try {
-          const v = this._type.decodeValue(b, opt._type)
+          // Attempt to decode a value using the `_type` of the current instance
+          const v = this._type.decodeValue(b, opt._type);
+          // If decoding succeeds, return the value wrapped in an array
           return [v];
-        } catch (e : any) {
+        } catch (e: any) {
+          // If an error occurs during decoding, restore the Pipe `b` to its previous state
           b.restore(checkpoint);
-          // skip value at wire type (to advance b)
-          const v = opt._type.decodeValue(b, opt._type)
-          // retun none
+          // Skip the value at the current wire type to advance the Pipe `b` position
+          opt._type.decodeValue(b, opt._type);
+          // Return an empty array to indicate a `none` value
           return [];
         }
       }

--- a/packages/candid/src/idl.ts
+++ b/packages/candid/src/idl.ts
@@ -921,18 +921,19 @@ export class OptClass<T> extends ConstructType<[T] | []> {
     switch (safeReadUint8(b)) {
       case 0:
         return [];
-      case 1:
-        let checkpoint = b.save();
+      case 1: {
+        const checkpoint = b.save();
         try {
-          let v = this._type.decodeValue(b, opt._type)
+          const v = this._type.decodeValue(b, opt._type)
           return [v];
         } catch (e : any) {
           b.restore(checkpoint);
           // skip value at wire type (to advance b)
-          let v = opt._type.decodeValue(b, opt._type)
-	  // retun none
+          const v = opt._type.decodeValue(b, opt._type)
+          // retun none
           return [];
-        };
+        }
+      }
       default:
         throw new Error('Not an option value');
     }

--- a/packages/candid/src/utils/buffer.ts
+++ b/packages/candid/src/utils/buffer.ts
@@ -39,6 +39,20 @@ export class PipeArrayBuffer {
   private _view: Uint8Array;
 
   /**
+   * Save a checkpoint of the reading view (for backtracking)
+   */
+  public save() : Uint8Array {
+     return this._view;
+  };
+
+  /**
+   * Restore a checkpoint of the reading view (for backtracking)
+   */
+  public restore(checkPoint: Uint8Array) {
+     this._view = checkPoint;
+  };
+
+  /**
    * The actual buffer containing the bytes.
    * @private
    */

--- a/packages/candid/src/utils/buffer.ts
+++ b/packages/candid/src/utils/buffer.ts
@@ -43,14 +43,15 @@ export class PipeArrayBuffer {
    */
   public save() : Uint8Array {
      return this._view;
-  };
+  }
 
   /**
    * Restore a checkpoint of the reading view (for backtracking)
+   * @param checkPoint a previously saved checkpoint
    */
   public restore(checkPoint: Uint8Array) {
      this._view = checkPoint;
-  };
+  }
 
   /**
    * The actual buffer containing the bytes.


### PR DESCRIPTION
# Description

Fixes decoding of variants under option types, allowing compatible tagged values from wider options, defaulting incompatible tagged values to null.

Brings decoding of options closer to spec, but see child PR #981 for the remaining edge cases.

This PR is marked `do not merge` until #981 is merged into this one.

# How Has This Been Tested?

See PR for additional candid tests.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.

What CHANGELOG?