### PR TITLE
ci: ubuntu latest for unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         ghc: ['8.8.4']
         spec:
           - '0.16.1'


### PR DESCRIPTION
# Description

the pinned version of ubuntu just was deprecated: https://github.com/actions/runner-images/issues/11101

using ubuntu latest going forward