### PR TITLE
feat!: replace `concat` with `concatBytes` from `@noble/hashes/utils`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - feat!: changes all @dfinity/candid interfaces to `Uint8Array<ArrayBuffer>` instead of `ArrayBuffer` to make the API more consistent.
-- feat!: replaces `fromHex` and `toHex` utils with `bytesToHex` and `hexToBytes` from `@noble/hashes/utils` to take advantage of existing dependencies.
+- feat!: replaces `fromHex`, `toHex`, `concat` utils with `bytesToHex`, `hexToBytes`, and `concatBytes` from `@noble/hashes/utils` respectively, to take advantage of existing dependencies.
 - chore: removes unused `bs58check` dependency from `@dfinity/identity-secp256k1`
 - feat!: changes polling strategy for `read_state` requests to support presigned requests. By default, `read_state` requests will create a new signature with a new ingress expiry each time they are made. However, the new `preSignReadStateRequest` will make one signature and use it for all polling requests. This is useful for hardware wallets or other external signing solutions that make signing cumbersome.
   - pollForResponse now moves `strategy`, `request`, and `preSignReadStateRequest` to the `options: PollingOptions` object
@@ -46,7 +46,6 @@
 - fix: fixes a bug in the Ed25519KeyIdentity verify implementation where the argument order was incorrect
 - fix: fixes a bug in the `Principal` library where the management canister id util was incorrectly importing using `fromHex`
 - feat: change auth-client's default identity provider url
-
 
 ## [2.4.0] - 2025-03-24
 

--- a/packages/agent/src/cbor.ts
+++ b/packages/agent/src/cbor.ts
@@ -5,8 +5,8 @@ import * as cbor from 'simple-cbor';
 import { CborEncoder, SelfDescribeCborSerializer } from 'simple-cbor';
 import { Principal } from '@dfinity/principal';
 import { CborDecodeErrorCode, InputError } from './errors';
-import { concat, uint8FromBufLike, uint8ToBuf } from './utils/buffer';
-import { hexToBytes } from '@noble/hashes/utils';
+import { uint8FromBufLike, uint8ToBuf } from './utils/buffer';
+import { hexToBytes, concatBytes } from '@noble/hashes/utils';
 
 // We are using hansl/simple-cbor for CBOR serialization, to avoid issues with
 // encoding the uint64 values that the HTTP handler of the client expects for
@@ -111,7 +111,7 @@ function decodePositiveBigInt(buf: Uint8Array): bigint {
 // A BORC subclass that decodes byte strings to Uint8Array instead of the Buffer class.
 class Uint8ArrayDecoder extends borc.Decoder {
   public createByteString(raw: Uint8Array[]): Uint8Array {
-    return concat(...raw);
+    return concatBytes(...raw);
   }
 
   public createByteStringFromHeap(start: number, end: number): Uint8Array {

--- a/packages/agent/src/utils/buffer.ts
+++ b/packages/agent/src/utils/buffer.ts
@@ -34,20 +34,6 @@ export function uint8FromBufLike(
 }
 
 /**
- * Concatenate multiple Uint8Arrays.
- * @param uint8Arrays The Uint8Arrays to concatenate.
- */
-export function concat(...uint8Arrays: Uint8Array[]): Uint8Array {
-  const result = new Uint8Array(uint8Arrays.reduce((acc, curr) => acc + curr.byteLength, 0));
-  let index = 0;
-  for (const b of uint8Arrays) {
-    result.set(b, index);
-    index += b.byteLength;
-  }
-  return result;
-}
-
-/**
  * Returns a true ArrayBuffer from a Uint8Array, as Uint8Array.buffer is unsafe.
  * @param {Uint8Array} arr Uint8Array to convert
  * @returns ArrayBuffer


### PR DESCRIPTION
# Description

Replaces the `concat` exposed function.

# How Has This Been Tested?

Same tests should pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
