### PR TITLE
fix: mark `@noble/hashes` as a dependency rather than a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15741,10 +15741,10 @@
       "version": "2.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/curves": "^1.2.0"
+        "@noble/curves": "^1.2.0",
+        "@noble/hashes": "^1.8.0"
       },
       "devDependencies": {
-        "@noble/hashes": "^1.8.0",
         "@peculiar/webcrypto": "^1.4.0",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
@@ -15891,7 +15891,6 @@
     },
     "packages/identity/node_modules/@noble/hashes": {
       "version": "1.8.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -50,10 +50,10 @@
     "@dfinity/principal": "^2.4.1"
   },
   "dependencies": {
-    "@noble/curves": "^1.2.0"
+    "@noble/curves": "^1.2.0",
+    "@noble/hashes": "^1.8.0"
   },
   "devDependencies": {
-    "@noble/hashes": "^1.8.0",
     "@peculiar/webcrypto": "^1.4.0",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",


### PR DESCRIPTION
# Description

I have just updated OpenChat to use v3.0.0-beta.0, but I had to manually add a dependency on `@noble/hashes` because prior to this PR it is only listed as a dev dependency of `@dfinity/identity` even though it is used at run time.

It is not a dev dependency of any other packages in this workspace.

# How Has This Been Tested?

It only moves a dependency from `devDependencies` to `dependencies`, so testing is not required.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
