### PR TITLE
refactor: use new error system and error codes

### DIFF
--- a/e2e/node/basic/mitm.test.ts
+++ b/e2e/node/basic/mitm.test.ts
@@ -39,14 +39,12 @@ mitmTest('mitm with query verification', async () => {
   try {
     await counter.greet('counter');
   } catch (error) {
-    console.log(error);
     expect(error).toBeInstanceOf(CertificateVerificationErrorV2);
     expect(error.cause.kind).toBe(ErrorKind.Trust);
   }
   try {
     await counter.queryGreet('counter');
   } catch (error) {
-    console.log(error);
     expect(error).toBeInstanceOf(AgentQueryError);
   }
 });

--- a/e2e/node/basic/mitm.test.ts
+++ b/e2e/node/basic/mitm.test.ts
@@ -1,6 +1,7 @@
 import { createActor } from '../canisters/declarations/counter/index';
 import { test, expect, TestAPI } from 'vitest';
 import { makeAgent } from '../utils/agent';
+import { AgentQueryError, CertificateVerificationErrorV2, ErrorKind } from '@dfinity/agent';
 
 let mitmTest: TestAPI | typeof test.skip = test;
 if (!process.env['MITM']) {
@@ -15,19 +16,37 @@ mitmTest(
         verifyQuerySignatures: false,
       }),
     });
-    await expect(counter.greet('counter')).rejects.toThrow(/Invalid certificate/);
+    expect.assertions(3);
+    try {
+      await counter.greet('counter');
+    } catch (error) {
+      expect(error).toBeInstanceOf(CertificateVerificationErrorV2);
+      expect(error.cause.kind).toBe(ErrorKind.Trust);
+    }
     expect(await counter.queryGreet('counter')).toEqual('Hullo, counter!');
   },
   { timeout: 30000 },
 );
 
 mitmTest('mitm with query verification', async () => {
-  const counter = await createActor('tnnnb-2yaaa-aaaab-qaiiq-cai', {
+  const counter = createActor('tnnnb-2yaaa-aaaab-qaiiq-cai', {
     agent: await makeAgent({
       host: 'http://127.0.0.1:8888',
       verifyQuerySignatures: true,
     }),
   });
-  await expect(counter.greet('counter')).rejects.toThrow(/Invalid certificate/);
-  await expect(counter.queryGreet('counter')).rejects.toThrow(/Invalid certificate/);
+  expect.assertions(3);
+  try {
+    await counter.greet('counter');
+  } catch (error) {
+    console.log(error);
+    expect(error).toBeInstanceOf(CertificateVerificationErrorV2);
+    expect(error.cause.kind).toBe(ErrorKind.Trust);
+  }
+  try {
+    await counter.queryGreet('counter');
+  } catch (error) {
+    console.log(error);
+    expect(error).toBeInstanceOf(AgentQueryError);
+  }
 });

--- a/e2e/node/basic/mitm.test.ts
+++ b/e2e/node/basic/mitm.test.ts
@@ -1,7 +1,7 @@
 import { createActor } from '../canisters/declarations/counter/index';
 import { test, expect, TestAPI } from 'vitest';
 import { makeAgent } from '../utils/agent';
-import { AgentQueryError, CertificateVerificationErrorV2, ErrorKind } from '@dfinity/agent';
+import { AgentQueryError, CertificateVerificationErrorCode, TrustError } from '@dfinity/agent';
 
 let mitmTest: TestAPI | typeof test.skip = test;
 if (!process.env['MITM']) {
@@ -20,8 +20,8 @@ mitmTest(
     try {
       await counter.greet('counter');
     } catch (error) {
-      expect(error).toBeInstanceOf(CertificateVerificationErrorV2);
-      expect(error.cause.kind).toBe(ErrorKind.Trust);
+      expect(error).toBeInstanceOf(TrustError);
+      expect(error.cause.code).toBeInstanceOf(CertificateVerificationErrorCode);
     }
     expect(await counter.queryGreet('counter')).toEqual('Hullo, counter!');
   },
@@ -39,8 +39,8 @@ mitmTest('mitm with query verification', async () => {
   try {
     await counter.greet('counter');
   } catch (error) {
-    expect(error).toBeInstanceOf(CertificateVerificationErrorV2);
-    expect(error.cause.kind).toBe(ErrorKind.Trust);
+    expect(error).toBeInstanceOf(TrustError);
+    expect(error.cause.code).toBeInstanceOf(CertificateVerificationErrorCode);
   }
   try {
     await counter.queryGreet('counter');

--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -665,7 +665,12 @@ export function getManagementCanister(config: CallConfig): ActorSubclass<Managem
     }
     const first = args[0];
     let effectiveCanisterId = Principal.fromHex('');
-    if (first && typeof first === 'object' && first.target_canister && methodName === "install_chunked_code") {
+    if (
+      first &&
+      typeof first === 'object' &&
+      first.target_canister &&
+      methodName === 'install_chunked_code'
+    ) {
       effectiveCanisterId = Principal.from(first.target_canister);
     }
     if (first && typeof first === 'object' && first.canister_id) {

--- a/packages/agent/src/canisterStatus/index.ts
+++ b/packages/agent/src/canisterStatus/index.ts
@@ -1,6 +1,6 @@
 /** @module CanisterStatus */
 import { Principal } from '@dfinity/principal';
-import { AgentError } from '../errors';
+import { CertificateVerificationError } from '../errors';
 import { HttpAgent } from '../agent/http';
 import {
   Cert,
@@ -234,8 +234,8 @@ export const request = async (options: {
         }
       } catch (error) {
         // Break on signature verification errors
-        if ((error as AgentError)?.message?.includes('Invalid certificate')) {
-          throw new AgentError((error as AgentError).message);
+        if (error instanceof CertificateVerificationError) {
+          throw error;
         }
         if (typeof path !== 'string' && 'key' in path && 'path' in path) {
           status.set(path.key, null);

--- a/packages/agent/src/cbor.ts
+++ b/packages/agent/src/cbor.ts
@@ -5,7 +5,7 @@ import * as cbor from 'simple-cbor';
 import { CborEncoder, SelfDescribeCborSerializer } from 'simple-cbor';
 import { Principal } from '@dfinity/principal';
 import { concat, fromHex } from './utils/buffer';
-import { CborDecodeError, ErrorKind } from './errors';
+import { CborDecodeErrorCode, InputError } from './errors';
 
 // We are using hansl/simple-cbor for CBOR serialization, to avoid issues with
 // encoding the uint64 values that the HTTP handler of the client expects for
@@ -139,6 +139,6 @@ export function decode<T>(input: ArrayBuffer): T {
   try {
     return decoder.decodeFirst(buffer);
   } catch (error: unknown) {
-    throw new CborDecodeError({ error, input: buffer }, ErrorKind.Input);
+    throw InputError.fromCode(new CborDecodeErrorCode(error, buffer));
   }
 }

--- a/packages/agent/src/cbor.ts
+++ b/packages/agent/src/cbor.ts
@@ -4,7 +4,8 @@ import borc from 'borc';
 import * as cbor from 'simple-cbor';
 import { CborEncoder, SelfDescribeCborSerializer } from 'simple-cbor';
 import { Principal } from '@dfinity/principal';
-import { concat, fromHex, toHex } from './utils/buffer';
+import { concat, fromHex } from './utils/buffer';
+import { CborDecodeError, ErrorKind } from './errors';
 
 // We are using hansl/simple-cbor for CBOR serialization, to avoid issues with
 // encoding the uint64 values that the HTTP handler of the client expects for
@@ -137,7 +138,7 @@ export function decode<T>(input: ArrayBuffer): T {
 
   try {
     return decoder.decodeFirst(buffer);
-  } catch (e: unknown) {
-    throw new Error(`Failed to decode CBOR: ${e}, input: ${toHex(buffer)}`);
+  } catch (error: unknown) {
+    throw new CborDecodeError({ error, input: buffer }, ErrorKind.Input);
   }
 }

--- a/packages/agent/src/certificate.test.ts
+++ b/packages/agent/src/certificate.test.ts
@@ -12,11 +12,12 @@ import { readFileSync } from 'fs';
 import path from 'path';
 import { IC_ROOT_KEY } from './agent';
 import {
-  CertificateHasTooManyDelegationsError,
-  CertificateNotAuthorizedError,
-  CertificateTimeError,
-  CertificateVerificationError,
-  ErrorKind,
+  CertificateHasTooManyDelegationsErrorCode,
+  CertificateNotAuthorizedErrorCode,
+  CertificateTimeErrorCode,
+  CertificateVerificationErrorCode,
+  ProtocolError,
+  TrustError,
 } from './errors';
 
 function label(str: string): ArrayBuffer {
@@ -424,8 +425,8 @@ test('delegation check fails for canisters outside of the subnet range', async (
         canisterId: canisterId,
       });
     } catch (error) {
-      expect(error).toBeInstanceOf(CertificateNotAuthorizedError);
-      expect(error.cause.kind).toBe(ErrorKind.Trust);
+      expect(error).toBeInstanceOf(TrustError);
+      expect(error.cause.code).toBeInstanceOf(CertificateNotAuthorizedErrorCode);
     }
   }
   expect.assertions(4);
@@ -451,8 +452,8 @@ test('certificate verification fails for an invalid signature', async () => {
       canisterId: Principal.fromText('ivg37-qiaaa-aaaab-aaaga-cai'),
     });
   } catch (error) {
-    expect(error).toBeInstanceOf(CertificateVerificationError);
-    expect(error.cause.kind).toBe(ErrorKind.Trust);
+    expect(error).toBeInstanceOf(TrustError);
+    expect(error.cause.code).toBeInstanceOf(CertificateVerificationErrorCode);
   }
 });
 
@@ -471,8 +472,8 @@ test('certificate verification fails if the time of the certificate is > 5 minut
       blsVerify: async () => true,
     });
   } catch (error) {
-    expect(error).toBeInstanceOf(CertificateTimeError);
-    expect(error.cause.kind).toBe(ErrorKind.Trust);
+    expect(error).toBeInstanceOf(TrustError);
+    expect(error.cause.code).toBeInstanceOf(CertificateTimeErrorCode);
   }
 });
 
@@ -490,8 +491,8 @@ test('certificate verification fails if the time of the certificate is > 5 minut
       blsVerify: async () => true,
     });
   } catch (error) {
-    expect(error).toBeInstanceOf(CertificateTimeError);
-    expect(error.cause.kind).toBe(ErrorKind.Trust);
+    expect(error).toBeInstanceOf(TrustError);
+    expect(error.cause.code).toBeInstanceOf(CertificateTimeErrorCode);
   }
 });
 
