### PR TITLE
refactor: remove `@dfnity/auth-client` from core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,12 +39,11 @@
     "attw": "attw --pack . --profile node16"
   },
   "peerDependencies": {
-    "@dfinity/agent": "workspace:*",
-    "@dfinity/auth-client": "workspace:*",
-    "@dfinity/candid": "workspace:*",
-    "@dfinity/identity": "workspace:*",
-    "@dfinity/identity-secp256k1": "workspace:*",
-    "@dfinity/principal": "workspace:*"
+    "@dfinity/agent": "workspace:^",
+    "@dfinity/candid": "workspace:^",
+    "@dfinity/identity": "workspace:^",
+    "@dfinity/identity-secp256k1": "workspace:^",
+    "@dfinity/principal": "workspace:^"
   },
   "exports": {
     ".": {
@@ -60,13 +59,6 @@
       "node": "./lib/cjs/agent/index.js",
       "require": "./lib/cjs/agent/index.js",
       "default": "./lib/esm/agent/index.js"
-    },
-    "./auth-client": {
-      "types": "./lib/esm/auth-client/index.d.ts",
-      "import": "./lib/esm/auth-client/index.js",
-      "node": "./lib/cjs/auth-client/index.js",
-      "require": "./lib/cjs/auth-client/index.js",
-      "default": "./lib/esm/auth-client/index.js"
     },
     "./candid": {
       "types": "./lib/esm/candid/index.d.ts",

--- a/packages/core/src/auth-client/index.ts
+++ b/packages/core/src/auth-client/index.ts
@@ -1,1 +1,0 @@
-export * from '@dfinity/auth-client';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,22 +261,19 @@ importers:
   packages/core:
     dependencies:
       '@dfinity/agent':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../agent
-      '@dfinity/auth-client':
-        specifier: workspace:*
-        version: link:../auth-client
       '@dfinity/candid':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../candid
       '@dfinity/identity':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../identity
       '@dfinity/identity-secp256k1':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../identity-secp256k1
       '@dfinity/principal':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../principal
 
   packages/identity:


### PR DESCRIPTION
# Description

The `@dfinity/auth-client` package should be moved to a (name yet to be decided) `@icp-sdk/auth` package.

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
