### PR TITLE
fix: add `bigint` to the `JsonValue` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- fix: add `bigint` to the `JsonValue` types in `@dfinity/candid`.
+
 ## [3.2.1] - 2025-08-12
 
 - fix: export the `GenericIdlFuncArgs`, `GenericIdlFuncRets`, and `GenericIdlServiceFields` types from `@dfinity/candid`.

--- a/packages/candid/src/types.ts
+++ b/packages/candid/src/types.ts
@@ -4,4 +4,4 @@ export interface JsonArray extends Array<JsonValue> {}
 
 export interface JsonObject extends Record<string, JsonValue> {}
 
-export type JsonValue = boolean | string | number | JsonArray | JsonObject;
+export type JsonValue = boolean | string | number | bigint | JsonArray | JsonObject;


### PR DESCRIPTION
# Description

Candid and cbor decoding can return bigints, so we must add that type to the return type.

Fixes https://github.com/demergent-labs/azle/issues/2639.

# How Has This Been Tested?

Same tests should pass.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
