### PR TITLE
chore: updates the version script to work with new pnpm workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- chore: updates the version script to work with new pnpm workspaces
 - feat: removes the watermark checks when checking query responses. Now the agent checks if the node signature is not older than the `ingressExpiryInMinutes` option (taking into account the clock drift).
 - fix: always account for the clock drift when calculating the ingress expiry.
 

--- a/bin/version.ts
+++ b/bin/version.ts
@@ -21,7 +21,6 @@ const workspaceConfig = yaml.parse(
   fs.readFileSync(path.resolve(__dirname, '..', 'pnpm-workspace.yaml')).toString(),
 );
 
-console.log(process.argv)
 const newVersion = process.argv[process.argv.length - 1];
 console.log('New version will be: ' + newVersion);
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "ts-jest": "^29.3.4",
     "typedoc": "^0.28.5",
     "typescript": "5.8.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "yaml": "^2.8.0"
   },
   "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39",
   "engines": {
@@ -53,7 +54,7 @@
     "e2e": "pnpm -r e2e",
     "test": "pnpm -r test",
     "publish": "pnpm -r publish",
-    "version": "pnpm -r version",
+    "version": "pnpm dlx tsx bin/version.ts",
     "attw": "pnpm -r attw",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,10 +67,10 @@ importers:
         version: 8.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.1)
+        version: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
       jest-cli:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.1)
+        version: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
       jest-environment-jsdom:
         specifier: 29.7.0
         version: 29.7.0
@@ -103,7 +103,7 @@ importers:
         version: 0.7.0
       ts-jest:
         specifier: ^29.3.4
-        version: 29.4.0(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.25.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.1))(typescript@5.8.3)
+        version: 29.4.0(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.25.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)))(typescript@5.8.3)
       typedoc:
         specifier: ^0.28.5
         version: 0.28.5(typescript@5.8.3)
@@ -113,6 +113,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(jiti@2.4.2)(jsdom@20.0.3)(yaml@2.8.0)
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.0
 
   e2e/node:
     dependencies:
@@ -230,6 +233,10 @@ importers:
       '@dfinity/principal':
         specifier: workspace:*
         version: link:../principal
+    devDependencies:
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.19.1)(typescript@5.8.3)
 
   packages/identity:
     dependencies:
@@ -281,7 +288,7 @@ importers:
     devDependencies:
       '@dfinity/utils':
         specifier: ^2.0.0
-        version: 2.13.1(@dfinity/agent@3.0.0-beta.1(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)(@noble/hashes@1.8.0))(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)
+        version: 2.13.1(@dfinity/agent@3.0.0-beta.2(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)(@noble/hashes@1.8.0))(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)
 
   packages/use-auth-client:
     dependencies:
@@ -511,23 +518,27 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@dfinity/agent@3.0.0-beta.1':
-    resolution: {integrity: sha512-XixBHGcyrhgeaJggbOtlR7CX3zw+Ytw4vwXvQkxDAztQW9cBF9AmZzHTtWYvjcfu5F21gZu3BhLA9vkOlOj0wA==}
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@dfinity/agent@3.0.0-beta.2':
+    resolution: {integrity: sha512-LEEYmfy/gsYdL6fPlTbRzm+zhdVXjjkHAr5QG8F7K5mPrJnHsK4+MfOsodGKDEmwAPO4PjaZYIDc89EiLS4GiQ==}
     peerDependencies:
-      '@dfinity/candid': ^3.0.0-beta.1
-      '@dfinity/principal': ^3.0.0-beta.1
+      '@dfinity/candid': 3.0.0-beta.2
+      '@dfinity/principal': 3.0.0-beta.2
       '@noble/hashes': ^1.8.0
 
-  '@dfinity/candid@3.0.0-beta.1':
-    resolution: {integrity: sha512-VapzoXZab4tueBM8iigQZI44km2TtzeWW/YE/cH9nuQG6vs3nuChOh/RpqCPzyxhc/5JHCF47rLc1uVqKisOuQ==}
+  '@dfinity/candid@3.0.0-beta.2':
+    resolution: {integrity: sha512-YhFEO56kmUldbcxndGIKiy6BnfjQFFdFtIZNaWnkcm9eiAN6ZF/rqhStx+5hPCOg20ibZwZeMohepDyxeDbkIA==}
     peerDependencies:
