### PR TITLE
 fix: fixes a bug in the `Principal` library where the management can…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- fix: fixes a bug in the `Principal` library where the management canister id util was incorrectly importing using `fromHex`
 - feat: change auth-client's default identity provider url
 
 ## [2.4.0] - 2025-03-24

--- a/packages/principal/src/index.test.ts
+++ b/packages/principal/src/index.test.ts
@@ -66,4 +66,9 @@ describe('Principal', () => {
     const json = JSON.stringify(principal);
     expect(Principal.from(json)).toEqual(principal);
   });
+
+  it('returns the management canister principal', () => {
+    const principal = Principal.fromText('aaaaa-aa');
+    expect(Principal.managementCanister()).toEqual(principal);
+  });
 });

--- a/packages/principal/src/index.ts
+++ b/packages/principal/src/index.ts
@@ -6,7 +6,7 @@ export const JSON_KEY_PRINCIPAL = '__principal__';
 const SELF_AUTHENTICATING_SUFFIX = 2;
 const ANONYMOUS_SUFFIX = 4;
 
-const MANAGEMENT_CANISTER_PRINCIPAL_HEX_STR = 'aaaaa-aa';
+const MANAGEMENT_CANISTER_PRINCIPAL_TEXT_STR = 'aaaaa-aa';
 
 const fromHexString = (hexString: string) =>
   new Uint8Array((hexString.match(/.{1,2}/g) ?? []).map(byte => parseInt(byte, 16)));
@@ -28,7 +28,7 @@ export class Principal {
    * @returns {Principal} principal of the management canister
    */
   public static managementCanister(): Principal {
-    return this.fromHex(MANAGEMENT_CANISTER_PRINCIPAL_HEX_STR);
+    return this.fromText(MANAGEMENT_CANISTER_PRINCIPAL_TEXT_STR);
   }
 
   public static selfAuthenticating(publicKey: Uint8Array): Principal {


### PR DESCRIPTION
where the management canister id util was incorrectly importing using `fromHex`

Fixes #855 


# How Has This Been Tested?

new unit test

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
