### PR TITLE
feat: enable type safety for Func and Service IDL types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - fix: do not subtract the replica permitted clock drift when calculating the ingress expiry.
 - fix: pick the expiry rounding strategy based on the delta, without adding the clock drift to the delta.
 - feat: adds a `clockDriftMs` optional parameter to `Expiry.fromDeltaInMilliseconds` to add to the current time, typically used to specify the clock drift between the client's clock and the IC network clock.
+- feat: enables type inference for the arguments and return types of `FuncClass`.
+- feat: enables type inference for the fields of `ServiceClass`.
 
 ## [3.1.0] - 2025-07-24
 


### PR DESCRIPTION
# Description

Adds generic type arguments to Func and Service IDL types. This should be backwards compatible.

# How Has This Been Tested?

Same tests should still pass. TypeScript should still build.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
