### PR TITLE
fix: export ESM modules

### DIFF
--- a/packages/agent/.gitignore
+++ b/packages/agent/.gitignore
@@ -2,5 +2,8 @@ node_modules/
 dist/
 lib/
 
+# ESM module declaration
+!lib/esm/package.json
+
 # generated docs
 /docs/reference

--- a/packages/agent/lib/esm/package.json
+++ b/packages/agent/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/agent/lib/esm/package.json
+++ b/packages/agent/lib/esm/package.json
@@ -1,3 +1,4 @@
 {
-  "type": "module"
+  "type": "module",
+  "sideEffects": false
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -38,9 +38,9 @@
   "types": "./lib/esm/index.d.ts",
   "exports": {
     "types": "./lib/esm/index.d.ts",
+    "import": "./lib/esm/index.js",
     "node": "./lib/cjs/index.js",
     "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js",
     "default": "./lib/esm/index.js"
   },
   "scripts": {

--- a/packages/agent/src/actor.test.ts
+++ b/packages/agent/src/actor.test.ts
@@ -337,6 +337,7 @@ describe('makeActor', () => {
     `);
     expect(replyUpdateWithHttpDetails.result).toEqual(canisterDecodedReturnValue);
 
+    // `requestDetails` is not inside the type. TODO: fix this
     replyUpdateWithHttpDetails.httpDetails['requestDetails']['nonce'] = new Uint8Array() as Nonce;
 
     expect(replyUpdateWithHttpDetails.httpDetails).toMatchSnapshot();

--- a/packages/agent/src/actor.test.ts
+++ b/packages/agent/src/actor.test.ts
@@ -337,7 +337,6 @@ describe('makeActor', () => {
     `);
     expect(replyUpdateWithHttpDetails.result).toEqual(canisterDecodedReturnValue);
 
-    // @ts-expect-error - `requestDetails` is not inside the type. TODO: fix this
     replyUpdateWithHttpDetails.httpDetails['requestDetails']['nonce'] = new Uint8Array() as Nonce;
 
     expect(replyUpdateWithHttpDetails.httpDetails).toMatchSnapshot();

--- a/packages/assets/.gitignore
+++ b/packages/assets/.gitignore
@@ -2,5 +2,8 @@ node_modules/
 dist/
 lib/
 
+# ESM module declaration
+!lib/esm/package.json
+
 # generated docs
 /docs/reference

--- a/packages/assets/lib/esm/package.json
+++ b/packages/assets/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/assets/lib/esm/package.json
+++ b/packages/assets/lib/esm/package.json
@@ -1,3 +1,4 @@
 {
-  "type": "module"
+  "type": "module",
+  "sideEffects": false
 }

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -45,9 +45,9 @@
   "types": "./lib/esm/index.d.ts",
   "exports": {
     "types": "./lib/esm/index.d.ts",
+    "import": "./lib/esm/index.js",
     "node": "./lib/cjs/index.js",
     "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js",
     "default": "./lib/esm/index.js"
   },
   "scripts": {

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -33,14 +33,12 @@
     "api"
   ],
   "type": "module",
-  "browser": "./lib/cjs/index.js",
+  "browser": "./lib/esm/index.js",
   "module": "./lib/esm/index.js",
   "default": "./lib/esm/index.js",
   "types": "./lib/esm/index.d.ts",
   "exports": {
     "types": "./lib/esm/index.d.ts",
-    "node": "./lib/cjs/index.js",
-    "require": "./lib/cjs/index.js",
     "import": "./lib/esm/index.js",
     "default": "./lib/esm/index.js"
   },

--- a/packages/candid/.gitignore
+++ b/packages/candid/.gitignore
@@ -2,5 +2,8 @@ node_modules/
 dist/
 lib/
 
+# ESM module declaration
+!lib/esm/package.json
+
 # generated docs
 /docs/reference

--- a/packages/candid/lib/esm/package.json
+++ b/packages/candid/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/candid/lib/esm/package.json
+++ b/packages/candid/lib/esm/package.json
@@ -1,3 +1,4 @@
 {
-  "type": "module"
+  "type": "module",
+  "sideEffects": false
 }

--- a/packages/candid/package.json
+++ b/packages/candid/package.json
@@ -37,9 +37,9 @@
   "types": "./lib/esm/index.d.ts",
   "exports": {
     "types": "./lib/esm/index.d.ts",
+    "import": "./lib/esm/index.js",
     "node": "./lib/cjs/index.js",
     "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js",
     "default": "./lib/esm/index.js"
   },
   "scripts": {

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -2,5 +2,8 @@ node_modules/
 dist/
 lib/
 
+# ESM module declaration
+!lib/esm/package.json
+
 # generated docs
 /docs/reference

--- a/packages/core/lib/esm/package.json
+++ b/packages/core/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/core/lib/esm/package.json
+++ b/packages/core/lib/esm/package.json
@@ -1,3 +1,4 @@
 {
-  "type": "module"
+  "type": "module",
+  "sideEffects": false
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,51 +50,51 @@
   "exports": {
     ".": {
       "types": "./lib/esm/index.d.ts",
+      "import": "./lib/esm/index.js",
       "node": "./lib/cjs/index.js",
       "require": "./lib/cjs/index.js",
-      "import": "./lib/esm/index.js",
       "default": "./lib/esm/index.js"
     },
     "./agent": {
       "types": "./lib/esm/agent/index.d.ts",
+      "import": "./lib/esm/agent/index.js",
       "node": "./lib/cjs/agent/index.js",
       "require": "./lib/cjs/agent/index.js",
-      "import": "./lib/esm/agent/index.js",
       "default": "./lib/esm/agent/index.js"
     },
     "./auth-client": {
       "types": "./lib/esm/auth-client/index.d.ts",
+      "import": "./lib/esm/auth-client/index.js",
       "node": "./lib/cjs/auth-client/index.js",
       "require": "./lib/cjs/auth-client/index.js",
-      "import": "./lib/esm/auth-client/index.js",
       "default": "./lib/esm/auth-client/index.js"
     },
     "./candid": {
       "types": "./lib/esm/candid/index.d.ts",
+      "import": "./lib/esm/candid/index.js",
       "node": "./lib/cjs/candid/index.js",
       "require": "./lib/cjs/candid/index.js",
-      "import": "./lib/esm/candid/index.js",
       "default": "./lib/esm/candid/index.js"
     },
     "./identity": {
       "types": "./lib/esm/identity/index.d.ts",
+      "import": "./lib/esm/identity/index.js",
       "node": "./lib/cjs/identity/index.js",
       "require": "./lib/cjs/identity/index.js",
-      "import": "./lib/esm/identity/index.js",
       "default": "./lib/esm/identity/index.js"
     },
     "./identity-secp256k1": {
       "types": "./lib/esm/identity-secp256k1/index.d.ts",
+      "import": "./lib/esm/identity-secp256k1/index.js",
       "node": "./lib/cjs/identity-secp256k1/index.js",
       "require": "./lib/cjs/identity-secp256k1/index.js",
-      "import": "./lib/esm/identity-secp256k1/index.js",
       "default": "./lib/esm/identity-secp256k1/index.js"
     },
     "./principal": {
       "types": "./lib/esm/principal/index.d.ts",
+      "import": "./lib/esm/principal/index.js",
       "node": "./lib/cjs/principal/index.js",
       "require": "./lib/cjs/principal/index.js",
-      "import": "./lib/esm/principal/index.js",
       "default": "./lib/esm/principal/index.js"
     }
   }

--- a/packages/identity-secp256k1/.gitignore
+++ b/packages/identity-secp256k1/.gitignore
@@ -2,5 +2,8 @@ node_modules/
 dist/
 lib/
 
+# ESM module declaration
+!lib/esm/package.json
+
 # generated docs
 /docs/reference

--- a/packages/identity-secp256k1/lib/esm/package.json
+++ b/packages/identity-secp256k1/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/identity-secp256k1/lib/esm/package.json
+++ b/packages/identity-secp256k1/lib/esm/package.json
@@ -1,3 +1,4 @@
 {
-  "type": "module"
+  "type": "module",
+  "sideEffects": false
 }

--- a/packages/identity-secp256k1/package.json
+++ b/packages/identity-secp256k1/package.json
@@ -10,9 +10,9 @@
   "types": "./lib/esm/index.d.ts",
   "exports": {
     "types": "./lib/esm/index.d.ts",
+    "import": "./lib/esm/index.js",
     "node": "./lib/cjs/index.js",
     "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js",
     "default": "./lib/esm/index.js"
   },
   "scripts": {

--- a/packages/identity/.gitignore
+++ b/packages/identity/.gitignore
@@ -2,5 +2,8 @@ node_modules/
 dist/
 lib/
 
+# ESM module declaration
+!lib/esm/package.json
+
 # generated docs
 /docs/reference

--- a/packages/identity/lib/esm/package.json
+++ b/packages/identity/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/identity/lib/esm/package.json
+++ b/packages/identity/lib/esm/package.json
@@ -1,3 +1,4 @@
 {
-  "type": "module"
+  "type": "module",
+  "sideEffects": false
 }

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -37,9 +37,9 @@
   "types": "./lib/esm/index.d.ts",
   "exports": {
     "types": "./lib/esm/index.d.ts",
+    "import": "./lib/esm/index.js",
     "node": "./lib/cjs/index.js",
     "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js",
     "default": "./lib/esm/index.js"
   },
   "scripts": {

--- a/packages/principal/.gitignore
+++ b/packages/principal/.gitignore
@@ -2,5 +2,8 @@ node_modules/
 dist/
 lib/
 
+# ESM module declaration
+!lib/esm/package.json
+
 # generated docs
 /docs/reference

--- a/packages/principal/lib/esm/package.json
+++ b/packages/principal/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/principal/lib/esm/package.json
+++ b/packages/principal/lib/esm/package.json
@@ -1,3 +1,4 @@
 {
-  "type": "module"
+  "type": "module",
+  "sideEffects": false
 }

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -37,9 +37,9 @@
   "types": "./lib/esm/index.d.ts",
   "exports": {
     "types": "./lib/esm/index.d.ts",
+    "import": "./lib/esm/index.js",
     "node": "./lib/cjs/index.js",
     "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js",
     "default": "./lib/esm/index.js"
   },
   "scripts": {

--- a/packages/use-auth-client/package.json
+++ b/packages/use-auth-client/package.json
@@ -3,14 +3,12 @@
   "version": "3.0.0-beta.1",
   "description": "React hooks for using the auth client",
   "type": "module",
-  "browser": "./lib/cjs/index.js",
+  "browser": "./lib/esm/index.js",
   "module": "./lib/esm/index.js",
   "default": "./lib/esm/index.js",
   "types": "./lib/esm/index.d.ts",
   "exports": {
     "types": "./lib/esm/index.d.ts",
-    "node": "./lib/cjs/index.js",
-    "require": "./lib/cjs/index.js",
     "import": "./lib/esm/index.js",
     "default": "./lib/esm/index.js"
   },


### PR DESCRIPTION
# Description

Changes the order in the `"exports"` fields in the packages' `package.json` file to prioritize ESM modules.
Adds a `package.json` inside each package's `lib/esm` output folder to tell any Node.js app that it's a module. 

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
