### PR TITLE
chore: ignore `docs` and `.dfx` folders in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,7 +15,15 @@ const compat = new FlatCompat({
 });
 
 export default defineConfig([
-  globalIgnores(['**/lib/', '**/dist/', '**/__certificates__/', '**/declarations/', '**/types/']),
+  globalIgnores([
+    'docs/',
+    '.dfx/',
+    '**/lib/',
+    '**/dist/',
+    '**/__certificates__/',
+    '**/declarations/',
+    '**/types/',
+  ]),
   {
     files: ['**/*.{ts,tsx,js,jsx}'],
 


### PR DESCRIPTION
# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
