### PR TITLE
chore: removes unused `bs58check` dependency from `@dfinity/identity-…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- chore: removes unused `bs58check` dependency from `@dfinity/identity-secp256k1`
 - feat!: changes polling strategy for `read_state` requests to support presigned requests. By default, `read_state` requests will create a new signature with a new ingress expiry each time they are made. However, the new `preSignReadStateRequest` will make one signature and use it for all polling requests. This is useful for hardware wallets or other external signing solutions that make signing cumbersome.
   - pollForResponse now moves `strategy`, `request`, and `preSignReadStateRequest` to the `options: PollingOptions` object
   - new export: `PollingOptions` type

--- a/package-lock.json
+++ b/package-lock.json
@@ -5425,10 +5425,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base-x": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
     "node_modules/base64-arraybuffer": {
       "version": "0.2.0",
       "engines": {
@@ -5731,21 +5727,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/bs58": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
-      }
-    },
-    "node_modules/bs58check": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0",
-        "bs58": "^5.0.0"
       }
     },
     "node_modules/bser": {
@@ -15189,13 +15170,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.6",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
-        "rollup": "^4.30.1"
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -15277,6 +15263,51 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/tinyglobby": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/vitest": {
@@ -17376,8 +17407,7 @@
         "@noble/hashes": "^1.3.1",
         "@scure/bip32": "^1.4.0",
         "@scure/bip39": "^1.3.0",
-        "asn1js": "^3.0.5",
-        "bs58check": "^3.0.1"
+        "asn1js": "^3.0.5"
       },
       "devDependencies": {
         "eslint": "^8.19.0",

--- a/packages/identity-secp256k1/package.json
+++ b/packages/identity-secp256k1/package.json
@@ -19,8 +19,7 @@
     "@noble/hashes": "^1.3.1",
     "@scure/bip32": "^1.4.0",
     "@scure/bip39": "^1.3.0",
-    "asn1js": "^3.0.5",
-    "bs58check": "^3.0.1"
+    "asn1js": "^3.0.5"
   },
   "devDependencies": {
     "eslint": "^8.19.0",


### PR DESCRIPTION
…secp256k1`

# Description

removes unused `bs58check` dependency from `@dfinity/identity-secp256k1`

# Checklist:

- [X] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [X] I have made corresponding changes to the documentation.
