### PR TITLE
refactor: move secp256k1 submodule to identity submodule

### DIFF
--- a/e2e/node/basic/identity.test.ts
+++ b/e2e/node/basic/identity.test.ts
@@ -7,7 +7,7 @@ import {
   Ed25519KeyIdentity,
   ECDSAKeyIdentity,
 } from '@icp-sdk/core/identity';
-import { Secp256k1KeyIdentity } from '@icp-sdk/core/identity-secp256k1';
+import { Secp256k1KeyIdentity } from '@icp-sdk/core/identity/secp256k1';
 import agent, { makeAgent } from '../utils/agent.ts';
 import whoamiCanister from '../canisters/whoami.ts';
 import { test, expect } from 'vitest';

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -49,7 +49,7 @@ The package provides the following import paths for accessing the re-exported mo
 - `@icp-sdk/core/agent`
 - `@icp-sdk/core/candid`
 - `@icp-sdk/core/identity`
-- `@icp-sdk/core/identity-secp256k1`
+  - `@icp-sdk/core/identity/secp256k1`
 - `@icp-sdk/core/principal`
 
 ## Usage Example

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,12 +74,12 @@
       "require": "./lib/cjs/identity/index.js",
       "default": "./lib/esm/identity/index.js"
     },
-    "./identity-secp256k1": {
-      "types": "./lib/esm/identity-secp256k1/index.d.ts",
-      "import": "./lib/esm/identity-secp256k1/index.js",
-      "node": "./lib/cjs/identity-secp256k1/index.js",
-      "require": "./lib/cjs/identity-secp256k1/index.js",
-      "default": "./lib/esm/identity-secp256k1/index.js"
+    "./identity/secp256k1": {
+      "types": "./lib/esm/identity/secp256k1/index.d.ts",
+      "import": "./lib/esm/identity/secp256k1/index.js",
+      "node": "./lib/cjs/identity/secp256k1/index.js",
+      "require": "./lib/cjs/identity/secp256k1/index.js",
+      "default": "./lib/esm/identity/secp256k1/index.js"
     },
     "./principal": {
       "types": "./lib/esm/principal/index.d.ts",

--- a/packages/core/src/identity-secp256k1/index.ts
+++ b/packages/core/src/identity-secp256k1/index.ts
@@ -1,1 +1,3 @@
-export * from '@dfinity/identity-secp256k1';
+throw new Error(
+  'There are no exports in this submodule. Import from @icp-sdk/core/identity/secp256k1 instead.',
+);

--- a/packages/core/src/identity-secp256k1/index.ts
+++ b/packages/core/src/identity-secp256k1/index.ts
@@ -1,3 +1,0 @@
-throw new Error(
-  'There are no exports in this submodule. Import from @icp-sdk/core/identity/secp256k1 instead.',
-);

--- a/packages/core/src/identity/secp256k1/index.ts
+++ b/packages/core/src/identity/secp256k1/index.ts
@@ -1,0 +1,1 @@
+export * from '@dfinity/identity-secp256k1';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,3 @@
-throw new Error('There are no exports in the root module of this package. Import from submodules instead. Use intellisense or the docs to find the available submodules.');
+throw new Error(
+  'There are no exports in the root module of this package. Import from submodules instead. Use intellisense or the docs to find the available submodules.',
+);


### PR DESCRIPTION
# Description

Now that we have submodules and tree-shaking, it doesn't make sense to move the secp256k1 package to its own submodule.

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
