### PR TITLE
feat!: replace `hash` with `sha256` from `@noble/hashes/sha2` to take advantage of existing dependencies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - feat!: changes all @dfinity/candid interfaces to `Uint8Array<ArrayBuffer>` instead of `ArrayBuffer` to make the API more consistent.
 - feat!: replaces `fromHex` and `toHex` utils with `bytesToHex` and `hexToBytes` from `@noble/hashes/utils` to take advantage of existing dependencies.
-- chore: removes unused `bs58check` dependency from `@dfinity/identity-secp256k1`
 - feat!: changes polling strategy for `read_state` requests to support presigned requests. By default, `read_state` requests will create a new signature with a new ingress expiry each time they are made. However, the new `preSignReadStateRequest` will make one signature and use it for all polling requests. This is useful for hardware wallets or other external signing solutions that make signing cumbersome.
   - pollForResponse now moves `strategy`, `request`, and `preSignReadStateRequest` to the `options: PollingOptions` object
   - new export: `PollingOptions` type
@@ -29,7 +28,9 @@
 - feat!: refactors `Expiry` class to use static factory methods and add JSON serialization/deserialization.
 - feat!: makes `lookup_path` compliant with the [IC Interface Specification](https://github.com/dfinity/portal/blob/8015a4ab50232176723ffd95e32a02f1bf7fef30/docs/references/ic-interface-spec.md?plain=1#L3069). Renames the `lookup` method of the `Certificate` class into `lookup_path`, for consistency.
 - feat!: removes the `lookup_label` method from the `Certificate` class.
+- feat!: replaces `hash` with `sha256` from `@noble/hashes/sha2` to take advantage of existing dependencies
 
+- chore: removes unused `bs58check` dependency from `@dfinity/identity-secp256k1`
 - fix: AuthClient `isAuthenticated` now correctly returns false if the delegation chain is invalid; eg: expired session
 - feat: introduces the `lookup_subtree` standalone function and `Certificate` class method.
 - chore: formatting files and changelog
@@ -46,7 +47,6 @@
 - fix: fixes a bug in the Ed25519KeyIdentity verify implementation where the argument order was incorrect
 - fix: fixes a bug in the `Principal` library where the management canister id util was incorrectly importing using `fromHex`
 - feat: change auth-client's default identity provider url
-
 
 ## [2.4.0] - 2025-03-24
 

--- a/packages/agent/src/certificate.ts
+++ b/packages/agent/src/certificate.ts
@@ -15,13 +15,13 @@ import {
   MalformedLookupFoundValueErrorCode,
   MissingLookupValueErrorCode,
 } from './errors';
-import { hash } from './request_id';
 import { Principal } from '@dfinity/principal';
 import * as bls from './utils/bls';
 import { decodeTime } from './utils/leb';
 import { MANAGEMENT_CANISTER_ID } from './agent';
 import { bytesToHex, concatBytes, hexToBytes, utf8ToBytes } from '@noble/hashes/utils';
 import { uint8Equals } from './utils/buffer';
+import { sha256 } from '@noble/hashes/sha2';
 
 export interface Cert {
   tree: HashTree;
@@ -377,16 +377,20 @@ export function lookupResultToBuffer(result: LookupResult): Uint8Array | undefin
 export async function reconstruct(t: HashTree): Promise<Uint8Array> {
   switch (t[0]) {
     case NodeType.Empty:
-      return hash(domain_sep('ic-hashtree-empty'));
+      return sha256(domain_sep('ic-hashtree-empty'));
     case NodeType.Pruned:
       return t[1];
     case NodeType.Leaf:
-      return hash(concatBytes(domain_sep('ic-hashtree-leaf'), t[1]));
+      return sha256(concatBytes(domain_sep('ic-hashtree-leaf'), t[1]));
     case NodeType.Labeled:
-      return hash(concatBytes(domain_sep('ic-hashtree-labeled'), t[1], await reconstruct(t[2])));
+      return sha256(concatBytes(domain_sep('ic-hashtree-labeled'), t[1], await reconstruct(t[2])));
     case NodeType.Fork:
-      return hash(
-        concatBytes(domain_sep('ic-hashtree-fork'), await reconstruct(t[1]), await reconstruct(t[2])),
+      return sha256(
+        concatBytes(
+          domain_sep('ic-hashtree-fork'),
+          await reconstruct(t[1]),
+          await reconstruct(t[2]),
+        ),
       );
     default:
       throw UNREACHABLE_ERROR;

--- a/packages/agent/src/request_id.test.ts
+++ b/packages/agent/src/request_id.test.ts
@@ -1,57 +1,8 @@
 // https://github.com/dfinity-lab/dfinity/blob/5fef1450c9ab16ccf18381379149e504b11c8218/docs/spec/public/index.adoc#request-ids
 import { Principal } from '@dfinity/principal';
-import { hash, hashValue, requestIdOf } from './request_id';
+import { hashValue, requestIdOf } from './request_id';
 import borc from 'borc';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
-
-const testHashOfBlob = async (input: Uint8Array, expected: string) => {
-  const hashed = await hash(input);
-  const hex = bytesToHex(hashed);
-  expect(hex).toBe(expected);
-};
-
-const testHashOfString = async (input: string, expected: string) => {
-  const encoded: Uint8Array = new TextEncoder().encode(input);
-  return testHashOfBlob(encoded, expected);
-};
-
-// This is based on the intermediate hashes of the request components from
-// example in the spec.
-test('hash', async () => {
-  await testHashOfString(
-    'request_type',
-    '769e6f87bdda39c859642b74ce9763cdd37cb1cd672733e8c54efaa33ab78af9',
-  );
-  await testHashOfString(
-    'call',
-    '7edb360f06acaef2cc80dba16cf563f199d347db4443da04da0c8173e3f9e4ed',
-  );
-  await testHashOfString(
-    'callee', // The "canister_id" field was previously named "callee"
-    '92ca4c0ced628df1e7b9f336416ead190bd0348615b6f71a64b21d1b68d4e7e2',
-  );
-  await testHashOfString(
-    'canister_id',
-    '0a3eb2ba16702a387e6321066dd952db7a31f9b5cc92981e0a92dd56802d3df9',
-  );
-  await testHashOfBlob(
-    new Uint8Array([0, 0, 0, 0, 0, 0, 4, 210]),
-    '4d8c47c3c1c837964011441882d745f7e92d10a40cef0520447c63029eafe396',
-  );
-  await testHashOfString(
-    'method_name',
-    '293536232cf9231c86002f4ee293176a0179c002daa9fc24be9bb51acdd642b6',
-  );
-  await testHashOfString(
-    'hello',
-    '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
-  );
-  await testHashOfString('arg', 'b25f03dedd69be07f356a06fe35c1b0ddc0de77dcd9066c4be0c6bbde14b23ff');
-  await testHashOfBlob(
-    new Uint8Array([68, 73, 68, 76, 0, 253, 42]),
-    '6c0b2ae49718f6995c02ac5700c9c789d7b7862a0d53e6d40a73f1fcd2f70189',
-  );
-});
 
 // This is based on the example in the spec.
 test('requestIdOf', async () => {

--- a/packages/agent/src/request_id.ts
+++ b/packages/agent/src/request_id.ts
@@ -1,20 +1,12 @@
 import { lebEncode, compare } from '@dfinity/candid';
 import { Principal } from '@dfinity/principal';
 import borc from 'borc';
-import { sha256 } from '@noble/hashes/sha256';
 import { HashValueErrorCode, InputError } from './errors';
 import { uint8FromBufLike } from './utils/buffer';
 import { concatBytes } from '@noble/hashes/utils';
+import { sha256 } from '@noble/hashes/sha2';
 
 export type RequestId = Uint8Array & { __requestId__: void };
-
-/**
- * sha256 hash the provided Buffer
- * @param data - input to hash function
- */
-export function hash(data: Uint8Array): Uint8Array {
-  return sha256.create().update(data).digest();
-}
 
 interface ToHashable {
   toHash(): unknown;
@@ -32,14 +24,14 @@ export function hashValue(value: unknown): Uint8Array {
   } else if (typeof value === 'string') {
     return hashString(value);
   } else if (typeof value === 'number') {
-    return hash(lebEncode(value));
+    return sha256(lebEncode(value));
   } else if (value instanceof Uint8Array || ArrayBuffer.isView(value)) {
-    return hash(uint8FromBufLike(value));
+    return sha256(uint8FromBufLike(value));
   } else if (Array.isArray(value)) {
     const vals = value.map(hashValue);
-    return hash(concatBytes(...vals));
+    return sha256(concatBytes(...vals));
   } else if (value && typeof value === 'object' && (value as Principal)._isPrincipal) {
-    return hash((value as Principal).toUint8Array());
+    return sha256((value as Principal).toUint8Array());
   } else if (
     typeof value === 'object' &&
     value !== null &&
@@ -56,14 +48,14 @@ export function hashValue(value: unknown): Uint8Array {
     // Do this check much later than the other bigint check because this one is much less
     // type-safe.
     // So we want to try all the high-assurance type guards before this 'probable' one.
-    return hash(lebEncode(value));
+    return sha256(lebEncode(value));
   }
   throw InputError.fromCode(new HashValueErrorCode(value));
 }
 
 const hashString = (value: string): Uint8Array => {
   const encoded = new TextEncoder().encode(value);
-  return hash(encoded);
+  return sha256(encoded);
 };
 
 /**
@@ -99,6 +91,6 @@ export function hashOfMap(map: Record<string, unknown>): Uint8Array {
   });
 
   const concatenated = concatBytes(...sorted.map(x => concatBytes(...x)));
-  const result = hash(concatenated);
+  const result = sha256(concatenated);
   return result;
 }


### PR DESCRIPTION
# Description

Removes the `hash` exported function.

# How Has This Been Tested?

Same tests should pass

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
