### PR TITLE
fix: fixes a bug in Ed25519KeyIdentity `toRaw`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- fix: fixes a bug in Ed25519KeyIdentity `toRaw` where the output was not an ArrayBuffer
 - fix: fixes a bug in the Ed25519KeyIdentity verify implementation where the argument order was incorrect
 - fix: fixes a bug in the `Principal` library where the management canister id util was incorrectly importing using `fromHex`
 - feat: change auth-client's default identity provider url

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -48,7 +48,6 @@ import { Ed25519PublicKey } from '../../public_key';
 import { decodeTime } from '../../utils/leb';
 import { ObservableLog } from '../../observable';
 import { BackoffStrategy, BackoffStrategyFactory, ExponentialBackoff } from '../../polling/backoff';
-import { DEFAULT_INGRESS_EXPIRY_DELTA_IN_MSECS } from '../../constants';
 export * from './transforms';
 export * from './errors';
 export { Nonce, makeNonce } from './types';
@@ -981,7 +980,7 @@ export class HttpAgent implements Agent {
     }
     const { status, signatures = [], requestId } = queryResponse;
 
-    const domainSeparator = new TextEncoder().encode('\x0Bic-response');
+    const domainSeparator = bufFromBufLike(new TextEncoder().encode('\x0Bic-response'));
     for (const sig of signatures) {
       const { timestamp, identity } = sig;
       const nodeId = Principal.fromUint8Array(identity).toText();
@@ -1010,7 +1009,7 @@ export class HttpAgent implements Agent {
         throw new Error(`Unknown status: ${status}`);
       }
 
-      const separatorWithHash = concat(domainSeparator, new Uint8Array(hash));
+      const separatorWithHash = concat(domainSeparator, bufFromBufLike(new Uint8Array(hash)));
 
       // FIX: check for match without verifying N times
       const pubKey = subnetStatus?.nodeKeys.get(nodeId);
@@ -1080,7 +1079,7 @@ export class HttpAgent implements Agent {
     function getRequestId(fields: ReadStateOptions): RequestId | undefined {
       for (const path of fields.paths) {
         const [pathName, value] = path;
-        const request_status = new TextEncoder().encode('request_status');
+        const request_status = bufFromBufLike(new TextEncoder().encode('request_status'));
         if (bufEquals(pathName, request_status)) {
           return value as RequestId;
         }

--- a/packages/identity/src/identity/ed25519.ts
+++ b/packages/identity/src/identity/ed25519.ts
@@ -73,7 +73,7 @@ export class Ed25519PublicKey implements PublicKey {
     if (unwrapped.length !== this.RAW_KEY_LENGTH) {
       throw new Error('An Ed25519 public key must be exactly 32bytes long');
     }
-    return unwrapped;
+    return bufFromBufLike(unwrapped);
   }
 
   #rawKey: ArrayBuffer;
@@ -93,7 +93,7 @@ export class Ed25519PublicKey implements PublicKey {
     if (key.byteLength !== Ed25519PublicKey.RAW_KEY_LENGTH) {
       throw new Error('An Ed25519 public key must be exactly 32bytes long');
     }
-    this.#rawKey = key;
+    this.#rawKey = bufFromBufLike(key);
     this.#derKey = Ed25519PublicKey.derEncode(key);
   }
 


### PR DESCRIPTION
where the output was not an arraybuffer



Fixes #989
Closes SDK-2078

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
