### PR TITLE
docs: preserve entities names casing

### DIFF
--- a/docs/src/libs-plugin.ts
+++ b/docs/src/libs-plugin.ts
@@ -174,7 +174,7 @@ export function libsPlugin(opts: LibsLoaderOptions): StarlightPlugin {
           const id = name.startsWith('@') ? name.split('/')[1] : name;
           const outputRootDir = path.resolve(outDir, id);
           const outputApiDir = path.resolve(outputRootDir, 'api');
-          const title = titleFromId(id);
+          const title = titleFromIdCapitalized(id);
 
           await processMarkdown({
             inputPath: path.resolve(baseDir, id, 'README.md'),
@@ -233,7 +233,7 @@ export function libsPlugin(opts: LibsLoaderOptions): StarlightPlugin {
         for (const file of opts.additionalFiles || []) {
           const fileName = path.basename(file.path).toLowerCase();
           const id = idFromFilename(fileName);
-          const title = titleFromId(id);
+          const title = titleFromIdCapitalized(id);
 
           await processMarkdown({
             inputPath: path.resolve(file.path),
@@ -276,7 +276,11 @@ function titleFromFilename(fileName: string): string {
 }
 
 function titleFromId(id: string): string {
-  return id.replace(/-/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
+  return id.replace(/-/g, ' ');
+}
+
+function titleFromIdCapitalized(id: string): string {
+  return titleFromId(id).replace(/\b\w/g, char => char.toUpperCase());
 }
 
 interface ProcessMarkdownOpts {


### PR DESCRIPTION
# Description

Preserve the entities (functions, variables, etc.) names casing in the pages and sidebar titles.

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