@@ -522,8 +523,8 @@ test('certificate verification fails on nested delegations', async () => {
       canisterId: canisterId,
     });
   } catch (error) {
-    expect(error).toBeInstanceOf(CertificateHasTooManyDelegationsError);
-    expect(error.cause.kind).toBe(ErrorKind.Protocol);
+    expect(error).toBeInstanceOf(ProtocolError);
+    expect(error.cause.code).toBeInstanceOf(CertificateHasTooManyDelegationsErrorCode);
   }
   try {
     await Cert.Certificate.create({
@@ -532,7 +533,7 @@ test('certificate verification fails on nested delegations', async () => {
       canisterId: canisterId,
     });
   } catch (error) {
-    expect(error).toBeInstanceOf(CertificateHasTooManyDelegationsError);
-    expect(error.cause.kind).toBe(ErrorKind.Protocol);
+    expect(error).toBeInstanceOf(ProtocolError);
+    expect(error.cause.code).toBeInstanceOf(CertificateHasTooManyDelegationsErrorCode);
   }
 });

--- a/packages/agent/src/certificate.test.ts
+++ b/packages/agent/src/certificate.test.ts
@@ -11,6 +11,12 @@ import { decodeTime } from './utils/leb';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { IC_ROOT_KEY } from './agent';
+import {
+  CertificateHasTooManyDelegationsError,
+  CertificateNotAuthorizedError,
+  CertificateTimeError,
+  CertificateVerificationError,
+} from './errors';
 
 function label(str: string): ArrayBuffer {
   return new TextEncoder().encode(str);
@@ -416,7 +422,7 @@ test('delegation check fails for canisters outside of the subnet range', async (
         rootKey: fromHex(IC_ROOT_KEY),
         canisterId: canisterId,
       }),
-    ).rejects.toThrow(/Invalid certificate/);
+    ).rejects.toThrow(CertificateNotAuthorizedError);
   }
   await certificateFails(beforeRange);
   await certificateFails(afterRange);
