### PR TITLE
fix: fixes a bug in the Ed25519KeyIdentity verify implementation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- fix: fixes a bug in the Ed25519KeyIdentity verify implementation where the argument order was incorrect
 - fix: fixes a bug in the `Principal` library where the management canister id util was incorrectly importing using `fromHex`
 - feat: change auth-client's default identity provider url
 

--- a/packages/identity/src/identity/delegation.test.ts
+++ b/packages/identity/src/identity/delegation.test.ts
@@ -2,6 +2,7 @@ import { Principal } from '@dfinity/principal';
 import { DelegationChain, DelegationIdentity, PartialDelegationIdentity } from './delegation';
 import { Ed25519KeyIdentity } from './ed25519';
 import { Ed25519PublicKey } from '@dfinity/agent';
+import { bufFromBufLike } from '@dfinity/candid';
 
 function createIdentity(seed: number): Ed25519KeyIdentity {
   const s = new Uint8Array([seed, ...new Array(31).fill(0)]);
@@ -113,12 +114,12 @@ test('Delegation Chain can sign', async () => {
 
   const identity = DelegationIdentity.fromDelegation(middle, rootToMiddle);
 
-  const signature = await identity.sign(new Uint8Array([1, 2, 3]));
+  const signature = await identity.sign(bufFromBufLike(new Uint8Array([1, 2, 3])));
 
   const isValid = Ed25519KeyIdentity.verify(
-    new Uint8Array([1, 2, 3]),
     signature,
-    middle.getPublicKey().rawKey as Uint8Array,
+    new Uint8Array([1, 2, 3]),
+    bufFromBufLike(middle.getPublicKey().rawKey),
   );
   expect(isValid).toBe(true);
   expect(middle.toJSON()[1].length).toBe(64);
@@ -126,7 +127,7 @@ test('Delegation Chain can sign', async () => {
 
 describe('PartialDelegationIdentity', () => {
   it('should create a partial identity from a public key and a delegation chain', async () => {
-    const key = Ed25519PublicKey.fromRaw(new Uint8Array(32).fill(0));
+    const key = Ed25519PublicKey.fromRaw(bufFromBufLike(new Uint8Array(32).fill(0)));
     const signingIdentity = Ed25519KeyIdentity.generate(new Uint8Array(32).fill(1));
     const chain = await DelegationChain.create(signingIdentity, key, new Date(1609459200000));
 
@@ -145,7 +146,7 @@ describe('PartialDelegationIdentity', () => {
     );
   });
   it('should throw an error if one attempts to sign', async () => {
-    const key = Ed25519PublicKey.fromRaw(new Uint8Array(32).fill(0));
+    const key = Ed25519PublicKey.fromRaw(bufFromBufLike(new Uint8Array(32).fill(0)));
     const signingIdentity = Ed25519KeyIdentity.generate(new Uint8Array(32).fill(1));
     const chain = await DelegationChain.create(signingIdentity, key, new Date(1609459200000));
 

--- a/packages/identity/src/identity/ed25519.test.ts
+++ b/packages/identity/src/identity/ed25519.test.ts
@@ -142,8 +142,8 @@ test('from JSON', async () => {
   const identity = Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
 
   const msg = new TextEncoder().encode('Hello, World!');
-  const signature = await identity.sign(msg);
-  const isValid = Ed25519KeyIdentity.verify(msg, signature, identity.getPublicKey().rawKey);
+  const signature = await identity.sign(bufFromBufLike(msg));
+  const isValid = Ed25519KeyIdentity.verify(signature, msg, identity.getPublicKey().rawKey);
   expect(isValid).toBe(true);
 });
 

--- a/packages/identity/src/identity/ed25519.test.ts
+++ b/packages/identity/src/identity/ed25519.test.ts
@@ -1,5 +1,6 @@
 import { DerEncodedPublicKey, PublicKey, fromHex, toHex } from '@dfinity/agent';
 import { Ed25519KeyIdentity, Ed25519PublicKey } from './ed25519';
+import { bufFromBufLike } from '@dfinity/candid';
 
 const testVectors: Array<[string, string]> = [
   [
@@ -107,10 +108,10 @@ describe('Ed25519KeyIdentity tests', () => {
     const identity = Ed25519KeyIdentity.generate();
     const message = new TextEncoder().encode('Hello, World!');
 
-    const signature = await identity.sign(message);
+    const signature = await identity.sign(bufFromBufLike(message));
     const pubkey = identity.getPublicKey();
 
-    const isValid = Ed25519KeyIdentity.verify(message, signature, pubkey.rawKey);
+    const isValid = Ed25519KeyIdentity.verify(signature, message, pubkey.rawKey);
 
     expect(isValid).toBe(true);
   });
@@ -120,13 +121,15 @@ describe('Ed25519KeyIdentity tests', () => {
     const key2 = Ed25519KeyIdentity.generate();
     expect(key1.toJSON().toString()).not.toEqual(key2.toJSON().toString());
   });
-  
+
   it('should warn if the key is an Uint8Array consisting of all zeroes', () => {
     const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const baseKey = new Uint8Array(new Array(32).fill(0));
     Ed25519KeyIdentity.generate(baseKey);
-    expect(consoleSpy).toHaveBeenCalledWith("Seed is all zeros. This is not a secure seed. Please provide a seed with sufficient entropy if this is a production environment.");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Seed is all zeros. This is not a secure seed. Please provide a seed with sufficient entropy if this is a production environment.',
+    );
   });
 });
 

--- a/packages/identity/src/identity/ed25519.ts
+++ b/packages/identity/src/identity/ed25519.ts
@@ -230,11 +230,11 @@ export class Ed25519KeyIdentity extends SignIdentity {
         x = fromHex(x);
       }
       if (x instanceof Uint8Array) {
-        x = x.buffer;
+        x = bufFromBufLike(x.buffer);
       }
       return new Uint8Array(x);
     });
-    return ed25519.verify(message, signature, publicKey);
+    return ed25519.verify(signature, message, publicKey);
   }
 }
 

--- a/packages/identity/src/identity/partial.ts
+++ b/packages/identity/src/identity/partial.ts
@@ -1,5 +1,4 @@
 import { Identity, PublicKey } from '@dfinity/agent';
-import { bufFromBufLike } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 
 /**

--- a/packages/identity/src/identity/partial.ts
+++ b/packages/identity/src/identity/partial.ts
@@ -1,4 +1,5 @@
 import { Identity, PublicKey } from '@dfinity/agent';
+import { bufFromBufLike } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 
 /**
@@ -39,7 +40,10 @@ export class PartialIdentity implements Identity {
    * The {@link Principal} of this identity.
    */
   public getPrincipal(): Principal {
-    return Principal.from(this.#inner.rawKey);
+    if (!this.#inner.rawKey) {
+      throw new Error('Cannot get principal from a public key without a raw key.');
+    }
+    return Principal.fromUint8Array(new Uint8Array(this.#inner.rawKey));
   }
 
   /**


### PR DESCRIPTION
# Description

The msg and signature arguments were being passed into @noble/curves in the incorrect sequence

Fixes #943 
closes SDK-2073

# How Has This Been Tested?

Fixes existing unit test

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
