### PR TITLE
refactor: remove unnecessary `uint8FromBufLike` calls

### DIFF
--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -24,7 +24,6 @@ import managementCanisterIdl from './canisters/management_idl';
 import _SERVICE, { canister_install_mode, canister_settings } from './canisters/management_service';
 import { HttpAgent } from './agent/http';
 import { utf8ToBytes } from '@noble/hashes/utils';
-import { uint8FromBufLike } from './utils/buffer';
 
 /**
  * Configuration to make calls to the Replica.
@@ -503,7 +502,7 @@ function _createActorMethod(
         }
         const cert = response.body.certificate;
         certificate = await Certificate.create({
-          certificate: uint8FromBufLike(cert),
+          certificate: cert,
           rootKey: agent.rootKey,
           canisterId: Principal.from(canisterId),
           blsVerify,

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -63,6 +63,7 @@ import { BackoffStrategy, BackoffStrategyFactory, ExponentialBackoff } from '../
 import { decodeTime } from '../../utils/leb';
 import { concatBytes, hexToBytes } from '@noble/hashes/utils';
 import { uint8Equals, uint8FromBufLike } from '../../utils/buffer';
+import { IC_RESPONSE_DOMAIN_SEPARATOR } from '../../constants';
 export * from './transforms';
 export { Nonce, makeNonce } from './types';
 
@@ -1007,7 +1008,6 @@ export class HttpAgent implements Agent {
     }
     const { status, signatures = [], requestId } = queryResponse;
 
-    const domainSeparator = uint8FromBufLike(new TextEncoder().encode('\x0Bic-response'));
     for (const sig of signatures) {
       const { timestamp, identity } = sig;
       const nodeId = Principal.fromUint8Array(identity).toText();
@@ -1036,7 +1036,7 @@ export class HttpAgent implements Agent {
         throw UnknownError.fromCode(new UnexpectedErrorCode(`Unknown status: ${status}`));
       }
 
-      const separatorWithHash = concatBytes(domainSeparator, hash);
+      const separatorWithHash = concatBytes(IC_RESPONSE_DOMAIN_SEPARATOR, hash);
 
       // FIX: check for match without verifying N times
       const pubKey = subnetStatus?.nodeKeys.get(nodeId);

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -1105,7 +1105,7 @@ export class HttpAgent implements Agent {
     function getRequestId(fields: ReadStateOptions): RequestId | undefined {
       for (const path of fields.paths) {
         const [pathName, value] = path;
-        const request_status = uint8FromBufLike(new TextEncoder().encode('request_status'));
+        const request_status = new TextEncoder().encode('request_status');
         if (uint8Equals(pathName, request_status)) {
           return value as RequestId;
         }

--- a/packages/agent/src/auth.ts
+++ b/packages/agent/src/auth.ts
@@ -2,9 +2,7 @@ import { Principal } from '@dfinity/principal';
 import { HttpAgentRequest } from './agent/http/types';
 import { requestIdOf } from './request_id';
 import { bytesToHex, concatBytes } from '@noble/hashes/utils';
-
-const domainSeparator = new TextEncoder().encode('\x0Aic-request');
-
+import { IC_REQUEST_DOMAIN_SEPARATOR } from './constants';
 /**
  * A Key Pair, containing a secret and public key.
  */
@@ -94,7 +92,7 @@ export abstract class SignIdentity implements Identity {
       body: {
         content: body,
         sender_pubkey: this.getPublicKey().toDer(),
-        sender_sig: await this.sign(concatBytes(domainSeparator, requestId)),
+        sender_sig: await this.sign(concatBytes(IC_REQUEST_DOMAIN_SEPARATOR, requestId)),
       },
     };
   }

--- a/packages/agent/src/certificate.ts
+++ b/packages/agent/src/certificate.ts
@@ -364,7 +364,6 @@ export function lookupResultToBuffer(result: LookupResult): Uint8Array | undefin
     return undefined;
   }
 
-  // Attepmt to decode the value as a Uint8Array
   if (result.value instanceof Uint8Array) {
     return result.value;
   }

--- a/packages/agent/src/constants.ts
+++ b/packages/agent/src/constants.ts
@@ -1,2 +1,19 @@
 // Default delta for ingress expiry is 5 minutes.
 export const DEFAULT_INGRESS_EXPIRY_DELTA_IN_MSECS = 5 * 60 * 1000;
+
+/**
+ * The `\x0Aic-request` domain separator used in the signature of IC requests.
+ */
+export const IC_REQUEST_DOMAIN_SEPARATOR = new TextEncoder().encode('\x0Aic-request');
+
+/**
+ * The `\x0Bic-response` domain separator used in the signature of IC responses.
+ */
+export const IC_RESPONSE_DOMAIN_SEPARATOR = new TextEncoder().encode('\x0Bic-response');
+
+/**
+ * The `\x1Aic-request-auth-delegation` domain separator used in the signature of delegations.
+ */
+export const IC_REQUEST_AUTH_DELEGATION_DOMAIN_SEPARATOR = new TextEncoder().encode(
+  '\x1Aic-request-auth-delegation',
+);

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5,6 +5,11 @@ export * from './agent/http/types';
 export * from './auth';
 export * from './canisters/asset';
 export * from './certificate';
