### PR TITLE
feat: Change auth-client's default identity provider url

### DIFF
--- a/demos/sample-javascript/src/index.html
+++ b/demos/sample-javascript/src/index.html
@@ -5,7 +5,7 @@
       <h2>Sign In</h2>
       <div>
         <label for="idpUrl" style="display: inline-block; width: 120px">Identity Provider: </label>
-        <input type="text" id="idpUrl" value="https://identity.ic0.app/" />
+        <input type="text" id="idpUrl" value="https://identity.internetcomputer.org/" />
       </div>
       <button id="signinBtn">Sign In</button>
       <button id="signoutBtn">Sign Out</button>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- feat: change auth-client's default identity provider url
+
 ## [2.4.0] - 2025-03-24
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -16180,9 +16180,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -418,7 +418,7 @@ function setup(options?: { onAuthRequest?: () => void }) {
   global.addEventListener = jest.fn((_, callback) => {
     // eslint-disable-next-line
     // @ts-ignore
-    idpMock = new IdpMock(callback, 'https://identity.ic0.app');
+    idpMock = new IdpMock(callback, 'https://identity.internetcomputer.org');
   });
 
   // Mock window.open and window.postMessage since we can't open windows here.
@@ -457,7 +457,7 @@ describe('Auth Client login', () => {
     global.open = jest.fn();
     await client.login();
     expect(global.open).toBeCalledWith(
-      'https://identity.ic0.app/#authorize',
+      'https://identity.internetcomputer.org/#authorize',
       'idpWindow',
       undefined,
     );
@@ -468,7 +468,7 @@ describe('Auth Client login', () => {
       windowOpenerFeatures: 'toolbar=0,location=0,menubar=0',
     });
     expect(global.open).toBeCalledWith(
-      'https://identity.ic0.app/#authorize',
+      'https://identity.internetcomputer.org/#authorize',
       'idpWindow',
       'toolbar=0,location=0,menubar=0',
     );

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -94,7 +94,7 @@ export type OnErrorFunc = (error?: string) => void | Promise<void>;
 export interface AuthClientLoginOptions {
   /**
    * Identity provider
-   * @default "https://identity.ic0.app"
+   * @default "https://identity.internetcomputer.org"
    */
   identityProvider?: string | URL;
   /**

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -31,7 +31,7 @@ import { PartialIdentity } from '@dfinity/identity/lib/cjs/identity/partial';
 export { AuthClientStorage, IdbStorage, LocalStorage, KEY_STORAGE_DELEGATION, KEY_STORAGE_KEY } from './storage';
 export { IdbKeyVal, DBCreateOptions } from './db';
 
-const IDENTITY_PROVIDER_DEFAULT = 'https://identity.ic0.app';
+const IDENTITY_PROVIDER_DEFAULT = 'https://identity.internetcomputer.org';
 const IDENTITY_PROVIDER_ENDPOINT = '#authorize';
 
 const ECDSA_KEY_LABEL = 'ECDSA';

--- a/packages/use-auth-client/README.md
+++ b/packages/use-auth-client/README.md
@@ -21,7 +21,7 @@ const App = () => {
     process.env.DFX_NETWORK === 'local'
       ? // eslint-disable-next-line no-undef
         `http://${process.env.CANISTER_ID_INTERNET_IDENTITY}.localhost:4943`
-      : 'https://identity.ic0.app';
+      : 'https://identity.internetcomputer.org';
 
   const { isAuthenticated, login, logout, actor } = useAuthClient({
     loginOptions: {

--- a/packages/use-auth-client/examples/auth-demo/src/auth-demo-frontend/src/App.tsx
+++ b/packages/use-auth-client/examples/auth-demo/src/auth-demo-frontend/src/App.tsx
@@ -31,7 +31,7 @@ function App() {
     process.env.DFX_NETWORK === 'local'
       ? // eslint-disable-next-line no-undef
         `http://${process.env.CANISTER_ID_INTERNET_IDENTITY}.localhost:4943`
-      : 'https://identity.ic0.app';
+      : 'https://identity.internetcomputer.org';
 
   const { isAuthenticated, login, logout, actors } = useAuthClient({
     loginOptions: {


### PR DESCRIPTION
# Description

Change the identity provider default URL to `https://identity.internetcomputer.org`.

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
