### PR TITLE
fix: use effective canister id to delete the node keys from the local map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - feat: enables type inference for the arguments and return types of `FuncClass`.
 - feat: enables type inference for the fields of `ServiceClass`.
 - fix: perform the canister range checks unconditionally for delegations when constructing a `Certificate` instance.
+- fix: use the effective canister id to delete the node keys from the local cache.
 
 ## [3.1.0] - 2025-07-24
 

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -963,13 +963,13 @@ export class HttpAgent implements Agent {
       const [queryWithDetails, subnetStatus] = await Promise.all([makeQuery(), getSubnetStatus()]);
 
       try {
-        return this.#verifyQueryResponse(queryWithDetails, subnetStatus!);
+        return this.#verifyQueryResponse(queryWithDetails, subnetStatus);
       } catch {
         // In case the node signatures have changed, refresh the subnet keys and try again
         this.log.warn('Query response verification failed. Retrying with fresh subnet keys.');
         this.#subnetKeys.delete(ecid.toString());
         const updatedSubnetStatus = await getSubnetStatus();
-        return this.#verifyQueryResponse(queryWithDetails, updatedSubnetStatus!);
+        return this.#verifyQueryResponse(queryWithDetails, updatedSubnetStatus);
       }
     } catch (error) {
       let queryError: AgentError;


### PR DESCRIPTION
# Description

Use the effective canister id to delete the node keys from the local cache. The fix was already applied in https://github.com/dfinity/agent-js/pull/1081/files#diff-1deee5c6f68eb82e2be634c32d050e818f857292ed0fa9c9e19026e2ef60869cR980-R981, but here we clean the code a bit more and update the changelog.

Additionally, avoids throwing an error in `Promise.all`.

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