+export {
+  IC_REQUEST_DOMAIN_SEPARATOR,
+  IC_RESPONSE_DOMAIN_SEPARATOR,
+  IC_REQUEST_AUTH_DELEGATION_DOMAIN_SEPARATOR,
+} from './constants';
 export * from './der';
 export * from './errors';
 export * from './fetch_candid';

--- a/packages/agent/src/request_id.ts
+++ b/packages/agent/src/request_id.ts
@@ -13,7 +13,7 @@ export type RequestId = Uint8Array & { __requestId__: void };
  * @param data - input to hash function
  */
 export function hash(data: Uint8Array): Uint8Array {
-  return sha256.create().update(uint8FromBufLike(data)).digest();
+  return sha256.create().update(data).digest();
 }
 
 interface ToHashable {

--- a/packages/agent/src/request_id.ts
+++ b/packages/agent/src/request_id.ts
@@ -98,7 +98,7 @@ export function hashOfMap(map: Record<string, unknown>): Uint8Array {
     return compare(k1, k2);
   });
 
-  const concatenated: Uint8Array = concatBytes(...sorted.map(x => concatBytes(...x)));
+  const concatenated = concatBytes(...sorted.map(x => concatBytes(...x)));
   const result = hash(concatenated);
   return result;
 }

--- a/packages/agent/src/utils/buffer.ts
+++ b/packages/agent/src/utils/buffer.ts
@@ -41,7 +41,7 @@ export function concat(...uint8Arrays: Uint8Array[]): Uint8Array {
   const result = new Uint8Array(uint8Arrays.reduce((acc, curr) => acc + curr.byteLength, 0));
   let index = 0;
   for (const b of uint8Arrays) {
-    result.set(uint8FromBufLike(new Uint8Array(b)), index);
+    result.set(b, index);
     index += b.byteLength;
   }
   return result;

--- a/packages/candid/src/utils/buffer.ts
+++ b/packages/candid/src/utils/buffer.ts
@@ -6,7 +6,7 @@ export function concat(...uint8Arrays: Uint8Array[]): Uint8Array {
   const result = new Uint8Array(uint8Arrays.reduce((acc, curr) => acc + curr.byteLength, 0));
   let index = 0;
   for (const b of uint8Arrays) {
-    result.set(uint8FromBufLike(new Uint8Array(b)), index);
+    result.set(b, index);
     index += b.byteLength;
   }
   return result;

--- a/packages/identity/src/identity/delegation.ts
+++ b/packages/identity/src/identity/delegation.ts
@@ -11,7 +11,6 @@ import { Principal } from '@dfinity/principal';
 import * as cbor from 'simple-cbor';
 import { PartialIdentity } from './partial';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
-import { uint8FromBufLike } from '@dfinity/candid';
 
 const domainSeparator = new TextEncoder().encode('\x1Aic-request-auth-delegation');
 const requestDomainSeparator = new TextEncoder().encode('\x0Aic-request');
@@ -115,7 +114,7 @@ async function _createSingleDelegation(
     ...domainSeparator,
     ...new Uint8Array(requestIdOf({ ...delegation })),
   ]);
-  const signature = await from.sign(uint8FromBufLike(challenge));
+  const signature = await from.sign(challenge);
 
   return {
     delegation,
@@ -308,9 +307,7 @@ export class DelegationIdentity extends SignIdentity {
       body: {
         content: body,
         sender_sig: await this.sign(
-          uint8FromBufLike(
-            new Uint8Array([...requestDomainSeparator, ...new Uint8Array(requestId)]),
-          ),
+          new Uint8Array([...requestDomainSeparator, ...new Uint8Array(requestId)]),
         ),
         sender_delegation: this._delegation.delegations,
         sender_pubkey: this._delegation.publicKey,

--- a/packages/identity/src/identity/delegation.ts
+++ b/packages/identity/src/identity/delegation.ts
@@ -6,14 +6,13 @@ import {
   Signature,
   SignIdentity,
   uint8ToBuf,
+  IC_REQUEST_DOMAIN_SEPARATOR,
+  IC_REQUEST_AUTH_DELEGATION_DOMAIN_SEPARATOR,
 } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 import * as cbor from 'simple-cbor';
 import { PartialIdentity } from './partial';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
-
-const domainSeparator = new TextEncoder().encode('\x1Aic-request-auth-delegation');
-const requestDomainSeparator = new TextEncoder().encode('\x0Aic-request');
 
 function _parseBlob(value: unknown): Uint8Array {
   if (typeof value !== 'string' || value.length < 64) {
@@ -111,7 +110,7 @@ async function _createSingleDelegation(
   // besides the actualy webauthn functionality (such as `sign`). Safari will de-register
   // a user gesture if you await an async call thats not fetch, xhr, or setTimeout.
   const challenge = new Uint8Array([
-    ...domainSeparator,
+    ...IC_REQUEST_AUTH_DELEGATION_DOMAIN_SEPARATOR,
     ...new Uint8Array(requestIdOf({ ...delegation })),
   ]);
   const signature = await from.sign(challenge);
@@ -307,7 +306,7 @@ export class DelegationIdentity extends SignIdentity {
       body: {
         content: body,
         sender_sig: await this.sign(
-          new Uint8Array([...requestDomainSeparator, ...new Uint8Array(requestId)]),
+          new Uint8Array([...IC_REQUEST_DOMAIN_SEPARATOR, ...new Uint8Array(requestId)]),
         ),
         sender_delegation: this._delegation.delegations,
         sender_pubkey: this._delegation.publicKey,

--- a/packages/identity/src/identity/ed25519.test.ts
+++ b/packages/identity/src/identity/ed25519.test.ts
@@ -1,6 +1,5 @@
 import { DerEncodedPublicKey, PublicKey } from '@dfinity/agent';
 import { Ed25519KeyIdentity, Ed25519PublicKey } from './ed25519';
-import { uint8FromBufLike } from '@dfinity/agent';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 
 const testVectors: Array<[string, string]> = [
@@ -109,7 +108,7 @@ describe('Ed25519KeyIdentity tests', () => {
     const identity = Ed25519KeyIdentity.generate();
     const message = new TextEncoder().encode('Hello, World!');
 
-    const signature = await identity.sign(uint8FromBufLike(message));
+    const signature = await identity.sign(message);
     const pubkey = identity.getPublicKey();
 
     const isValid = Ed25519KeyIdentity.verify(signature, message, pubkey.rawKey);
@@ -143,7 +142,7 @@ test('from JSON', async () => {
   const identity = Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
 
   const msg = new TextEncoder().encode('Hello, World!');
-  const signature = await identity.sign(uint8FromBufLike(msg));
+  const signature = await identity.sign(msg);
   const isValid = Ed25519KeyIdentity.verify(signature, msg, identity.getPublicKey().rawKey);
   expect(isValid).toBe(true);
 });

--- a/packages/identity/src/identity/ed25519.ts
+++ b/packages/identity/src/identity/ed25519.ts
@@ -70,7 +70,7 @@ export class Ed25519PublicKey implements PublicKey {
     if (unwrapped.length !== this.RAW_KEY_LENGTH) {
       throw new Error('An Ed25519 public key must be exactly 32bytes long');
     }
-    return uint8FromBufLike(unwrapped);
+    return unwrapped;
   }
 
   #rawKey: Uint8Array;
@@ -124,9 +124,11 @@ export class Ed25519KeyIdentity extends SignIdentity {
       );
     }
     const sk = new Uint8Array(32);
-    for (let i = 0; i < 32; i++) sk[i] = new Uint8Array(seed)[i];
+    for (let i = 0; i < 32; i++) {
+      sk[i] = seed[i];
+    }
 
-    const pk = uint8FromBufLike(ed25519.getPublicKey(sk));
+    const pk = ed25519.getPublicKey(sk);
     return Ed25519KeyIdentity.fromKeyPair(pk, sk);
   }
 
@@ -155,7 +157,7 @@ export class Ed25519KeyIdentity extends SignIdentity {
   }
 
   public static fromSecretKey(secretKey: Uint8Array): Ed25519KeyIdentity {
-    const publicKey = ed25519.getPublicKey(new Uint8Array(secretKey));
+    const publicKey = ed25519.getPublicKey(secretKey);
     return Ed25519KeyIdentity.fromKeyPair(publicKey, secretKey);
   }
 
@@ -166,7 +168,7 @@ export class Ed25519KeyIdentity extends SignIdentity {
   protected constructor(publicKey: PublicKey, privateKey: Uint8Array) {
     super();
     this.#publicKey = Ed25519PublicKey.from(publicKey);
-    this.#privateKey = new Uint8Array(privateKey);
+    this.#privateKey = privateKey;
   }
 
   /**
@@ -198,9 +200,8 @@ export class Ed25519KeyIdentity extends SignIdentity {
    * @param challenge - challenge to sign with this identity's secretKey, producing a signature
    */
   public async sign(challenge: Uint8Array): Promise<Signature> {
-    const blob = new Uint8Array(challenge);
     // Some implementations of Ed25519 private keys append a public key to the end of the private key. We only want the private key.
-    const signature = ed25519.sign(blob, this.#privateKey.slice(0, 32));
+    const signature = ed25519.sign(challenge, this.#privateKey.slice(0, 32));
     // add { __signature__: void; } to the signature to make it compatible with the agent
 
     Object.defineProperty(signature, '__signature__', {
@@ -227,10 +228,7 @@ export class Ed25519KeyIdentity extends SignIdentity {
       if (typeof x === 'string') {
         x = hexToBytes(x);
       }
-      if (x instanceof Uint8Array) {
-        x = uint8FromBufLike(x.buffer);
-      }
-      return new Uint8Array(x);
+      return uint8FromBufLike(x);
     });
     return ed25519.verify(signature, message, publicKey);
   }


### PR DESCRIPTION
# Description

- Removes unnecessary `uint8FromBufLike` calls
- Moves the domain separators to the constants in the agent

# How Has This Been Tested?

Same tests as before

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
