### PR TITLE
chore: update `@noble/*` dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,17 +117,6 @@
         "node": ">=10.10.0"
       }
     },
-    "e2e/node/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "e2e/node/node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "dev": true,
@@ -1771,20 +1760,27 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.2",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
+      "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2455,30 +2451,36 @@
       ]
     },
     "node_modules/@scure/base": {
-      "version": "1.1.7",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.4.0",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.3.0",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -14853,8 +14855,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dfinity/cbor": "^0.2.2",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.3.1"
+        "@noble/curves": "^1.9.2"
       },
       "devDependencies": {
         "@peculiar/webcrypto": "^1.4.3",
@@ -14872,7 +14873,8 @@
       },
       "peerDependencies": {
         "@dfinity/candid": "^2.4.1",
-        "@dfinity/principal": "^2.4.1"
+        "@dfinity/principal": "^2.4.1",
+        "@noble/hashes": "^1.8.0"
       }
     },
     "packages/agent/node_modules/@dfinity/cbor": {
@@ -15095,7 +15097,7 @@
       "peerDependencies": {
         "@dfinity/agent": "^2.4.1",
         "@dfinity/principal": "^2.4.1",
-        "@noble/hashes": "^1.3.1"
+        "@noble/hashes": "^1.8.0"
       }
     },
     "packages/assets/node_modules/@typescript-eslint/eslint-plugin": {
@@ -15740,10 +15742,6 @@
       "name": "@dfinity/identity",
       "version": "2.4.1",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.2.0",
-        "@noble/hashes": "^1.8.0"
-      },
       "devDependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
@@ -15760,7 +15758,9 @@
       },
       "peerDependencies": {
         "@dfinity/agent": "^2.4.1",
-        "@dfinity/principal": "^2.4.1"
+        "@dfinity/principal": "^2.4.1",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0"
       }
     },
     "packages/identity-secp256k1": {
@@ -15769,15 +15769,17 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dfinity/agent": "^2.4.1",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.3.1",
-        "@scure/bip32": "^1.4.0",
-        "@scure/bip39": "^1.3.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
         "asn1js": "^3.0.5"
       },
       "devDependencies": {
         "eslint": "^8.19.0",
         "typedoc": "^0.28.4"
+      },
+      "peerDependencies": {
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0"
       }
     },
     "packages/identity-secp256k1/node_modules/@eslint/js": {
@@ -15887,16 +15889,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "packages/identity/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/identity/node_modules/@typescript-eslint/eslint-plugin": {
@@ -16095,7 +16087,7 @@
       "version": "2.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/hashes": "^1.3.1"
+        "@noble/hashes": "^1.8.0"
       },
       "devDependencies": {
         "@dfinity/utils": "^2.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -48,12 +48,12 @@
   },
   "peerDependencies": {
     "@dfinity/candid": "^2.4.1",
-    "@dfinity/principal": "^2.4.1"
+    "@dfinity/principal": "^2.4.1",
+    "@noble/hashes": "^1.8.0"
   },
   "dependencies": {
     "@dfinity/cbor": "^0.2.2",
-    "@noble/curves": "^1.4.0",
-    "@noble/hashes": "^1.3.1"
+    "@noble/curves": "^1.9.2"
   },
   "devDependencies": {
     "@peculiar/webcrypto": "^1.4.3",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -56,7 +56,7 @@
   "peerDependencies": {
     "@dfinity/agent": "^2.4.1",
     "@dfinity/principal": "^2.4.1",
-    "@noble/hashes": "^1.3.1"
+    "@noble/hashes": "^1.8.0"
   },
   "dependencies": {
     "mime": "^3.0.0"

--- a/packages/identity-secp256k1/package.json
+++ b/packages/identity-secp256k1/package.json
@@ -18,11 +18,13 @@
   },
   "dependencies": {
     "@dfinity/agent": "^2.4.1",
-    "@noble/curves": "^1.4.0",
-    "@noble/hashes": "^1.3.1",
-    "@scure/bip32": "^1.4.0",
-    "@scure/bip39": "^1.3.0",
+    "@scure/bip32": "^1.7.0",
+    "@scure/bip39": "^1.6.0",
     "asn1js": "^3.0.5"
+  },
+  "peerDependencies": {
+    "@noble/curves": "^1.9.2",
+    "@noble/hashes": "^1.8.0"
   },
   "devDependencies": {
     "eslint": "^8.19.0",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -47,10 +47,8 @@
   },
   "peerDependencies": {
     "@dfinity/agent": "^2.4.1",
-    "@dfinity/principal": "^2.4.1"
-  },
-  "dependencies": {
-    "@noble/curves": "^1.2.0",
+    "@dfinity/principal": "^2.4.1",
+    "@noble/curves": "^1.9.2",
     "@noble/hashes": "^1.8.0"
   },
   "devDependencies": {

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -66,6 +66,6 @@
     }
   ],
   "dependencies": {
-    "@noble/hashes": "^1.3.1"
+    "@noble/hashes": "^1.8.0"
   }
 }


### PR DESCRIPTION
# Description

Update the `@noble/curves` and `@noble/hashes` dependencies. Following the suggestion in https://github.com/dfinity/agent-js/pull/1034#issuecomment-2983647447, sets them as peer dependencies where needed.

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