@@ -438,7 +444,7 @@ test('certificate verification fails for an invalid signature', async () => {
       rootKey: fromHex(IC_ROOT_KEY),
       canisterId: Principal.fromText('ivg37-qiaaa-aaaab-aaaga-cai'),
     }),
-  ).rejects.toThrow('Invalid certificate');
+  ).rejects.toThrow(CertificateVerificationError);
 });
 
 test('certificate verification fails if the time of the certificate is > 5 minutes in the past', async () => {
@@ -454,7 +460,7 @@ test('certificate verification fails if the time of the certificate is > 5 minut
       canisterId: Principal.fromText('ivg37-qiaaa-aaaab-aaaga-cai'),
       blsVerify: async () => true,
     }),
-  ).rejects.toThrow('Invalid certificate: Certificate is signed more than 5 minutes in the past');
+  ).rejects.toThrow(CertificateTimeError);
 });
 
 test('certificate verification fails if the time of the certificate is > 5 minutes in the future', async () => {
@@ -470,7 +476,7 @@ test('certificate verification fails if the time of the certificate is > 5 minut
       canisterId: Principal.fromText('ivg37-qiaaa-aaaab-aaaga-cai'),
       blsVerify: async () => true,
     }),
-  ).rejects.toThrow('Invalid certificate: Certificate is signed more than 5 minutes in the future');
+  ).rejects.toThrow(CertificateTimeError);
 });
 
 test('certificate verification fails on nested delegations', async () => {
@@ -498,5 +504,5 @@ test('certificate verification fails on nested delegations', async () => {
       rootKey: fromHex(IC_ROOT_KEY),
       canisterId: canisterId,
     }),
-  ).rejects.toThrow('Invalid certificate: Delegation certificates cannot be nested');
+  ).rejects.toThrow(CertificateHasTooManyDelegationsError);
 });

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -7,6 +7,7 @@ import {
 } from './agent/api';
 import { RequestId } from './request_id';
 import { toHex } from './utils/buffer';
