### PR TITLE
fix: error handling of call responses

### DIFF
--- a/packages/agent/src/actor.ts
+++ b/packages/agent/src/actor.ts
@@ -469,20 +469,20 @@ function _createActorMethod(
           }
         }
       } else if (isV2ResponseBody(response.body)) {
-        // handle v2 response errors by throwing an UpdateCallRejectedError object
         const { reject_code, reject_message, error_code } = response.body;
-        const certifiedRejectErrorCode = new CertifiedRejectErrorCode(
+        const errorCode = new UncertifiedRejectErrorCode(
           requestId,
           reject_code,
           reject_message,
           error_code,
+          undefined,
         );
-        certifiedRejectErrorCode.callContext = {
+        errorCode.callContext = {
           canisterId: cid,
           methodName,
           httpDetails: response,
         };
-        throw RejectError.fromCode(certifiedRejectErrorCode);
+        throw RejectError.fromCode(errorCode);
       }
 
       // Fall back to polling if we receive an Accepted response code

--- a/packages/agent/src/agent/http/index.ts
+++ b/packages/agent/src/agent/http/index.ts
@@ -481,6 +481,7 @@ export class HttpAgent implements Agent {
    * @param options.effectiveCanisterId - (Optional) The effective canister ID, if different from the target canister ID.
    * @param options.callSync - (Optional) Whether to use synchronous call mode. Defaults to true.
    * @param options.nonce - (Optional) A unique nonce for the request. If provided, it will override any nonce set by transforms.
+   * @param options.throwOnIngressExpiryError - (Optional) Whether to throw an error if the ingress expiry is invalid. If `false`, retries the request after syncing time with the IC network. Default `false`.
    * @param identity - (Optional) The identity to use for the call. If not provided, the agent's current identity will be used.
    * @returns A promise that resolves to the response of the call, including the request ID and response details.
    */
@@ -492,11 +493,12 @@ export class HttpAgent implements Agent {
       effectiveCanisterId?: Principal | string;
       callSync?: boolean;
       nonce?: Uint8Array | Nonce;
+      throwOnIngressExpiryError?: boolean;
     },
     identity?: Identity | Promise<Identity>,
   ): Promise<SubmitResponse> {
-    // TODO - restore this value
     const callSync = options.callSync ?? true;
+    const throwOnIngressExpiryError = options.throwOnIngressExpiryError ?? false;
     const id = await (identity ?? this.#identity);
     if (!id) {
       throw ExternalError.fromCode(new IdentityInvalidErrorCode());
@@ -630,10 +632,17 @@ export class HttpAgent implements Agent {
             },
             identity,
           );
-        } else if (error.hasCode(IngressExpiryInvalidErrorCode)) {
+        } else if (error.hasCode(IngressExpiryInvalidErrorCode) && !throwOnIngressExpiryError) {
           // if there is an ingress expiry error, sync time with the network and try again
           await this.syncTime(canister);
-          return this.call(canister, options, identity);
+          return this.call(
+            canister,
+            {
+              ...options,
+              throwOnIngressExpiryError: true,
+            },
+            identity,
+          );
         } else {
           // override the error code to include the request details
           error.code.requestContext = {


### PR DESCRIPTION
# Description

- change error code to `UncertifiedRejectErrorCode` when throwing an error in v2 responses
- fixes retry logic to avoid syncing time indefinitely in case of an ingress expiry error

# How Has This Been Tested?

Added e2e test for ingress expiry fix.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
