### PR TITLE
docs: copy 404.html to the root to make 404 work

### DIFF
--- a/docs/scripts/predeploy.sh
+++ b/docs/scripts/predeploy.sh
@@ -7,3 +7,6 @@ pnpm run build
 # move all content to /core directory
 mkdir -p dist/core
 mv dist/* dist/core/ 2>/dev/null || true
+
+# copy the 404 file to the root
+cp dist/core/404.html dist/404.html


### PR DESCRIPTION
# Description

Copy `dist/core/404.html` to `dist/404.html` to make Juno's 404 fallback work.

This will be unnecessary once we have a landing page for the root path.

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