+import { RequestStatusResponseStatus } from './agent/http';
 
 export enum ErrorKind {
   Trust = 'Trust',
@@ -317,6 +318,39 @@ export class HexDecodeError extends AgentErrorV2 {
   constructor(options: { error: string }, kind: ErrorKind) {
     super(new HexDecodeErrorCode(options.error), kind);
     Object.setPrototypeOf(this, HexDecodeError.prototype);
+  }
+}
+
+class TimeoutWaitingForResponseErrorCode implements ErrorCode {
+  constructor(
+    public readonly message: string,
+    public readonly requestId: RequestId,
+    public readonly status: RequestStatusResponseStatus,
+  ) {
+    Object.setPrototypeOf(this, TimeoutWaitingForResponseErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return (
+      `${this.message}:\n` +
+      `  Request ID: ${toHex(this.requestId)}\n` +
+      `  Request status: ${this.status}\n`
+    );
+  }
+}
+
+export class TimeoutWaitingForResponseError extends AgentErrorV2 {
+  public name = 'TimeoutWaitingForResponseError';
+
+  constructor(
+    options: { message: string; requestId: RequestId; status: RequestStatusResponseStatus },
+    kind: ErrorKind,
+  ) {
+    super(
+      new TimeoutWaitingForResponseErrorCode(options.message, options.requestId, options.status),
+      kind,
+    );
+    Object.setPrototypeOf(this, TimeoutWaitingForResponseError.prototype);
   }
 }
 

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -429,6 +429,25 @@ export class MissingRootKeyError extends AgentErrorV2 {
   }
 }
 
+class HashValueErrorCode implements ErrorCode {
+  constructor(public readonly value: unknown) {
+    Object.setPrototypeOf(this, HashValueErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `Attempt to hash a value of unsupported type: ${this.value}`;
+  }
+}
+
+export class HashValueError extends AgentErrorV2 {
+  public name = 'HashValueError';
+
+  constructor(options: { value: unknown }, kind: ErrorKind) {
+    super(new HashValueErrorCode(options.value), kind);
+    Object.setPrototypeOf(this, HashValueError.prototype);
+  }
+}
+
 /**
  * An error that happens in the Agent. This is the root of all errors and should be used
  * everywhere in the Agent code (this package).

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -222,6 +222,28 @@ export class DerPrefixMismatchError extends AgentErrorV2 {
   }
 }
 
+class CborDecodeErrorCode implements ErrorCode {
+  constructor(
+    public readonly error: unknown,
+    public readonly input: Uint8Array,
+  ) {
+    Object.setPrototypeOf(this, CborDecodeErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `Failed to decode CBOR: ${this.error}, input: ${toHex(this.input)}`;
+  }
+}
+
+export class CborDecodeError extends AgentErrorV2 {
+  public name = 'CborDecodeError';
+
+  constructor(options: { error: unknown; input: Uint8Array }, kind: ErrorKind) {
+    super(new CborDecodeErrorCode(options.error, options.input), kind);
+    Object.setPrototypeOf(this, CborDecodeError.prototype);
+  }
+}
+
 /**
  * An error that happens in the Agent. This is the root of all errors and should be used
  * everywhere in the Agent code (this package).

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -354,6 +354,81 @@ export class TimeoutWaitingForResponseError extends AgentErrorV2 {
   }
 }
 
+class CertifiedRejectErrorCode implements ErrorCode {
+  constructor(
+    public readonly requestId: RequestId,
+    public readonly rejectCode: number,
+    public readonly rejectMessage: string,
+  ) {
+    Object.setPrototypeOf(this, CertifiedRejectErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return (
+      `Call was rejected:\n` +
+      `  Request ID: ${toHex(this.requestId)}\n` +
+      `  Reject code: ${this.rejectCode}\n` +
+      `  Reject text: ${this.rejectMessage}\n`
+    );
+  }
+}
+
+export class CertifiedRejectError extends AgentErrorV2 {
+  public name = 'CertifiedRejectError';
+
+  constructor(
+    options: { requestId: RequestId; rejectCode: number; rejectMessage: string },
+    kind: ErrorKind,
+  ) {
+    super(
+      new CertifiedRejectErrorCode(options.requestId, options.rejectCode, options.rejectMessage),
+      kind,
+    );
+    Object.setPrototypeOf(this, CertifiedRejectError.prototype);
+  }
+}
+
+class RequestStatusDoneNoReplyErrorCode implements ErrorCode {
+  constructor(public readonly requestId: RequestId) {
+    Object.setPrototypeOf(this, RequestStatusDoneNoReplyErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return (
+      `Call was marked as done but we never saw the reply:\n` +
+      `  Request ID: ${toHex(this.requestId)}\n`
+    );
+  }
+}
+
+export class RequestStatusDoneNoReplyError extends AgentErrorV2 {
+  public name = 'RequestStatusDoneNoReplyError';
+
+  constructor(options: { requestId: RequestId }, kind: ErrorKind) {
+    super(new RequestStatusDoneNoReplyErrorCode(options.requestId), kind);
+    Object.setPrototypeOf(this, RequestStatusDoneNoReplyError.prototype);
+  }
+}
+
+class MissingRootKeyErrorCode implements ErrorCode {
+  constructor() {
+    Object.setPrototypeOf(this, MissingRootKeyErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return 'Agent is missing root key';
+  }
+}
+
+export class MissingRootKeyError extends AgentErrorV2 {
+  public name = 'MissingRootKeyError';
+
+  constructor(kind: ErrorKind) {
+    super(new MissingRootKeyErrorCode(), kind);
+    Object.setPrototypeOf(this, MissingRootKeyError.prototype);
+  }
+}
+
 /**
  * An error that happens in the Agent. This is the root of all errors and should be used
  * everywhere in the Agent code (this package).

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -20,8 +20,11 @@ enum ErrorKindEnum {
   Unknown = 'Unknown',
 }
 
-abstract class ErrorCode {
-  public abstract toErrorMessage(): string;
+class ErrorCode {
+  public toErrorMessage(): string {
+    throw new Error('Not implemented');
+  }
+
   public toString(): string {
     return this.toErrorMessage();
   }
@@ -138,8 +141,11 @@ export class UnknownError extends ErrorKind {
   }
 }
 
-export class CertificateVerificationErrorCode implements ErrorCode {
+export class CertificateVerificationErrorCode extends ErrorCode {
+  public name = 'CertificateVerificationErrorCode';
+
   constructor(public readonly reason: string) {
+    super();
     Object.setPrototypeOf(this, CertificateVerificationErrorCode.prototype);
   }
 
@@ -148,13 +154,16 @@ export class CertificateVerificationErrorCode implements ErrorCode {
   }
 }
 
-export class CertificateTimeErrorCode implements ErrorCode {
+export class CertificateTimeErrorCode extends ErrorCode {
+  public name = 'CertificateTimeErrorCode';
+
   constructor(
     public readonly maxAgeInMinutes: number,
     public readonly certificateTime: Date,
     public readonly currentTime: Date,
     public readonly ageType: 'past' | 'future',
   ) {
+    super();
     Object.setPrototypeOf(this, CertificateTimeErrorCode.prototype);
   }
 
@@ -163,8 +172,11 @@ export class CertificateTimeErrorCode implements ErrorCode {
   }
 }
 
-export class CertificateHasTooManyDelegationsErrorCode implements ErrorCode {
+export class CertificateHasTooManyDelegationsErrorCode extends ErrorCode {
+  public name = 'CertificateHasTooManyDelegationsErrorCode';
+
   constructor() {
+    super();
     Object.setPrototypeOf(this, CertificateHasTooManyDelegationsErrorCode.prototype);
   }
 
@@ -173,11 +185,14 @@ export class CertificateHasTooManyDelegationsErrorCode implements ErrorCode {
   }
 }
 
-export class CertificateNotAuthorizedErrorCode implements ErrorCode {
+export class CertificateNotAuthorizedErrorCode extends ErrorCode {
+  public name = 'CertificateNotAuthorizedErrorCode';
+
   constructor(
     public readonly canisterId: Principal,
     public readonly subnetId: ArrayBuffer,
   ) {
+    super();
     Object.setPrototypeOf(this, CertificateNotAuthorizedErrorCode.prototype);
   }
 
@@ -186,8 +201,11 @@ export class CertificateNotAuthorizedErrorCode implements ErrorCode {
   }
 }
 
-export class LookupErrorCode implements ErrorCode {
+export class LookupErrorCode extends ErrorCode {
+  public name = 'LookupErrorCode';
+
   constructor(public readonly message: string) {
+    super();
     Object.setPrototypeOf(this, LookupErrorCode.prototype);
   }
 
@@ -196,11 +214,14 @@ export class LookupErrorCode implements ErrorCode {
   }
 }
 
-export class DerKeyLengthMismatchErrorCode implements ErrorCode {
+export class DerKeyLengthMismatchErrorCode extends ErrorCode {
+  public name = 'DerKeyLengthMismatchErrorCode';
+
   constructor(
     public readonly expectedLength: number,
     public readonly actualLength: number,
   ) {
+    super();
     Object.setPrototypeOf(this, DerKeyLengthMismatchErrorCode.prototype);
   }
 
@@ -209,11 +230,14 @@ export class DerKeyLengthMismatchErrorCode implements ErrorCode {
   }
 }
 
-export class DerPrefixMismatchErrorCode implements ErrorCode {
+export class DerPrefixMismatchErrorCode extends ErrorCode {
+  public name = 'DerPrefixMismatchErrorCode';
+
   constructor(
     public readonly expectedPrefix: ArrayBuffer,
     public readonly actualPrefix: ArrayBuffer,
   ) {
+    super();
     Object.setPrototypeOf(this, DerPrefixMismatchErrorCode.prototype);
   }
 
@@ -222,11 +246,14 @@ export class DerPrefixMismatchErrorCode implements ErrorCode {
   }
 }
 
-export class DerDecodeLengthMismatchErrorCode implements ErrorCode {
+export class DerDecodeLengthMismatchErrorCode extends ErrorCode {
+  public name = 'DerDecodeLengthMismatchErrorCode';
+
   constructor(
     public readonly expectedLength: number,
     public readonly actualLength: number,
   ) {
+    super();
     Object.setPrototypeOf(this, DerDecodeLengthMismatchErrorCode.prototype);
   }
 
@@ -235,8 +262,11 @@ export class DerDecodeLengthMismatchErrorCode implements ErrorCode {
   }
 }
 
-export class DerDecodeErrorCode implements ErrorCode {
+export class DerDecodeErrorCode extends ErrorCode {
+  public name = 'DerDecodeErrorCode';
+
   constructor(public readonly error: string) {
+    super();
     Object.setPrototypeOf(this, DerDecodeErrorCode.prototype);
   }
 
@@ -245,8 +275,11 @@ export class DerDecodeErrorCode implements ErrorCode {
   }
 }
 
-export class DerEncodeErrorCode implements ErrorCode {
+export class DerEncodeErrorCode extends ErrorCode {
+  public name = 'DerEncodeErrorCode';
+
   constructor(public readonly error: string) {
+    super();
     Object.setPrototypeOf(this, DerEncodeErrorCode.prototype);
   }
 
@@ -255,11 +288,14 @@ export class DerEncodeErrorCode implements ErrorCode {
   }
 }
 
-export class CborDecodeErrorCode implements ErrorCode {
+export class CborDecodeErrorCode extends ErrorCode {
+  public name = 'CborDecodeErrorCode';
+
   constructor(
     public readonly error: unknown,
     public readonly input: Uint8Array,
   ) {
+    super();
     Object.setPrototypeOf(this, CborDecodeErrorCode.prototype);
   }
 
@@ -268,8 +304,11 @@ export class CborDecodeErrorCode implements ErrorCode {
   }
 }
 
-export class HexDecodeErrorCode implements ErrorCode {
+export class HexDecodeErrorCode extends ErrorCode {
+  public name = 'HexDecodeErrorCode';
+
   constructor(public readonly error: string) {
+    super();
     Object.setPrototypeOf(this, HexDecodeErrorCode.prototype);
   }
 
@@ -278,12 +317,15 @@ export class HexDecodeErrorCode implements ErrorCode {
   }
 }
 
-export class TimeoutWaitingForResponseErrorCode implements ErrorCode {
+export class TimeoutWaitingForResponseErrorCode extends ErrorCode {
+  public name = 'TimeoutWaitingForResponseErrorCode';
+
   constructor(
     public readonly message: string,
     public readonly requestId: RequestId,
     public readonly status: RequestStatusResponseStatus,
   ) {
+    super();
     Object.setPrototypeOf(this, TimeoutWaitingForResponseErrorCode.prototype);
   }
 
@@ -296,12 +338,15 @@ export class TimeoutWaitingForResponseErrorCode implements ErrorCode {
   }
 }
 
-export class CertifiedRejectErrorCode implements ErrorCode {
+export class CertifiedRejectErrorCode extends ErrorCode {
+  public name = 'CertifiedRejectErrorCode';
+
   constructor(
     public readonly requestId: RequestId,
     public readonly rejectCode: number,
     public readonly rejectMessage: string,
   ) {
+    super();
     Object.setPrototypeOf(this, CertifiedRejectErrorCode.prototype);
   }
 
@@ -315,8 +360,11 @@ export class CertifiedRejectErrorCode implements ErrorCode {
   }
 }
 
-export class RequestStatusDoneNoReplyErrorCode implements ErrorCode {
+export class RequestStatusDoneNoReplyErrorCode extends ErrorCode {
+  public name = 'RequestStatusDoneNoReplyErrorCode';
+
   constructor(public readonly requestId: RequestId) {
+    super();
     Object.setPrototypeOf(this, RequestStatusDoneNoReplyErrorCode.prototype);
   }
 
@@ -328,8 +376,11 @@ export class RequestStatusDoneNoReplyErrorCode implements ErrorCode {
   }
 }
 
-export class MissingRootKeyErrorCode implements ErrorCode {
+export class MissingRootKeyErrorCode extends ErrorCode {
+  public name = 'MissingRootKeyErrorCode';
+
   constructor() {
+    super();
     Object.setPrototypeOf(this, MissingRootKeyErrorCode.prototype);
   }
 
@@ -338,8 +389,11 @@ export class MissingRootKeyErrorCode implements ErrorCode {
   }
 }
 
-export class HashValueErrorCode implements ErrorCode {
+export class HashValueErrorCode extends ErrorCode {
+  public name = 'HashValueErrorCode';
+
   constructor(public readonly value: unknown) {
+    super();
     Object.setPrototypeOf(this, HashValueErrorCode.prototype);
   }
 

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -219,6 +219,66 @@ export class DerPrefixMismatchError extends AgentErrorV2 {
   }
 }
 
+class DerDecodeLengthMismatchErrorCode implements ErrorCode {
+  constructor(
+    public readonly expectedLength: number,
+    public readonly actualLength: number,
+  ) {
+    Object.setPrototypeOf(this, DerDecodeLengthMismatchErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `DER payload mismatch: Expected length ${this.expectedLength}, actual length: ${this.actualLength}`;
+  }
+}
+
+export class DerDecodeLengthMismatchError extends AgentErrorV2 {
+  public name = 'DerDecodeLengthMismatchError';
+
+  constructor(options: { expectedLength: number; actualLength: number }, kind: ErrorKind) {
+    super(new DerDecodeLengthMismatchErrorCode(options.expectedLength, options.actualLength), kind);
+    Object.setPrototypeOf(this, DerDecodeLengthMismatchError.prototype);
+  }
+}
+
+class DerDecodeErrorCode implements ErrorCode {
+  constructor(public readonly error: string) {
+    Object.setPrototypeOf(this, DerDecodeErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `Failed to decode DER: ${this.error}`;
+  }
+}
+
+export class DerDecodeError extends AgentErrorV2 {
+  public name = 'DerDecodeError';
+
+  constructor(options: { error: string }, kind: ErrorKind) {
+    super(new DerDecodeErrorCode(options.error), kind);
+    Object.setPrototypeOf(this, DerDecodeError.prototype);
+  }
+}
+
+class DerEncodeErrorCode implements ErrorCode {
+  constructor(public readonly error: string) {
+    Object.setPrototypeOf(this, DerEncodeErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `Failed to encode DER: ${this.error}`;
+  }
+}
+
+export class DerEncodeError extends AgentErrorV2 {
+  public name = 'DerEncodeError';
+
+  constructor(options: { error: string }, kind: ErrorKind) {
+    super(new DerEncodeErrorCode(options.error), kind);
+    Object.setPrototypeOf(this, DerEncodeError.prototype);
+  }
+}
+
 class CborDecodeErrorCode implements ErrorCode {
   constructor(
     public readonly error: unknown,

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -31,10 +31,7 @@ abstract class ErrorCode {
 export class AgentErrorV2 extends Error {
   public name = 'AgentError';
 
-  constructor(
-    public readonly code: ErrorCode,
-    public readonly kind: ErrorKind,
-  ) {
+  constructor(code: ErrorCode, kind: ErrorKind) {
     // @ts-expect-error - Error.cause is not supported in the Typescript version that we are using
     super(code.toString(), { cause: { code, kind } });
     Object.setPrototypeOf(this, AgentErrorV2.prototype);

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -8,6 +8,220 @@ import {
 import { RequestId } from './request_id';
 import { toHex } from './utils/buffer';
 
+export enum ErrorKind {
+  Trust = 'Trust',
+  Protocol = 'Protocol',
+  Reject = 'Reject',
+  Transport = 'Transport',
+  External = 'External',
+  Limit = 'Limit',
+  Input = 'Input',
+  Unknown = 'Unknown',
+}
+
+abstract class ErrorCode {
+  public abstract toString(): string;
+}
+
+/**
+ * An error that happens in the Agent. This is the root of all errors and should be used
+ * everywhere in the Agent code (this package).
+ * @todo rename to `AgentError` and remove the old `AgentError`
+ */
+export class AgentErrorV2 extends Error {
+  public name = 'AgentError';
+
+  constructor(
+    public readonly code: ErrorCode,
+    public readonly kind: ErrorKind,
+  ) {
+    // @ts-expect-error - Error.cause is not supported in the Typescript version that we are using
+    super(code.toString(), { cause: { code, kind } });
+    Object.setPrototypeOf(this, AgentErrorV2.prototype);
+  }
+}
+
+class CertificateVerificationErrorCode implements ErrorCode {
+  constructor(public readonly reason: string) {
+    Object.setPrototypeOf(this, CertificateVerificationErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `Certificate verification error: "${this.reason}"`;
+  }
+}
+
+/**
+ * A certificate may fail verification with respect to the provided public key
+ */
+export class CertificateVerificationError extends AgentErrorV2 {
+  public name = 'CertificateVerificationError';
+
+  constructor(reason: string, kind: ErrorKind) {
+    super(new CertificateVerificationErrorCode(reason), kind);
+    Object.setPrototypeOf(this, CertificateVerificationError.prototype);
+  }
+}
+
+class CertificateTimeErrorCode implements ErrorCode {
+  constructor(
+    public readonly maxAgeInMinutes: number,
+    public readonly certificateTime: Date,
+    public readonly currentTime: Date,
+    public readonly ageType: 'past' | 'future',
+  ) {
+    Object.setPrototypeOf(this, CertificateTimeErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `Certificate is signed more than ${this.maxAgeInMinutes} minutes in the ${this.ageType}. Certificate time: ${this.certificateTime.toISOString()} Current time: ${this.currentTime.toISOString()}`;
+  }
+}
+
+export class CertificateTimeError extends AgentErrorV2 {
+  public name = 'CertificateTimeError';
+
+  constructor(
+    options: {
+      maxAgeInMinutes: number;
+      certificateTime: Date;
+      currentTime: Date;
+      ageType: 'past' | 'future';
+    },
+    kind: ErrorKind,
+  ) {
+    super(
+      new CertificateTimeErrorCode(
+        options.maxAgeInMinutes,
+        options.certificateTime,
+        options.currentTime,
+        options.ageType,
+      ),
+      kind,
+    );
+    Object.setPrototypeOf(this, CertificateTimeError.prototype);
+  }
+}
+
+class CertificateHasTooManyDelegationsErrorCode implements ErrorCode {
+  constructor() {
+    Object.setPrototypeOf(this, CertificateHasTooManyDelegationsErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return 'Certificate has too many delegations';
+  }
+}
+
+export class CertificateHasTooManyDelegationsError extends AgentErrorV2 {
+  public name = 'CertificateHasTooManyDelegationsError';
+
+  constructor(kind: ErrorKind) {
+    super(new CertificateHasTooManyDelegationsErrorCode(), kind);
+    Object.setPrototypeOf(this, CertificateHasTooManyDelegationsError.prototype);
+  }
+}
+
+class CertificateNotAuthorizedErrorCode implements ErrorCode {
+  constructor(
+    public readonly canisterId: Principal,
+    public readonly subnetId: ArrayBuffer,
+  ) {
+    Object.setPrototypeOf(this, CertificateNotAuthorizedErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `The certificate contains a delegation that does not include the canister ${this.canisterId.toText()} in the canister_ranges field. Subnet ID: 0x${toHex(this.subnetId)}`;
+  }
+}
+
+export class CertificateNotAuthorizedError extends AgentErrorV2 {
+  public name = 'CertificateNotAuthorizedError';
+
+  constructor(
+    options: {
+      canisterId: Principal;
+      subnetId: ArrayBuffer;
+    },
+    kind: ErrorKind,
+  ) {
+    super(new CertificateNotAuthorizedErrorCode(options.canisterId, options.subnetId), kind);
+    Object.setPrototypeOf(this, CertificateNotAuthorizedError.prototype);
+  }
+}
+
+class LookupErrorCode implements ErrorCode {
+  constructor(public readonly message: string) {
+    Object.setPrototypeOf(this, LookupErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return this.message;
+  }
+}
+
+export class LookupError extends AgentErrorV2 {
+  public name = 'LookupError';
+
+  constructor(message: string, kind: ErrorKind) {
+    super(new LookupErrorCode(message), kind);
+    Object.setPrototypeOf(this, LookupError.prototype);
+  }
+}
+
+class DerKeyLengthMismatchErrorCode implements ErrorCode {
+  constructor(
+    public readonly expectedLength: number,
+    public readonly actualLength: number,
+  ) {
+    Object.setPrototypeOf(this, DerKeyLengthMismatchErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `BLS DER-encoded public key must be ${this.expectedLength} bytes long, but is ${this.actualLength} bytes long`;
+  }
+}
+
+export class DerKeyLengthMismatchError extends AgentErrorV2 {
+  public name = 'DerKeyLengthMismatchError';
+
+  constructor(
+    options: {
+      expectedLength: number;
+      actualLength: number;
+    },
+    kind: ErrorKind,
+  ) {
+    super(new DerKeyLengthMismatchErrorCode(options.expectedLength, options.actualLength), kind);
+    Object.setPrototypeOf(this, DerKeyLengthMismatchError.prototype);
+  }
+}
+
+class DerPrefixMismatchErrorCode implements ErrorCode {
+  constructor(
+    public readonly expectedPrefix: ArrayBuffer,
+    public readonly actualPrefix: ArrayBuffer,
+  ) {
+    Object.setPrototypeOf(this, DerPrefixMismatchErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `BLS DER-encoded public key is invalid. Expected the following prefix: ${this.expectedPrefix}, but got ${this.actualPrefix}`;
+  }
+}
+
+export class DerPrefixMismatchError extends AgentErrorV2 {
+  public name = 'DerPrefixMismatchError';
+
+  constructor(
+    options: { expectedPrefix: ArrayBuffer; actualPrefix: ArrayBuffer },
+    kind: ErrorKind,
+  ) {
+    super(new DerPrefixMismatchErrorCode(options.expectedPrefix, options.actualPrefix), kind);
+    Object.setPrototypeOf(this, DerPrefixMismatchError.prototype);
+  }
+}
+
 /**
  * An error that happens in the Agent. This is the root of all errors and should be used
  * everywhere in the Agent code (this package).

--- a/packages/agent/src/errors.ts
+++ b/packages/agent/src/errors.ts
@@ -301,6 +301,25 @@ export class CborDecodeError extends AgentErrorV2 {
   }
 }
 
+class HexDecodeErrorCode implements ErrorCode {
+  constructor(public readonly error: string) {
+    Object.setPrototypeOf(this, HexDecodeErrorCode.prototype);
+  }
+
+  public toString(): string {
+    return `Failed to decode hex: ${this.error}`;
+  }
+}
+
+export class HexDecodeError extends AgentErrorV2 {
+  public name = 'HexDecodeError';
+
+  constructor(options: { error: string }, kind: ErrorKind) {
+    super(new HexDecodeErrorCode(options.error), kind);
+    Object.setPrototypeOf(this, HexDecodeError.prototype);
+  }
+}
+
 /**
  * An error that happens in the Agent. This is the root of all errors and should be used
  * everywhere in the Agent code (this package).

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,6 +6,14 @@ export * from './auth';
 export * from './canisters/asset';
 export * from './certificate';
 export * from './der';
+// TODO: rename to CertificateVerificationError once we have removed the old error
+export {
+  CertificateHasTooManyDelegationsError,
+  CertificateNotAuthorizedError,
+  CertificateTimeError,
+  CertificateVerificationError as CertificateVerificationErrorV2,
+  ErrorKind,
+} from './errors';
 export * from './fetch_candid';
 export * from './observable';
 export * from './public_key';

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,14 +6,8 @@ export * from './auth';
 export * from './canisters/asset';
 export * from './certificate';
 export * from './der';
-// TODO: rename to CertificateVerificationError once we have removed the old error
-export {
-  CertificateHasTooManyDelegationsError,
-  CertificateNotAuthorizedError,
-  CertificateTimeError,
-  CertificateVerificationError as CertificateVerificationErrorV2,
-  ErrorKind,
-} from './errors';
+// TODO: use * export once we have removed all the old errors
+export { CertificateVerificationErrorCode, TrustError } from './errors';
 export * from './fetch_candid';
 export * from './observable';
 export * from './public_key';

--- a/packages/agent/src/polling/strategy.ts
+++ b/packages/agent/src/polling/strategy.ts
@@ -2,7 +2,7 @@ import { Principal } from '@dfinity/principal';
 import { RequestStatusResponseStatus } from '../agent';
 import { PollStrategy } from './index';
 import { RequestId } from '../request_id';
-import { ErrorKind, TimeoutWaitingForResponseError } from '../errors';
+import { ProtocolError, TimeoutWaitingForResponseErrorCode } from '../errors';
 
 export type Predicate<T> = (
   canisterId: Principal,
@@ -63,13 +63,12 @@ export function maxAttempts(count: number): PollStrategy {
     status: RequestStatusResponseStatus,
   ) => {
     if (--attempts <= 0) {
-      throw new TimeoutWaitingForResponseError(
-        {
-          message: `Failed to retrieve a reply for request after ${count} attempts`,
+      throw ProtocolError.fromCode(
+        new TimeoutWaitingForResponseErrorCode(
+          `Failed to retrieve a reply for request after ${count} attempts`,
           requestId,
           status,
-        },
-        ErrorKind.Protocol,
+        ),
       );
     }
   };
@@ -95,9 +94,12 @@ export function timeout(timeInMsec: number): PollStrategy {
     status: RequestStatusResponseStatus,
   ) => {
     if (Date.now() > end) {
-      throw new TimeoutWaitingForResponseError(
-        { message: `Request timed out after ${timeInMsec} msec`, requestId, status },
-        ErrorKind.Protocol,
+      throw ProtocolError.fromCode(
+        new TimeoutWaitingForResponseErrorCode(
+          `Request timed out after ${timeInMsec} msec`,
+          requestId,
+          status,
+        ),
       );
     }
   };

--- a/packages/agent/src/public_key.ts
+++ b/packages/agent/src/public_key.ts
@@ -1,6 +1,6 @@
 import { DerEncodedPublicKey, PublicKey } from './auth';
 import { ED25519_OID, unwrapDER, wrapDER } from './der';
-import { DerDecodeError, ErrorKind } from './errors';
+import { DerDecodeErrorCode, InputError } from './errors';
 
 export class Ed25519PublicKey implements PublicKey {
   public static from(key: PublicKey): Ed25519PublicKey {
@@ -25,9 +25,8 @@ export class Ed25519PublicKey implements PublicKey {
   private static derDecode(key: DerEncodedPublicKey): ArrayBuffer {
     const unwrapped = unwrapDER(key, ED25519_OID);
     if (unwrapped.length !== this.RAW_KEY_LENGTH) {
-      throw new DerDecodeError(
-        { error: 'An Ed25519 public key must be exactly 32 bytes long' },
-        ErrorKind.Input,
+      throw InputError.fromCode(
+        new DerDecodeErrorCode('An Ed25519 public key must be exactly 32 bytes long'),
       );
     }
     return unwrapped;
@@ -48,9 +47,8 @@ export class Ed25519PublicKey implements PublicKey {
   // `fromRaw` and `fromDer` should be used for instantiation, not this constructor.
   private constructor(key: ArrayBuffer) {
     if (key.byteLength !== Ed25519PublicKey.RAW_KEY_LENGTH) {
-      throw new DerDecodeError(
-        { error: 'An Ed25519 public key must be exactly 32 bytes long' },
-        ErrorKind.Input,
+      throw InputError.fromCode(
+        new DerDecodeErrorCode('An Ed25519 public key must be exactly 32 bytes long'),
       );
     }
     this.#rawKey = key;

--- a/packages/agent/src/public_key.ts
+++ b/packages/agent/src/public_key.ts
@@ -1,5 +1,6 @@
 import { DerEncodedPublicKey, PublicKey } from './auth';
 import { ED25519_OID, unwrapDER, wrapDER } from './der';
+import { DerDecodeError, ErrorKind } from './errors';
 
 export class Ed25519PublicKey implements PublicKey {
   public static from(key: PublicKey): Ed25519PublicKey {
@@ -24,7 +25,10 @@ export class Ed25519PublicKey implements PublicKey {
   private static derDecode(key: DerEncodedPublicKey): ArrayBuffer {
     const unwrapped = unwrapDER(key, ED25519_OID);
     if (unwrapped.length !== this.RAW_KEY_LENGTH) {
-      throw new Error('An Ed25519 public key must be exactly 32bytes long');
+      throw new DerDecodeError(
+        { error: 'An Ed25519 public key must be exactly 32 bytes long' },
+        ErrorKind.Input,
+      );
     }
     return unwrapped;
   }
@@ -44,7 +48,10 @@ export class Ed25519PublicKey implements PublicKey {
   // `fromRaw` and `fromDer` should be used for instantiation, not this constructor.
   private constructor(key: ArrayBuffer) {
     if (key.byteLength !== Ed25519PublicKey.RAW_KEY_LENGTH) {
-      throw new Error('An Ed25519 public key must be exactly 32bytes long');
+      throw new DerDecodeError(
+        { error: 'An Ed25519 public key must be exactly 32 bytes long' },
+        ErrorKind.Input,
+      );
     }
     this.#rawKey = key;
     this.#derKey = Ed25519PublicKey.derEncode(key);

--- a/packages/agent/src/request_id.ts
+++ b/packages/agent/src/request_id.ts
@@ -3,7 +3,7 @@ import { Principal } from '@dfinity/principal';
 import borc from 'borc';
 import { sha256 } from '@noble/hashes/sha256';
 import { compare, concat, uint8ToBuf } from './utils/buffer';
-import { ErrorKind, HashValueError } from './errors';
+import { HashValueErrorCode, InputError } from './errors';
 
 export type RequestId = ArrayBuffer & { __requestId__: void };
 
@@ -57,7 +57,7 @@ export function hashValue(value: unknown): ArrayBuffer {
     // So we want to try all the high-assurance type guards before this 'probable' one.
     return hash(lebEncode(value));
   }
-  throw new HashValueError({ value }, ErrorKind.Input);
+  throw InputError.fromCode(new HashValueErrorCode(value));
 }
 
 const hashString = (value: string): ArrayBuffer => {

--- a/packages/agent/src/request_id.ts
+++ b/packages/agent/src/request_id.ts
@@ -3,6 +3,7 @@ import { Principal } from '@dfinity/principal';
 import borc from 'borc';
 import { sha256 } from '@noble/hashes/sha256';
 import { compare, concat, uint8ToBuf } from './utils/buffer';
+import { ErrorKind, HashValueError } from './errors';
 
 export type RequestId = ArrayBuffer & { __requestId__: void };
 
@@ -56,11 +57,7 @@ export function hashValue(value: unknown): ArrayBuffer {
     // So we want to try all the high-assurance type guards before this 'probable' one.
     return hash(lebEncode(value));
   }
-  throw Object.assign(new Error(`Attempt to hash a value of unsupported type: ${value}`), {
-    // include so logs/callers can understand the confusing value.
-    // (when stringified in error message, prototype info is lost)
-    value,
-  });
+  throw new HashValueError({ value }, ErrorKind.Input);
 }
 
 const hashString = (value: string): ArrayBuffer => {

--- a/packages/agent/src/utils/buffer.ts
+++ b/packages/agent/src/utils/buffer.ts
@@ -1,4 +1,4 @@
-import { ErrorKind, HexDecodeError } from '../errors';
+import { HexDecodeErrorCode, InputError } from '../errors';
 
 /**
  * Concatenate multiple array buffers.
@@ -30,7 +30,7 @@ const hexRe = new RegExp(/^[0-9a-fA-F]+$/);
  */
 export function fromHex(hex: string): ArrayBuffer {
   if (!hexRe.test(hex)) {
-    throw new HexDecodeError({ error: 'Invalid hexadecimal string.' }, ErrorKind.Input);
+    throw InputError.fromCode(new HexDecodeErrorCode('Invalid hexadecimal string.'));
   }
   const buffer = [...hex]
     .reduce((acc, curr, i) => {

--- a/packages/agent/src/utils/buffer.ts
+++ b/packages/agent/src/utils/buffer.ts
@@ -1,3 +1,5 @@
+import { ErrorKind, HexDecodeError } from '../errors';
+
 /**
  * Concatenate multiple array buffers.
  * @param buffers The buffers to concatenate.
@@ -28,7 +30,7 @@ const hexRe = new RegExp(/^[0-9a-fA-F]+$/);
  */
 export function fromHex(hex: string): ArrayBuffer {
   if (!hexRe.test(hex)) {
-    throw new Error('Invalid hexadecimal string.');
+    throw new HexDecodeError({ error: 'Invalid hexadecimal string.' }, ErrorKind.Input);
   }
   const buffer = [...hex]
     .reduce((acc, curr, i) => {


### PR DESCRIPTION
# Description

Refactor the error system in the `@dfinity/agent` package to reflect Rust agent's implementation.
For now, I've added the error types and replaced all the internal `throw` statements with the new error system. This PR shouldn't break anything. In a follow-up PR, I'll refactor the agent and the actor errors in order to use the new error system across all the `@dfinity/agent` package.

# How Has This Been Tested?

Updated tests and assertions where already present.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
