### PR TITLE
refactor: use hex utils from `@noble/hashes`

### DIFF
--- a/packages/identity-secp256k1/src/secp256k1.test.ts
+++ b/packages/identity-secp256k1/src/secp256k1.test.ts
@@ -51,26 +51,11 @@ describe('Secp256k1PublicKey Tests', () => {
     });
   });
 
-  const hexRe = new RegExp(/^[0-9a-fA-F]+$/);
-  function fromHex(hex: string): Uint8Array {
-    if (!hexRe.test(hex)) {
-      throw new Error('Invalid hexadecimal string.');
-    }
-    const buffer = [...hex]
-      .reduce((acc, curr, i) => {
-        acc[(i / 2) | 0] = (acc[(i / 2) | 0] || '') + curr;
-        return acc;
-      }, [] as string[])
-      .map(x => Number.parseInt(x, 16));
-
-    return new Uint8Array(buffer);
-  }
-
   test('DER decoding of invalid keys', async () => {
     // Too short.
     expect(() => {
       Secp256k1PublicKey.fromDer(
-        fromHex(
+        hexToBytes(
           '3056301006072a8648ce3d020106052b8104000a0342000401ec030acd7d1199f73ae3469329c114944e0693c89502f850bcc6bad397a5956767c79b410c29ac6f587eec84878020fdb54ba002a79b02aa153fe47b6',
         ) as DerEncodedPublicKey,
       );
@@ -78,7 +63,7 @@ describe('Secp256k1PublicKey Tests', () => {
     // Too long.
     expect(() => {
       Secp256k1PublicKey.fromDer(
-        fromHex(
+        hexToBytes(
           '3056301006072a8648ce3d020106052b8104000a0342000401ec030acd7d1199f73ae3469329c114944e0693c89502f850bcc6bad397a5956767c79b410c29ac6f587eec84878020fdb54ba002a79b02aa153fe47b6ffd33' +
             '1b42211ce',
         ) as DerEncodedPublicKey,

--- a/packages/identity-secp256k1/src/secp256k1.test.ts
+++ b/packages/identity-secp256k1/src/secp256k1.test.ts
@@ -51,11 +51,28 @@ describe('Secp256k1PublicKey Tests', () => {
     });
   });
 
+  // we have to keep this function because the hex strings are do not have a valid padding,
+  // and we cannot use `hexToBytes` from `@noble/hashes/utils`
+  function fromHex(hex: string): Uint8Array {
+    const hexRe = new RegExp(/^[0-9a-fA-F]+$/);
+    if (!hexRe.test(hex)) {
+      throw new Error('Invalid hexadecimal string.');
+    }
+    const buffer = [...hex]
+      .reduce((acc, curr, i) => {
+        acc[(i / 2) | 0] = (acc[(i / 2) | 0] || '') + curr;
+        return acc;
+      }, [] as string[])
+      .map(x => Number.parseInt(x, 16));
+
+    return new Uint8Array(buffer);
+  }
+
   test('DER decoding of invalid keys', async () => {
     // Too short.
     expect(() => {
       Secp256k1PublicKey.fromDer(
-        hexToBytes(
+        fromHex(
           '3056301006072a8648ce3d020106052b8104000a0342000401ec030acd7d1199f73ae3469329c114944e0693c89502f850bcc6bad397a5956767c79b410c29ac6f587eec84878020fdb54ba002a79b02aa153fe47b6',
         ) as DerEncodedPublicKey,
       );
@@ -63,7 +80,7 @@ describe('Secp256k1PublicKey Tests', () => {
     // Too long.
     expect(() => {
       Secp256k1PublicKey.fromDer(
-        hexToBytes(
+        fromHex(
           '3056301006072a8648ce3d020106052b8104000a0342000401ec030acd7d1199f73ae3469329c114944e0693c89502f850bcc6bad397a5956767c79b410c29ac6f587eec84878020fdb54ba002a79b02aa153fe47b6ffd33' +
             '1b42211ce',
         ) as DerEncodedPublicKey,

--- a/packages/principal/src/index.ts
+++ b/packages/principal/src/index.ts
@@ -1,18 +1,13 @@
 import { decode, encode } from './utils/base32';
 import { getCrc32 } from './utils/getCrc';
 import { sha224 } from './utils/sha224';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 
 export const JSON_KEY_PRINCIPAL = '__principal__';
 const SELF_AUTHENTICATING_SUFFIX = 2;
 const ANONYMOUS_SUFFIX = 4;
 
 const MANAGEMENT_CANISTER_PRINCIPAL_TEXT_STR = 'aaaaa-aa';
-
-const fromHexString = (hexString: string) =>
-  new Uint8Array((hexString.match(/.{1,2}/g) ?? []).map(byte => parseInt(byte, 16)));
-
-const toHexString = (bytes: Uint8Array) =>
-  bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
 
 export type JsonnablePrincipal = {
   [JSON_KEY_PRINCIPAL]: string;
@@ -53,7 +48,7 @@ export class Principal {
   }
 
   public static fromHex(hex: string): Principal {
-    return new this(fromHexString(hex));
+    return new this(hexToBytes(hex));
   }
 
   public static fromText(text: string): Principal {
@@ -98,7 +93,7 @@ export class Principal {
   }
 
   public toHex(): string {
-    return toHexString(this._arr).toUpperCase();
+    return bytesToHex(this._arr).toUpperCase();
   }
 
   public toText(): string {


### PR DESCRIPTION
# Description

Minor changes

# How Has This Been Tested?

Same tests should pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
