### PR TITLE
test: update tsconfig, cleanup (auth-client)

### DIFF
--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -62,6 +62,7 @@
     "idb": "^7.0.2"
   },
   "devDependencies": {
+    "@dfinity/candid": "workspace:*",
     "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/packages/auth-client/src/__snapshots__/index.test.ts.snap
+++ b/packages/auth-client/src/__snapshots__/index.test.ts.snap
@@ -21,4 +21,4 @@ DelegationIdentity {
 }
 `;
 
-exports[`Migration from Ed25519Key should generate and store a Ed25519 if no key is stored and keyType is set to Ed25519, and load the same key from storage if it's found in storage 1`] = `"["302a300506032b6570032100d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809","4bbff6b476463558d7be318aa342d1a97778d70833038680187950e9e02486c0d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809"]"`;
+exports[`Migration from Ed25519Key should generate and store a Ed25519 if no key is stored and keyType is set to Ed25519, and load the same key if it's found in storage 1`] = `"["302a300506032b6570032100d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809","4bbff6b476463558d7be318aa342d1a97778d70833038680187950e9e02486c0d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809"]"`;

--- a/packages/auth-client/src/__snapshots__/index.test.ts.snap
+++ b/packages/auth-client/src/__snapshots__/index.test.ts.snap
@@ -21,4 +21,4 @@ DelegationIdentity {
 }
 `;
 
-exports[`Migration from Ed25519Key should generate and store a ECDSAKey if no key is stored and keyType is set to Ed25519 1`] = `"["302a300506032b6570032100d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809","4bbff6b476463558d7be318aa342d1a97778d70833038680187950e9e02486c0d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809"]"`;
+exports[`Migration from Ed25519Key should generate and store a Ed25519 if no key is stored and keyType is set to Ed25519, and load the same key from storage if it's found in storage 1`] = `"["302a300506032b6570032100d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809","4bbff6b476463558d7be318aa342d1a97778d70833038680187950e9e02486c0d1fa89134802051c8b5d4e53c08b87381b87097bca4c4f348611eb8ce6c91809"]"`;

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -171,16 +171,16 @@ describe('Auth Client', () => {
 
     idpMock.ready();
 
-    expect(storage.set).toBeCalled();
-    expect(storage.remove).not.toBeCalled();
+    expect(storage.set).toHaveBeenCalled();
+    expect(storage.remove).not.toHaveBeenCalled();
 
     // simulate user being inactive for 10 minutes
     jest.advanceTimersByTime(10 * 60 * 1000);
 
     // Storage should be cleared by default after logging out
-    expect(storage.remove).toBeCalled();
+    expect(storage.remove).toHaveBeenCalled();
 
-    expect(window.location.reload).toBeCalled();
+    expect(window.location.reload).toHaveBeenCalled();
   });
   it('should not reload the page if the default callback is disabled', async () => {
     setup({
@@ -222,16 +222,16 @@ describe('Auth Client', () => {
     await test.login();
     idpMock.ready();
 
-    expect(storage.set).toBeCalled();
-    expect(storage.remove).not.toBeCalled();
+    expect(storage.set).toHaveBeenCalled();
+    expect(storage.remove).not.toHaveBeenCalled();
 
     // simulate user being inactive for 10 minutes
     jest.advanceTimersByTime(10 * 60 * 1000);
 
     // Storage should not be cleared
-    expect(storage.remove).not.toBeCalled();
+    expect(storage.remove).not.toHaveBeenCalled();
     // Page should not be reloaded
-    expect(window.location.reload).not.toBeCalled();
+    expect(window.location.reload).not.toHaveBeenCalled();
   });
   it('should not reload the page if a callback is provided', async () => {
     setup({
@@ -268,8 +268,8 @@ describe('Auth Client', () => {
     // simulate user being inactive for 10 minutes
     jest.advanceTimersByTime(10 * 60 * 1000);
 
-    expect(window.location.reload).not.toBeCalled();
-    expect(idleCb).toBeCalled();
+    expect(window.location.reload).not.toHaveBeenCalled();
+    expect(idleCb).toHaveBeenCalled();
   });
 
   /**
@@ -383,16 +383,16 @@ describe('Auth Client', () => {
       },
     });
 
-    expect(storage.set).toBeCalled();
-    expect(storage.remove).not.toBeCalled();
+    expect(storage.set).toHaveBeenCalled();
+    expect(storage.remove).not.toHaveBeenCalled();
 
     // simulate user being inactive for 10 minutes
     jest.advanceTimersByTime(10 * 60 * 1000);
 
     // Storage should not be cleared
-    expect(storage.remove).not.toBeCalled();
+    expect(storage.remove).not.toHaveBeenCalled();
     // Page should not be reloaded
-    expect(window.location.reload).not.toBeCalled();
+    expect(window.location.reload).not.toHaveBeenCalled();
   });
 });
 
@@ -753,7 +753,7 @@ describe('Migration from Ed25519Key', () => {
       ]
     `);
   });
-  it("should generate and store a Ed25519 if no key is stored and keyType is set to Ed25519, and load the same key from storage if it's found in storage", async () => {
+  it("should generate and store a Ed25519 if no key is stored and keyType is set to Ed25519, and load the same key if it's found in storage", async () => {
     const fakeStore: Record<any, any> = {};
     const storage = {
       remove: jest.fn(),

--- a/packages/auth-client/src/index.test.ts
+++ b/packages/auth-client/src/index.test.ts
@@ -76,7 +76,7 @@ describe('Auth Client', () => {
     expect(test.idleManager).not.toBeDefined();
   });
   it('should initialize an idleManager if an identity is passed', async () => {
-    const test = await AuthClient.create({ identity: await Ed25519KeyIdentity.generate() });
+    const test = await AuthClient.create({ identity: Ed25519KeyIdentity.generate() });
     expect(test.idleManager).toBeDefined();
   });
   it('should be able to invalidate an identity after going idle', async () => {
@@ -109,7 +109,7 @@ describe('Auth Client', () => {
         idleTimeout: 1000,
       },
     });
-    const httpAgent = new HttpAgent({ fetch: mockFetch });
+    const httpAgent = await HttpAgent.create({ fetch: mockFetch });
     const actor = Actor.createActor(actorInterface, { canisterId, agent: httpAgent });
 
     test.idleManager?.registerCallback(() => {
@@ -316,7 +316,7 @@ describe('Auth Client', () => {
         idleTimeout: 1000,
       },
     });
-    const httpAgent = new HttpAgent({ fetch: mockFetch });
+    const httpAgent = await HttpAgent.create({ fetch: mockFetch });
     const actor = Actor.createActor(actorInterface, { canisterId, agent: httpAgent });
 
     Actor.agentOf(actor)?.invalidateIdentity?.();
@@ -447,17 +447,17 @@ describe('Auth Client login', () => {
     const client = await AuthClient.create();
     // Try without #authorize hash.
     await client.login({ identityProvider: 'http://127.0.0.1' });
-    expect(global.open).toBeCalledWith('http://127.0.0.1/#authorize', 'idpWindow', undefined);
+    expect(global.open).toHaveBeenCalledWith('http://127.0.0.1/#authorize', 'idpWindow', undefined);
 
     // Try with #authorize hash.
     global.open = jest.fn();
     await client.login({ identityProvider: 'http://127.0.0.1#authorize' });
-    expect(global.open).toBeCalledWith('http://127.0.0.1/#authorize', 'idpWindow', undefined);
+    expect(global.open).toHaveBeenCalledWith('http://127.0.0.1/#authorize', 'idpWindow', undefined);
 
     // Default url
     global.open = jest.fn();
     await client.login();
-    expect(global.open).toBeCalledWith(
+    expect(global.open).toHaveBeenCalledWith(
       'https://identity.internetcomputer.org/#authorize',
       'idpWindow',
       undefined,
@@ -468,7 +468,7 @@ describe('Auth Client login', () => {
     await client.login({
       windowOpenerFeatures: 'toolbar=0,location=0,menubar=0',
     });
-    expect(global.open).toBeCalledWith(
+    expect(global.open).toHaveBeenCalledWith(
       'https://identity.internetcomputer.org/#authorize',
       'idpWindow',
       'toolbar=0,location=0,menubar=0',
@@ -499,7 +499,7 @@ describe('Auth Client login', () => {
     idpMock.ready('bad origin');
 
     // No response to the IDP canister.
-    expect(idpWindow.postMessage).not.toBeCalled();
+    expect(idpWindow.postMessage).not.toHaveBeenCalled();
   });
 
   it('should respond to authorize-ready events with correct origin', async () => {
@@ -511,7 +511,7 @@ describe('Auth Client login', () => {
     idpMock.ready();
 
     // A response should be sent to the IDP.
-    expect(idpWindow.postMessage).toBeCalled();
+    expect(idpWindow.postMessage).toHaveBeenCalled();
   });
 
   it('should call onError and close the IDP window on failure', async () => {
@@ -530,8 +530,8 @@ describe('Auth Client login', () => {
 
     idpMock.ready();
 
-    expect(failureFunc).toBeCalledWith('mock error message');
-    expect(idpWindow.close).toBeCalled();
+    expect(failureFunc).toHaveBeenCalledWith('mock error message');
+    expect(idpWindow.close).toHaveBeenCalled();
   });
 
   it('should call onError if received an invalid success message', done => {
@@ -546,7 +546,7 @@ describe('Auth Client login', () => {
     AuthClient.create()
       .then(client => {
         const onError = () => {
-          expect(idpWindow.close).toBeCalled();
+          expect(idpWindow.close).toHaveBeenCalled();
 
           client.logout().then(done);
         };
@@ -581,7 +581,7 @@ describe('Auth Client login', () => {
     AuthClient.create()
       .then(client => {
         const onSuccess = () => {
-          expect(idpWindow.close).toBeCalled();
+          expect(idpWindow.close).toHaveBeenCalled();
 
           client.logout().then(done);
         };
@@ -620,7 +620,7 @@ describe('Migration from localstorage', () => {
     await AuthClient.create({ storage });
 
     // Key is stored during creation when none is provided
-    expect(storage.set as jest.Mock).toBeCalledTimes(1);
+    expect(storage.set as jest.Mock).toHaveBeenCalledTimes(1);
   });
   it('should not attempt to migrate if a delegation is already stored', async () => {
     const storage: AuthClientStorage = {
@@ -635,7 +635,7 @@ describe('Migration from localstorage', () => {
 
     await AuthClient.create({ storage });
 
-    expect(storage.set as jest.Mock).toBeCalledTimes(1);
+    expect(storage.set as jest.Mock).toHaveBeenCalledTimes(1);
   });
   it('should migrate storage from localstorage', async () => {
     const localStorage = new LocalStorage();
@@ -650,7 +650,7 @@ describe('Migration from localstorage', () => {
 
     await AuthClient.create({ storage });
 
-    expect(storage.set as jest.Mock).toBeCalledTimes(3);
+    expect(storage.set as jest.Mock).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -666,7 +666,7 @@ describe('Migration from Ed25519Key', () => {
     // two days from now
     const expiration = new Date('2020-01-03T00:00:00.000Z');
 
-    const key = await Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
+    const key = Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
     const chain = DelegationChain.create(key, key.getPublicKey(), expiration);
     const storage: AuthClientStorage = {
       remove: jest.fn(),
@@ -680,7 +680,7 @@ describe('Migration from Ed25519Key', () => {
 
     const client = await AuthClient.create({ storage });
 
-    const identity = await client.getIdentity();
+    const identity = client.getIdentity();
     expect(identity).toMatchSnapshot();
   });
   it('should continue using an existing Ed25519Key with no delegation', async () => {
@@ -698,7 +698,7 @@ describe('Migration from Ed25519Key', () => {
 
     const client = await AuthClient.create({ storage });
 
-    const identity = await client.getIdentity();
+    const identity = client.getIdentity();
     expect(identity.getPrincipal().isAnonymous()).toBe(true);
   });
   it('should continue using an existing Ed25519Key with an expired delegation', async () => {
@@ -708,7 +708,7 @@ describe('Migration from Ed25519Key', () => {
     // two days ago
     const expiration = new Date('2019-12-30T00:00:00.000Z');
 
-    const key = await Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
+    const key = Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
 
     const chain = DelegationChain.create(key, key.getPublicKey(), expiration);
     const fakeStore: Record<any, any> = {};
@@ -727,11 +727,11 @@ describe('Migration from Ed25519Key', () => {
 
     const client = await AuthClient.create({ storage });
 
-    const identity = await client.getIdentity();
+    const identity = client.getIdentity();
     expect(identity.getPrincipal().isAnonymous()).toBe(true);
 
     // expect the delegation to be removed
-    expect(storage.remove as jest.Mock).toBeCalledTimes(3);
+    expect(storage.remove as jest.Mock).toHaveBeenCalledTimes(3);
     expect(fakeStore).toMatchInlineSnapshot(`{}`);
   });
   it('should generate and store a ECDSAKey if no key is stored', async () => {
@@ -753,7 +753,7 @@ describe('Migration from Ed25519Key', () => {
       ]
     `);
   });
-  it('should generate and store a ECDSAKey if no key is stored and keyType is set to Ed25519', async () => {
+  it("should generate and store a Ed25519 if no key is stored and keyType is set to Ed25519, and load the same key from storage if it's found in storage", async () => {
     const fakeStore: Record<any, any> = {};
     const storage = {
       remove: jest.fn(),
@@ -763,26 +763,26 @@ describe('Migration from Ed25519Key', () => {
       }),
     };
 
-    // mock ED25519 generate method
+    // Mock the ED25519 generate method, only for the first auth client
     const generate = jest.spyOn(Ed25519KeyIdentity, 'generate');
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    generate.mockImplementationOnce(async (): Promise<Ed25519KeyIdentity> => {
-      const key = await Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
+    generate.mockImplementationOnce((): Ed25519KeyIdentity => {
+      const key = Ed25519KeyIdentity.fromJSON(JSON.stringify(testSecrets));
       return key;
     });
 
     const client1 = await AuthClient.create({ storage, keyType: 'Ed25519' });
+    const identity1 = client1.getIdentity();
 
-    const identity1 = await client1.getIdentity();
-
+    // This auth client should find the Ed25519 key in the storage,
+    // and not generate a new one
     const client2 = await AuthClient.create({ storage, keyType: 'Ed25519' });
+    const identity2 = client2.getIdentity();
 
-    const identity2 = await client2.getIdentity();
-
+    expect(generate).toHaveBeenCalledTimes(1);
     // It should have stored a cryptoKey
     expect(fakeStore[KEY_STORAGE_KEY]).toMatchSnapshot();
+    // The first identity, created from testSecrets, should be the same as the second identity,
+    // loaded from the storage
     expect(identity1.getPrincipal().toString()).toEqual(identity2.getPrincipal().toString());
   });
 });

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -266,7 +266,7 @@ export class AuthClient {
         try {
           if (typeof maybeIdentityStorage === 'object') {
             if (keyType === ED25519_KEY_LABEL && typeof maybeIdentityStorage === 'string') {
-              key = await Ed25519KeyIdentity.fromJSON(maybeIdentityStorage);
+              key = Ed25519KeyIdentity.fromJSON(maybeIdentityStorage);
             } else {
               key = await ECDSAKeyIdentity.fromKeyPair(maybeIdentityStorage);
             }
@@ -330,7 +330,7 @@ export class AuthClient {
     if (!key) {
       // Create a new key (whether or not one was in storage).
       if (keyType === ED25519_KEY_LABEL) {
-        key = await Ed25519KeyIdentity.generate();
+        key = Ed25519KeyIdentity.generate();
         await storage.set(KEY_STORAGE_KEY, JSON.stringify((key as Ed25519KeyIdentity).toJSON()));
       } else {
         if (options.storage && keyType === ECDSA_KEY_LABEL) {

--- a/packages/auth-client/tsconfig.test.json
+++ b/packages/auth-client/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.test.json",
   "compilerOptions": {
-    "types": ["jest", "jsdom"]
+    "types": ["jest", "jest-environment-jsdom"]
   },
   "include": ["src/**/*.ts", "types/*", "FixJSDOMEnvironment.ts", "test-setup.ts"],
   "exclude": ["node_modules", "dist", "lib", "**/*.snap"]

--- a/packages/use-auth-client/test/use-auth-client.test.tsx
+++ b/packages/use-auth-client/test/use-auth-client.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
 import { useAuthClient } from '../src/use-auth-client';
-import { describe, it, jest, afterEach, expect } from '@jest/globals';
 import { IDL } from '@dfinity/candid';
 
 interface GenericComponentProps {

--- a/packages/use-auth-client/tsconfig.test.json
+++ b/packages/use-auth-client/tsconfig.test.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": ["ESNext", "dom"],
     "jsx": "react-jsx",
-    "types": ["jest", "jsdom"]
+    "types": ["jest", "jest-environment-jsdom"]
   },
   "include": [
     "src/**/*.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
         specifier: ^7.0.2
         version: 7.1.1
     devDependencies:
+      '@dfinity/candid':
+        specifier: workspace:*
+        version: link:../candid
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "moduleResolution": "node10",
     "target": "ES2022"
   },
-  "exclude": ["bin", "node_modules", "e2e", "**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["bin", "node_modules", "e2e", "**/*.{test,spec}.tsx?"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "moduleResolution": "node10",
     "target": "ES2022"
   },
-  "exclude": ["bin", "node_modules", "e2e"]
+  "exclude": ["bin", "node_modules", "e2e", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "moduleResolution": "node10",
     "target": "ES2022"
   },
-  "exclude": ["bin", "node_modules", "e2e", "**/*.{test,spec}.tsx?"]
+  "exclude": ["bin", "node_modules", "e2e", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
# Description

Updates TS config for `auth-client` and `use-auth-client` to make the IDE load the proper configuration.

Updates the `auth-client` index (and the related test file) to remove unnecessary `await`s.
Updates the `auth-client` index test file to remove deprecated Jest function calls.

Updates the `use-auth-client` test to remove unnecessary `@jest/globals` import.

# How Has This Been Tested?

Updated unit tests should pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