-      '@dfinity/principal': ^3.0.0-beta.1
+      '@dfinity/principal': 3.0.0-beta.2
 
   '@dfinity/cbor@0.2.2':
     resolution: {integrity: sha512-GPJpH73kDEKbUBdUjY80lz7cq9l0vm1h/7ppejPV6O0ZTqCLrYspssYvqjRmK4aNnJ/SKXsP0rg9LYX7zpegaA==}
 
-  '@dfinity/principal@3.0.0-beta.1':
-    resolution: {integrity: sha512-lOWzep6K6PwnEbeuuupuYunnPZdrdLbNE5zWONo8NkYqLJBRM8nbAB37eiq8dkjAarIOwBapgS+q4erv3XrJ+w==}
+  '@dfinity/principal@3.0.0-beta.2':
+    resolution: {integrity: sha512-p6d/z1tBuiTokgfBVB1iMBuX48U3nPalPpil5S9rB4SlkZalf50tMNP2BvrGVjmI9mmCciaTBsFFNPNzDlhfNA==}
 
   '@dfinity/utils@2.13.1':
     resolution: {integrity: sha512-WJ2iYYncfAAWEJQYfUDOYw6e5EFmI8jlmRVOTki+EFVKWo5gmubVT3OguisEqEMCZfxoP1SZKs1DXrYSGYrxfw==}
@@ -972,6 +983,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@loaderkit/resolve@1.0.4':
     resolution: {integrity: sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==}
 
@@ -1275,6 +1289,18 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
   '@tsconfig/node18@18.2.4':
     resolution: {integrity: sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==}
@@ -1608,6 +1634,9 @@ packages:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
 
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -1936,6 +1965,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
 
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2053,6 +2085,10 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
 
   direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
@@ -4293,6 +4329,20 @@ packages:
       jest-util:
         optional: true
 
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4442,6 +4492,9 @@ packages:
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -4672,6 +4725,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4910,29 +4967,33 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@dfinity/agent@3.0.0-beta.1(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)(@noble/hashes@1.8.0)':
+  '@cspotcode/source-map-support@0.8.1':
     dependencies:
-      '@dfinity/candid': 3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1)
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@dfinity/agent@3.0.0-beta.2(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)(@noble/hashes@1.8.0)':
+    dependencies:
+      '@dfinity/candid': 3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2)
       '@dfinity/cbor': 0.2.2
-      '@dfinity/principal': 3.0.0-beta.1
+      '@dfinity/principal': 3.0.0-beta.2
       '@noble/curves': 1.9.2
       '@noble/hashes': 1.8.0
 
-  '@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1)':
+  '@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2)':
     dependencies:
-      '@dfinity/principal': 3.0.0-beta.1
+      '@dfinity/principal': 3.0.0-beta.2
 
   '@dfinity/cbor@0.2.2': {}
 
-  '@dfinity/principal@3.0.0-beta.1':
+  '@dfinity/principal@3.0.0-beta.2':
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@dfinity/utils@2.13.1(@dfinity/agent@3.0.0-beta.1(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)(@noble/hashes@1.8.0))(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)':
+  '@dfinity/utils@2.13.1(@dfinity/agent@3.0.0-beta.2(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)(@noble/hashes@1.8.0))(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)':
     dependencies:
-      '@dfinity/agent': 3.0.0-beta.1(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)(@noble/hashes@1.8.0)
-      '@dfinity/candid': 3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1)
-      '@dfinity/principal': 3.0.0-beta.1
+      '@dfinity/agent': 3.0.0-beta.2(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)(@noble/hashes@1.8.0)
+      '@dfinity/candid': 3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2)
+      '@dfinity/principal': 3.0.0-beta.2
 
   '@es-joy/jsdoccomment@0.46.0':
     dependencies:
@@ -5228,7 +5289,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -5242,7 +5303,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.1)
+      jest-config: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -5394,6 +5455,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -5678,6 +5744,14 @@ snapshots:
   '@tootallnate/once@2.0.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
 
   '@tsconfig/node18@18.2.4': {}
 
@@ -6087,6 +6161,8 @@ snapshots:
 
   are-docs-informative@0.0.2: {}
 
+  arg@4.1.3: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -6425,13 +6501,13 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  create-jest@29.7.0(@types/node@20.19.1):
+  create-jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.1)
+      jest-config: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -6439,6 +6515,8 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  create-require@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6526,6 +6604,8 @@ snapshots:
       dequal: 2.0.3
 
   diff-sequences@29.6.3: {}
+
+  diff@4.0.2: {}
 
   direction@2.0.1: {}
 
@@ -7561,16 +7641,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.1):
+  jest-cli@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.1)
+      create-jest: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.1)
+      jest-config: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -7580,7 +7660,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.1):
+  jest-config@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)):
     dependencies:
       '@babel/core': 7.27.4
       '@jest/test-sequencer': 29.7.0
@@ -7606,6 +7686,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.1
+      ts-node: 10.9.2(@types/node@20.19.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -7840,12 +7921,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.1):
+  jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.1)
+      jest-cli: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9422,12 +9503,12 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  ts-jest@29.4.0(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.25.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.1))(typescript@5.8.3):
+  ts-jest@29.4.0(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.25.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.19.1)
+      jest: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -9442,6 +9523,24 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.27.4)
       esbuild: 0.25.5
       jest-util: 29.7.0
+
+  ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
 
   tslib@2.8.1: {}
 
@@ -9612,6 +9711,8 @@ snapshots:
       is-generator-function: 1.1.0
       is-typed-array: 1.1.15
       which-typed-array: 1.1.19
+
+  v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -9859,6 +9960,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(jiti@2.4.2)(jsdom@20.0.3)(yaml@2.8.0)
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.0
 
   e2e/node:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,10 +67,10 @@ importers:
         version: 8.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+        version: 29.7.0(@types/node@20.19.1)
       jest-cli:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+        version: 29.7.0(@types/node@20.19.1)
       jest-environment-jsdom:
         specifier: 29.7.0
         version: 29.7.0
@@ -103,7 +103,7 @@ importers:
         version: 0.7.0
       ts-jest:
         specifier: ^29.3.4
-        version: 29.4.0(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.25.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.0(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.25.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.1))(typescript@5.8.3)
       typedoc:
         specifier: ^0.28.5
         version: 0.28.5(typescript@5.8.3)
@@ -113,9 +113,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.1)(jiti@2.4.2)(jsdom@20.0.3)(yaml@2.8.0)
-      yaml:
-        specifier: ^2.8.0
-        version: 2.8.0
 
   e2e/node:
     dependencies:
@@ -233,10 +230,6 @@ importers:
       '@dfinity/principal':
         specifier: workspace:*
         version: link:../principal
-    devDependencies:
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.1)(typescript@5.8.3)
 
   packages/identity:
     dependencies:
@@ -288,7 +281,7 @@ importers:
     devDependencies:
       '@dfinity/utils':
         specifier: ^2.0.0
-        version: 2.13.1(@dfinity/agent@3.0.0-beta.2(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)(@noble/hashes@1.8.0))(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)
+        version: 2.13.1(@dfinity/agent@3.0.0-beta.1(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)(@noble/hashes@1.8.0))(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)
 
   packages/use-auth-client:
     dependencies:
@@ -518,27 +511,23 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
-
-  '@dfinity/agent@3.0.0-beta.2':
-    resolution: {integrity: sha512-LEEYmfy/gsYdL6fPlTbRzm+zhdVXjjkHAr5QG8F7K5mPrJnHsK4+MfOsodGKDEmwAPO4PjaZYIDc89EiLS4GiQ==}
+  '@dfinity/agent@3.0.0-beta.1':
+    resolution: {integrity: sha512-XixBHGcyrhgeaJggbOtlR7CX3zw+Ytw4vwXvQkxDAztQW9cBF9AmZzHTtWYvjcfu5F21gZu3BhLA9vkOlOj0wA==}
     peerDependencies:
-      '@dfinity/candid': 3.0.0-beta.2
-      '@dfinity/principal': 3.0.0-beta.2
+      '@dfinity/candid': ^3.0.0-beta.1
+      '@dfinity/principal': ^3.0.0-beta.1
       '@noble/hashes': ^1.8.0
 
-  '@dfinity/candid@3.0.0-beta.2':
-    resolution: {integrity: sha512-YhFEO56kmUldbcxndGIKiy6BnfjQFFdFtIZNaWnkcm9eiAN6ZF/rqhStx+5hPCOg20ibZwZeMohepDyxeDbkIA==}
+  '@dfinity/candid@3.0.0-beta.1':
+    resolution: {integrity: sha512-VapzoXZab4tueBM8iigQZI44km2TtzeWW/YE/cH9nuQG6vs3nuChOh/RpqCPzyxhc/5JHCF47rLc1uVqKisOuQ==}
     peerDependencies:
-      '@dfinity/principal': 3.0.0-beta.2
+      '@dfinity/principal': ^3.0.0-beta.1
 
   '@dfinity/cbor@0.2.2':
     resolution: {integrity: sha512-GPJpH73kDEKbUBdUjY80lz7cq9l0vm1h/7ppejPV6O0ZTqCLrYspssYvqjRmK4aNnJ/SKXsP0rg9LYX7zpegaA==}
 
-  '@dfinity/principal@3.0.0-beta.2':
-    resolution: {integrity: sha512-p6d/z1tBuiTokgfBVB1iMBuX48U3nPalPpil5S9rB4SlkZalf50tMNP2BvrGVjmI9mmCciaTBsFFNPNzDlhfNA==}
+  '@dfinity/principal@3.0.0-beta.1':
+    resolution: {integrity: sha512-lOWzep6K6PwnEbeuuupuYunnPZdrdLbNE5zWONo8NkYqLJBRM8nbAB37eiq8dkjAarIOwBapgS+q4erv3XrJ+w==}
 
   '@dfinity/utils@2.13.1':
     resolution: {integrity: sha512-WJ2iYYncfAAWEJQYfUDOYw6e5EFmI8jlmRVOTki+EFVKWo5gmubVT3OguisEqEMCZfxoP1SZKs1DXrYSGYrxfw==}
@@ -983,9 +972,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@jridgewell/trace-mapping@0.3.9':
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
-
   '@loaderkit/resolve@1.0.4':
     resolution: {integrity: sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==}
 
@@ -1289,18 +1275,6 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-
-  '@tsconfig/node10@1.0.11':
-    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
-
-  '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-
-  '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-
-  '@tsconfig/node16@1.0.4':
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
   '@tsconfig/node18@18.2.4':
     resolution: {integrity: sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==}
@@ -1634,9 +1608,6 @@ packages:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
 
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
-
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -1965,9 +1936,6 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
 
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2085,10 +2053,6 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
 
   direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
@@ -4329,20 +4293,6 @@ packages:
       jest-util:
         optional: true
 
-  ts-node@10.9.2:
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4492,9 +4442,6 @@ packages:
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
-
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -4725,10 +4672,6 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4967,33 +4910,29 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@cspotcode/source-map-support@0.8.1':
+  '@dfinity/agent@3.0.0-beta.1(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)(@noble/hashes@1.8.0)':
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
-
-  '@dfinity/agent@3.0.0-beta.2(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)(@noble/hashes@1.8.0)':
-    dependencies:
-      '@dfinity/candid': 3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2)
+      '@dfinity/candid': 3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1)
       '@dfinity/cbor': 0.2.2
-      '@dfinity/principal': 3.0.0-beta.2
+      '@dfinity/principal': 3.0.0-beta.1
       '@noble/curves': 1.9.2
       '@noble/hashes': 1.8.0
 
-  '@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2)':
+  '@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1)':
     dependencies:
-      '@dfinity/principal': 3.0.0-beta.2
+      '@dfinity/principal': 3.0.0-beta.1
 
   '@dfinity/cbor@0.2.2': {}
 
-  '@dfinity/principal@3.0.0-beta.2':
+  '@dfinity/principal@3.0.0-beta.1':
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@dfinity/utils@2.13.1(@dfinity/agent@3.0.0-beta.2(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)(@noble/hashes@1.8.0))(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)':
+  '@dfinity/utils@2.13.1(@dfinity/agent@3.0.0-beta.1(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)(@noble/hashes@1.8.0))(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)':
     dependencies:
-      '@dfinity/agent': 3.0.0-beta.2(@dfinity/candid@3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2))(@dfinity/principal@3.0.0-beta.2)(@noble/hashes@1.8.0)
-      '@dfinity/candid': 3.0.0-beta.2(@dfinity/principal@3.0.0-beta.2)
-      '@dfinity/principal': 3.0.0-beta.2
+      '@dfinity/agent': 3.0.0-beta.1(@dfinity/candid@3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1))(@dfinity/principal@3.0.0-beta.1)(@noble/hashes@1.8.0)
+      '@dfinity/candid': 3.0.0-beta.1(@dfinity/principal@3.0.0-beta.1)
+      '@dfinity/principal': 3.0.0-beta.1
 
   '@es-joy/jsdoccomment@0.46.0':
     dependencies:
@@ -5289,7 +5228,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))':
+  '@jest/core@29.7.0':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -5303,7 +5242,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@20.19.1)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -5455,11 +5394,6 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
-
-  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -5744,14 +5678,6 @@ snapshots:
   '@tootallnate/once@2.0.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
-
-  '@tsconfig/node10@1.0.11': {}
-
-  '@tsconfig/node12@1.0.11': {}
-
-  '@tsconfig/node14@1.0.3': {}
-
-  '@tsconfig/node16@1.0.4': {}
 
   '@tsconfig/node18@18.2.4': {}
 
@@ -6161,8 +6087,6 @@ snapshots:
 
   are-docs-informative@0.0.2: {}
 
-  arg@4.1.3: {}
-
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -6501,13 +6425,13 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  create-jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)):
+  create-jest@29.7.0(@types/node@20.19.1):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@20.19.1)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -6515,8 +6439,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  create-require@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6604,8 +6526,6 @@ snapshots:
       dequal: 2.0.3
 
   diff-sequences@29.6.3: {}
-
-  diff@4.0.2: {}
 
   direction@2.0.1: {}
 
@@ -7641,16 +7561,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)):
+  jest-cli@29.7.0(@types/node@20.19.1):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+      create-jest: 29.7.0(@types/node@20.19.1)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@20.19.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -7660,7 +7580,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)):
+  jest-config@29.7.0(@types/node@20.19.1):
     dependencies:
       '@babel/core': 7.27.4
       '@jest/test-sequencer': 29.7.0
@@ -7686,7 +7606,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.1
-      ts-node: 10.9.2(@types/node@20.19.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -7921,12 +7840,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)):
+  jest@29.7.0(@types/node@20.19.1):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+      jest-cli: 29.7.0(@types/node@20.19.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9503,12 +9422,12 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  ts-jest@29.4.0(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.25.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)))(typescript@5.8.3):
+  ts-jest@29.4.0(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.25.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.1))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.19.1)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@20.19.1)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -9523,24 +9442,6 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.27.4)
       esbuild: 0.25.5
       jest-util: 29.7.0
-
-  ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.1
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.8.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
 
   tslib@2.8.1: {}
 
@@ -9711,8 +9612,6 @@ snapshots:
       is-generator-function: 1.1.0
       is-typed-array: 1.1.15
       which-typed-array: 1.1.19
-
-  v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -9960,8 +9859,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
# Description

Noticed this was broken while making the release today. It still doesn't account for a different version between core and other packages. Should we add that support while we're at it? We'll need to update the "prepare release" github action to have two inputs if we want to have multiple versions handled
