### PR TITLE
test: fixes e2e tests for compatibility with dfx 0.26.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- test: fixes e2e tests for compatibility with dfx 0.26.0 and `pocket-ic` by querying for the `default_effective_canister_id` before calling the management canister
 - fix: fixes a bug in the Ed25519KeyIdentity verify implementation where the argument order was incorrect
 - fix: fixes a bug in the `Principal` library where the management canister id util was incorrectly importing using `fromHex`
 - feat: change auth-client's default identity provider url

--- a/e2e/node/basic/basic.test.ts
+++ b/e2e/node/basic/basic.test.ts
@@ -10,21 +10,48 @@ import { Principal } from '@dfinity/principal';
 import agent from '../utils/agent';
 import { test, expect } from 'vitest';
 
+/**
+ * Util for determining the default effective canister id, necessary for pocketic
+ * @returns the default effective canister id
+ */
+export async function getDefaultEffectiveCanisterId() {
+  const res = await fetch('http://localhost:4943/_/topology'); //?
+  const data = await res.json(); //?
+  const id = data['default_effective_canister_id']['canister_id'];
+  // decode from base64
+  const decoded = Buffer.from(id, 'base64').toString('hex');
+
+  return Principal.fromHex(decoded);
+}
+
+test('createCanister', async () => {
+  // Make sure this doesn't fail.
+  await getManagementCanister({
+    agent: await agent,
+  }).provisional_create_canister_with_cycles({
+    amount: [BigInt(1e12)],
+    settings: [],
+    specified_id: [],
+    sender_canister_version: [],
+  });
+});
 test('read_state', async () => {
+  const ecid = await getDefaultEffectiveCanisterId();
   const resolvedAgent = await agent;
   const now = Date.now() / 1000;
   const path = [new TextEncoder().encode('time')];
-  const canisterId = Principal.fromHex('00000000000000000001');
-  const response = await resolvedAgent.readState(canisterId, {
+  const response = await resolvedAgent.readState(ecid, {
     paths: [path],
   });
   if (resolvedAgent.rootKey == null) throw new Error(`The agent doesn't have a root key yet`);
   const cert = await Certificate.create({
     certificate: response.certificate,
     rootKey: resolvedAgent.rootKey,
-    canisterId: canisterId,
+    canisterId: ecid,
   });
-  expect(cert.lookup([new TextEncoder().encode('Time')])).toEqual({ status: LookupStatus.Unknown });
+  expect(cert.lookup([new TextEncoder().encode('Time')])).toEqual({
+    status: LookupStatus.Unknown,
+  });
 
   let rawTime = cert.lookup(path);
 
@@ -51,7 +78,7 @@ test('read_state with passed request', async () => {
   const resolvedAgent = await agent;
   const now = Date.now() / 1000;
   const path = [new TextEncoder().encode('time')];
-  const canisterId = Principal.fromHex('00000000000000000001');
+  const canisterId = await getDefaultEffectiveCanisterId();
   const request = await resolvedAgent.createReadStateRequest({ paths: [path] });
   const response = await resolvedAgent.readState(
     canisterId,
@@ -67,7 +94,9 @@ test('read_state with passed request', async () => {
     rootKey: resolvedAgent.rootKey,
     canisterId: canisterId,
   });
-  expect(cert.lookup([new TextEncoder().encode('Time')])).toEqual({ status: LookupStatus.Unknown });
+  expect(cert.lookup([new TextEncoder().encode('Time')])).toEqual({
+    status: LookupStatus.Unknown,
+  });
 
   let rawTime = cert.lookup(path);
 
@@ -88,18 +117,6 @@ test('read_state with passed request', async () => {
   const time = Number(decoded as any) / 1e9;
   // The diff between decoded time and local time is within 5s
   expect(Math.abs(time - now) < 5).toBe(true);
-});
-
-test('createCanister', async () => {
-  // Make sure this doesn't fail.
-  await getManagementCanister({
-    agent: await agent,
-  }).provisional_create_canister_with_cycles({
-    amount: [BigInt(1e12)],
-    settings: [],
-    specified_id: [],
-    sender_canister_version: [],
-  });
 });
 
 test('withOptions', async () => {

--- a/e2e/node/canisters/counter.ts
+++ b/e2e/node/canisters/counter.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'fs';
 import path from 'path';
 import agent, { makeAgent } from '../utils/agent';
 import { _SERVICE } from './declarations/counter';
+import { getDefaultEffectiveCanisterId } from '../basic/basic.test';
 
 let cache: {
   canisterId: Principal;
@@ -61,7 +62,10 @@ export const createActor = async (options?: HttpAgentOptions, agent?: Agent) => 
     //
   }
 
-  const canisterId = await Actor.createCanister({ agent: effectiveAgent });
+  const canisterId = await Actor.createCanister({
+    agent: effectiveAgent,
+    effectiveCanisterId: await getDefaultEffectiveCanisterId(),
+  });
   await Actor.install({ module }, { canisterId, agent: effectiveAgent });
   return Actor.createActor(idl, { canisterId, agent: effectiveAgent }) as ActorSubclass<_SERVICE>;
 };


### PR DESCRIPTION
# Description

Our e2e changes started failing with the release of dfx 0.26.0 and calls to the management canister. Now we use a dynamic default effective canister id for when there are no known canisters on the entire network in the tests

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
