### PR TITLE
refactor: use `@noble/hashes/sha2` consistently

### DIFF
--- a/packages/assets/src/index.ts
+++ b/packages/assets/src/index.ts
@@ -13,7 +13,7 @@ import {
 } from '@dfinity/agent';
 import { lebDecode, PipeArrayBuffer, compare } from '@dfinity/candid';
 import { AssetsCanisterRecord, getAssetsCanister } from './canisters/assets';
-import { sha256 } from '@noble/hashes/sha256';
+import { sha256 } from '@noble/hashes/sha2';
 import { BatchOperationKind } from './canisters/assets_service';
 import { isReadable, Readable } from './readable/readable';
 import { ReadableFile } from './readable/readableFile';
@@ -201,7 +201,7 @@ export class AssetManager {
         await readable.open();
         const bytes = await readable.slice(0, readable.length);
         await readable.close();
-        const hash = config?.sha256 ?? sha256.create().update(new Uint8Array(bytes)).digest();
+        const hash = config?.sha256 ?? sha256(new Uint8Array(bytes));
         return this._actor.store({
           key,
           content: bytes,

--- a/packages/identity-secp256k1/src/secp256k1.test.ts
+++ b/packages/identity-secp256k1/src/secp256k1.test.ts
@@ -1,6 +1,6 @@
 import { DerEncodedPublicKey, PublicKey } from '@dfinity/agent';
 import { randomBytes } from 'crypto';
-import { sha256 } from '@noble/hashes/sha256';
+import { sha256 } from '@noble/hashes/sha2';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { Secp256k1KeyIdentity, Secp256k1PublicKey } from './secp256k1';
 import { hexToBytes, bytesToHex } from '@noble/curves/abstract/utils';
@@ -195,13 +195,7 @@ describe('Secp256k1KeyIdentity Tests', () => {
     const message = 'Hello world. Secp256k1 test here';
     const challenge = new TextEncoder().encode(message);
     const signature = await identity.sign(challenge);
-    const hash = sha256.create();
-    hash.update(challenge);
-    const isValid = secp256k1.verify(
-      new Uint8Array(signature),
-      new Uint8Array(hash.digest()),
-      new Uint8Array(rawPublicKey),
-    );
+    const isValid = secp256k1.verify(signature, sha256(challenge), rawPublicKey);
     expect(isValid).toBe(true);
   });
 });

--- a/packages/identity-secp256k1/src/secp256k1.ts
+++ b/packages/identity-secp256k1/src/secp256k1.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { DerEncodedPublicKey, KeyPair, Signature, PublicKey, SignIdentity } from '@dfinity/agent';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import { sha256 } from '@noble/hashes/sha256';
+import { sha256 } from '@noble/hashes/sha2';
 import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils';
 import * as bip39 from '@scure/bip39';
 import { HDKey } from '@scure/bip32';
@@ -252,13 +252,12 @@ export class Secp256k1KeyIdentity extends SignIdentity {
 
   /**
    * Signs a blob of data, with this identity's private key.
-   * @param {Uint8Array} challenge - challenge to sign with this identity's secretKey, producing a signature
+   * @param {Uint8Array} data - bytes to hash and sign with this identity's secretKey, producing a signature
    * @returns {Promise<Signature>} signature
    */
-  public async sign(challenge: Uint8Array): Promise<Signature> {
-    const hash = sha256.create();
-    hash.update(challenge);
-    const signature = secp256k1.sign(hash.digest(), this._privateKey).toCompactRawBytes();
+  public async sign(data: Uint8Array): Promise<Signature> {
+    const challenge = sha256(data);
+    const signature = secp256k1.sign(challenge, this._privateKey).toCompactRawBytes();
     return signature as Signature;
   }
 }

--- a/packages/identity/src/identity/ecdsa.test.ts
+++ b/packages/identity/src/identity/ecdsa.test.ts
@@ -1,4 +1,3 @@
-import { sha256 } from '@noble/hashes/sha256';
 import { ECDSAKeyIdentity } from './ecdsa';
 import { Crypto } from '@peculiar/webcrypto';
 
@@ -11,9 +10,7 @@ describe('ECDSAKeyIdentity Tests', () => {
     const keyPair = identity.getKeyPair();
     const identity2 = await ECDSAKeyIdentity.fromKeyPair(keyPair, subtle);
 
-    expect(await identity.getPublicKey().toDer()).toStrictEqual(
-      await identity2.getPublicKey().toDer(),
-    );
+    expect(identity.getPublicKey().toDer()).toStrictEqual(identity2.getPublicKey().toDer());
   });
 
   test('getKeyPair should return a copy of the key pair', async () => {
@@ -28,8 +25,6 @@ describe('ECDSAKeyIdentity Tests', () => {
     const message = 'Hello world. ECDSA test here';
     const challenge = new TextEncoder().encode(message);
     const signature = await identity.sign(challenge);
-    const hash = sha256.create();
-    hash.update(challenge);
     const isValid = await subtle.verify(
       {
         name: 'ECDSA',

--- a/packages/principal/src/index.ts
+++ b/packages/principal/src/index.ts
@@ -1,6 +1,6 @@
 import { decode, encode } from './utils/base32';
 import { getCrc32 } from './utils/getCrc';
-import { sha224 } from './utils/sha224';
+import { sha224 } from '@noble/hashes/sha2';
 
 export const JSON_KEY_PRINCIPAL = '__principal__';
 const SELF_AUTHENTICATING_SUFFIX = 2;

--- a/packages/principal/src/utils/sha224.ts
+++ b/packages/principal/src/utils/sha224.ts
@@ -1,9 +1,0 @@
-import { sha224 as jsSha224 } from '@noble/hashes/sha256';
-
-/**
- * Returns the SHA224 hash of the buffer.
- * @param data Arraybuffer to encode
- */
-export function sha224(data: Uint8Array): Uint8Array {
-  return jsSha224.create().update(data).digest();
-}


### PR DESCRIPTION
# Description

Remove useless utility functions and use `sha256` from `@noble/hashes/sha2` as function.

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
