### PR TITLE
chore: rename `agent-js` to `icp-js-core`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Directions to set up your project are available in the [README](../README.md).
 
-Before you make your changes, check to see if an [issue exists](https://github.com/dfinity/agent-js/issues). If there isn't one, you can [create one](https://github.com/dfinity/agent-js/issues/new/choose) to discuss your proposed changes.
+Before you make your changes, check to see if an [issue exists](https://github.com/dfinity/icp-sdk-js-core/issues). If there isn't one, you can [create one](https://github.com/dfinity/icp-sdk-js-core/issues/new/choose) to discuss your proposed changes.
 
 ## Forking the repository
 
@@ -98,7 +98,7 @@ We utilize the [release-it](https://github.com/release-it/release-it) package to
 
 Start the process by initiating the GitHub Action Workflow `prepare-release.yml`. This can be done by:
 
-- Navigating to the GitHub web UI and clicking "Run workflow" at https://github.com/smallstepman/agent-js/actions/workflows/prepare-release.yml, or
+- Navigating to the GitHub web UI and clicking "Run workflow" at https://github.com/dfinity/icp-sdk-js-core/actions/workflows/prepare-release.yml, or
 - Running this command from your console:
   ```shell
   gh workflow run "prepare-release.yml" -f "semverBump=major"
@@ -249,7 +249,7 @@ Once the changes are merged, you can publish to NPM by running:
   - To do this, you will need publishing authorization under our NPM organization. Contact IT if you require access.
   - You can include the `--dry-run` flag to verify the version before actual publishing.
 
-After publishing to NPM, go to https://github.com/dfinity/agent-js/releases/new, select "Draft a new release", enter the new tag version (in `v#.#.#` format), and click "Publish release".
+After publishing to NPM, go to https://github.com/dfinity/icp-sdk-js-core/releases/new, select "Draft a new release", enter the new tag version (in `v#.#.#` format), and click "Publish release".
 
 </details>
 
@@ -283,14 +283,9 @@ Docs are built and published in the `publish-docs` step of the [`publish.yml`](.
 
 To deprecate a package, follow these steps
 
-- Remove all contents except the package.json, license, and readme
 - Add a note to the README saying `**Warning** this package is deprecated`
-- Remove unnecessary content, dependencies, and metadata from the package.json
-- add a `"deprecation"` tag to the package.json with instructions you want users to follow in migrating
-- remove the package as a workspace from the root `package.json`
-- the next time that agent-js releases, manually publish a new version of newly deprecated packages by incrementing the patch version and running `pnpm publish:packages`
-
-So far, the following packages were deprecated:
-
-- @dfinity/ledger-identityhq (#665)
-- @dfinity/authentication (#665 & #661)
+- Increment the patch version of the package in its `package.json` file
+- Release the patched version of the package to NPM
+- Deprecate the package in NPM with `npm deprecate ...`
+- Remove the package from the root [`pnpm-workspace.yaml`](../pnpm-workspace.yaml) file
+- Optionally, remove all contents except the package.json, license, and readme. This can be done later, so that the source code stays available for reference for a while.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Directions to set up your project are available in the [README](../README.md).
 
-Before you make your changes, check to see if an [issue exists](https://github.com/dfinity/icp-sdk-js-core/issues). If there isn't one, you can [create one](https://github.com/dfinity/icp-sdk-js-core/issues/new/choose) to discuss your proposed changes.
+Before you make your changes, check to see if an [issue exists](https://github.com/dfinity/icp-js-core/issues). If there isn't one, you can [create one](https://github.com/dfinity/icp-js-core/issues/new/choose) to discuss your proposed changes.
 
 ## Forking the repository
 
@@ -98,7 +98,7 @@ We utilize the [release-it](https://github.com/release-it/release-it) package to
 
 Start the process by initiating the GitHub Action Workflow `prepare-release.yml`. This can be done by:
 
-- Navigating to the GitHub web UI and clicking "Run workflow" at https://github.com/dfinity/icp-sdk-js-core/actions/workflows/prepare-release.yml, or
+- Navigating to the GitHub web UI and clicking "Run workflow" at https://github.com/dfinity/icp-js-core/actions/workflows/prepare-release.yml, or
 - Running this command from your console:
   ```shell
   gh workflow run "prepare-release.yml" -f "semverBump=major"
@@ -249,7 +249,7 @@ Once the changes are merged, you can publish to NPM by running:
   - To do this, you will need publishing authorization under our NPM organization. Contact IT if you require access.
   - You can include the `--dry-run` flag to verify the version before actual publishing.
 
-After publishing to NPM, go to https://github.com/dfinity/icp-sdk-js-core/releases/new, select "Draft a new release", enter the new tag version (in `v#.#.#` format), and click "Publish release".
+After publishing to NPM, go to https://github.com/dfinity/icp-js-core/releases/new, select "Draft a new release", enter the new tag version (in `v#.#.#` format), and click "Publish release".
 
 </details>
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 
 # Checklist:
 
-- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
+- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/icp-sdk-js-core/blob/main/.github/CONTRIBUTING.md).
 - [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 - [ ] I have edited the CHANGELOG accordingly.
 - [ ] I have made corresponding changes to the documentation.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 
 # Checklist:
 
-- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/icp-sdk-js-core/blob/main/.github/CONTRIBUTING.md).
+- [ ] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/icp-js-core/blob/main/.github/CONTRIBUTING.md).
 - [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 - [ ] I have edited the CHANGELOG accordingly.
 - [ ] I have made corresponding changes to the documentation.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# icp-sdk-js-core
+# icp-js-core
 
 Use an Agent to interact with the Internet Computer from your JavaScript program.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# agent-js
+# icp-sdk-js-core
 
 Use an Agent to interact with the Internet Computer from your JavaScript program.
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -21,7 +21,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'ICP JS SDK Core',
-      social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/dfinity/icp-sdk-js-core' }],
+      social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/dfinity/icp-js-core' }],
       plugins: [
         dfinityStarlightTheme(),
         markdownUrlsPlugin({

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -21,7 +21,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'ICP JS SDK Core',
-      social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/dfinity/agent-js' }],
+      social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/dfinity/icp-sdk-js-core' }],
       plugins: [
         dfinityStarlightTheme(),
         markdownUrlsPlugin({

--- a/docs/src/content/docs/upgrading/v3.md
+++ b/docs/src/content/docs/upgrading/v3.md
@@ -135,8 +135,8 @@ const combined = concatBytes(buffer1, buffer2);
 
 Several specific error classes have been removed in favor of a new, more generic `AgentError`. This new error class has the following properties:
 
-- `code`: an `ErrorCode` class value, e.g. `CertifiedRejectErrorCode`. See [`errors.ts`](https://github.com/dfinity/agent-js/blob/e7e371b5399d44ea387f21cdcb0e195af4bef2b9/packages/agent/src/errors.ts) for all error codes.
-- `kind`: an `ErrorKindEnum` enum value, e.g. `ErrorKindEnum.Trust`. See [`ErrorKindEnum`](https://github.com/dfinity/agent-js/blob/e7e371b5399d44ea387f21cdcb0e195af4bef2b9/packages/agent/src/errors.ts#L9-L18) for all error kinds.
+- `code`: an `ErrorCode` class value, e.g. `CertifiedRejectErrorCode`. See [`errors.ts`](https://github.com/dfinity/icp-sdk-js-core/blob/e7e371b5399d44ea387f21cdcb0e195af4bef2b9/packages/agent/src/errors.ts) for all error codes.
+- `kind`: an `ErrorKindEnum` enum value, e.g. `ErrorKindEnum.Trust`. See [`ErrorKindEnum`](https://github.com/dfinity/icp-sdk-js-core/blob/e7e371b5399d44ea387f21cdcb0e195af4bef2b9/packages/agent/src/errors.ts#L9-L18) for all error kinds.
 - [`message`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message): a human-readable error message
 - [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause): an object containing the `code` and `kind` properties
 
@@ -288,7 +288,7 @@ const hashed = sha256(myBuffer);
 
 ### Cbor package replacement in `@dfinity/agent`
 
-The `@dfinity/agent` package now uses [`@dfinity/cbor`](https://npmjs.com/package/@dfinity/cbor) instead of the `borc` and `simple-cbor` dependencies, reducing the bundle size of most packages [by at least 30% (gzipped) 🤯](https://github.com/dfinity/agent-js/pull/1015#issuecomment-2912381841).
+The `@dfinity/agent` package now uses [`@dfinity/cbor`](https://npmjs.com/package/@dfinity/cbor) instead of the `borc` and `simple-cbor` dependencies, reducing the bundle size of most packages [by at least 30% (gzipped) 🤯](https://github.com/dfinity/icp-sdk-js-core/pull/1015#issuecomment-2912381841).
 
 **Before:**
 

--- a/docs/src/content/docs/upgrading/v3.md
+++ b/docs/src/content/docs/upgrading/v3.md
@@ -135,8 +135,8 @@ const combined = concatBytes(buffer1, buffer2);
 
 Several specific error classes have been removed in favor of a new, more generic `AgentError`. This new error class has the following properties:
 
-- `code`: an `ErrorCode` class value, e.g. `CertifiedRejectErrorCode`. See [`errors.ts`](https://github.com/dfinity/icp-sdk-js-core/blob/e7e371b5399d44ea387f21cdcb0e195af4bef2b9/packages/agent/src/errors.ts) for all error codes.
-- `kind`: an `ErrorKindEnum` enum value, e.g. `ErrorKindEnum.Trust`. See [`ErrorKindEnum`](https://github.com/dfinity/icp-sdk-js-core/blob/e7e371b5399d44ea387f21cdcb0e195af4bef2b9/packages/agent/src/errors.ts#L9-L18) for all error kinds.
+- `code`: an `ErrorCode` class value, e.g. `CertifiedRejectErrorCode`. See [`errors.ts`](https://github.com/dfinity/icp-js-core/blob/e7e371b5399d44ea387f21cdcb0e195af4bef2b9/packages/agent/src/errors.ts) for all error codes.
+- `kind`: an `ErrorKindEnum` enum value, e.g. `ErrorKindEnum.Trust`. See [`ErrorKindEnum`](https://github.com/dfinity/icp-js-core/blob/e7e371b5399d44ea387f21cdcb0e195af4bef2b9/packages/agent/src/errors.ts#L9-L18) for all error kinds.
 - [`message`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message): a human-readable error message
 - [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause): an object containing the `code` and `kind` properties
 
@@ -288,7 +288,7 @@ const hashed = sha256(myBuffer);
 
 ### Cbor package replacement in `@dfinity/agent`
 
-The `@dfinity/agent` package now uses [`@dfinity/cbor`](https://npmjs.com/package/@dfinity/cbor) instead of the `borc` and `simple-cbor` dependencies, reducing the bundle size of most packages [by at least 30% (gzipped) 🤯](https://github.com/dfinity/icp-sdk-js-core/pull/1015#issuecomment-2912381841).
+The `@dfinity/agent` package now uses [`@dfinity/cbor`](https://npmjs.com/package/@dfinity/cbor) instead of the `borc` and `simple-cbor` dependencies, reducing the bundle size of most packages [by at least 30% (gzipped) 🤯](https://github.com/dfinity/icp-js-core/pull/1015#issuecomment-2912381841).
 
 **Before:**
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/icp-sdk-js-core"
+    "url": "https://github.com/dfinity/icp-js-core"
   },
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/agent-js"
+    "url": "https://github.com/dfinity/icp-sdk-js-core"
   },
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/agent",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
+    "url": "https://github.com/dfinity/icp-js-core.git",
     "directory": "packages/agent"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
+    "url": "https://github.com/dfinity/icp-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/agent",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/agent-js.git",
+    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
     "directory": "packages/agent"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/agent-js/issues"
+    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/assets",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/agent-js.git",
+    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
     "directory": "packages/assets"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/agent-js/issues"
+    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/assets",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
+    "url": "https://github.com/dfinity/icp-js-core.git",
     "directory": "packages/assets"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
+    "url": "https://github.com/dfinity/icp-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/auth-client",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
+    "url": "https://github.com/dfinity/icp-js-core.git",
     "directory": "packages/auth-client"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
+    "url": "https://github.com/dfinity/icp-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/auth-client",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/agent-js.git",
+    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
     "directory": "packages/auth-client"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/agent-js/issues"
+    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/candid/package.json
+++ b/packages/candid/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/candid",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/agent-js.git",
+    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
     "directory": "packages/candid"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/agent-js/issues"
+    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/candid/package.json
+++ b/packages/candid/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/candid",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
+    "url": "https://github.com/dfinity/icp-js-core.git",
     "directory": "packages/candid"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
+    "url": "https://github.com/dfinity/icp-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -1113,7 +1113,7 @@ describe('IDL subtyping', () => {
   });
 
   describe('Subtyping on records/variants normalizes field labels', () => {
-    // Checks we don't regress https://github.com/dfinity/icp-sdk-js-core/issues/1072
+    // Checks we don't regress https://github.com/dfinity/icp-js-core/issues/1072
     testSub(IDL.Record({ a: IDL.Nat, "_98_": IDL.Nat }), IDL.Record({ "_97_": IDL.Nat, b: IDL.Nat }));
     testSub(IDL.Variant({ a: IDL.Nat, "_98_": IDL.Nat }), IDL.Variant({ "_97_": IDL.Nat, b: IDL.Nat }));
   });

--- a/packages/candid/src/idl.test.ts
+++ b/packages/candid/src/idl.test.ts
@@ -1113,7 +1113,7 @@ describe('IDL subtyping', () => {
   });
 
   describe('Subtyping on records/variants normalizes field labels', () => {
-    // Checks we don't regress https://github.com/dfinity/agent-js/issues/1072
+    // Checks we don't regress https://github.com/dfinity/icp-sdk-js-core/issues/1072
     testSub(IDL.Record({ a: IDL.Nat, "_98_": IDL.Nat }), IDL.Record({ "_97_": IDL.Nat, b: IDL.Nat }));
     testSub(IDL.Variant({ a: IDL.Nat, "_98_": IDL.Nat }), IDL.Variant({ "_97_": IDL.Nat, b: IDL.Nat }));
   });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -84,8 +84,8 @@ Additional API Documentation can be found [here](https://js.icp.build/core/lates
 
 ## Contributing
 
-Contributions are welcome! Please refer to the [repository](https://github.com/dfinity/icp-sdk-js-core) for guidelines on contributing to this project.
+Contributions are welcome! Please refer to the [repository](https://github.com/dfinity/icp-js-core) for guidelines on contributing to this project.
 
 ## License
 
-This project is licensed under the Apache-2.0 License. See the [LICENSE](https://github.com/dfinity/icp-sdk-js-core/blob/main/LICENSE) file for details.
+This project is licensed under the Apache-2.0 License. See the [LICENSE](https://github.com/dfinity/icp-js-core/blob/main/LICENSE) file for details.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -84,8 +84,8 @@ Additional API Documentation can be found [here](https://js.icp.build/core/lates
 
 ## Contributing
 
-Contributions are welcome! Please refer to the [repository](https://github.com/dfinity/agent-js) for guidelines on contributing to this project.
+Contributions are welcome! Please refer to the [repository](https://github.com/dfinity/icp-sdk-js-core) for guidelines on contributing to this project.
 
 ## License
 
-This project is licensed under the Apache-2.0 License. See the [LICENSE](https://github.com/dfinity/agent-js/blob/main/LICENSE) file for details.
+This project is licensed under the Apache-2.0 License. See the [LICENSE](https://github.com/dfinity/icp-sdk-js-core/blob/main/LICENSE) file for details.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/agent-js.git",
+    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
     "directory": "packages/core"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/agent-js/issues"
+    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
+    "url": "https://github.com/dfinity/icp-js-core.git",
     "directory": "packages/core"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
+    "url": "https://github.com/dfinity/icp-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/identity-secp256k1/package.json
+++ b/packages/identity-secp256k1/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/identity-secp256k1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/agent-js.git",
+    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
     "directory": "packages/identity-secp256k1"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/agent-js/issues"
+    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/identity-secp256k1/package.json
+++ b/packages/identity-secp256k1/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/identity-secp256k1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
+    "url": "https://github.com/dfinity/icp-js-core.git",
     "directory": "packages/identity-secp256k1"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
+    "url": "https://github.com/dfinity/icp-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/identity",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
+    "url": "https://github.com/dfinity/icp-js-core.git",
     "directory": "packages/identity"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
+    "url": "https://github.com/dfinity/icp-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/identity",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/agent-js.git",
+    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
     "directory": "packages/identity"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/agent-js/issues"
+    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/latest/upgrading/v4/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
+    "url": "https://github.com/dfinity/icp-js-core.git",
     "directory": "packages/migrate"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
+    "url": "https://github.com/dfinity/icp-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/latest/upgrading/v4/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/agent-js.git",
+    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
     "directory": "packages/migrate"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/agent-js/issues"
+    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/principal",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
+    "url": "https://github.com/dfinity/icp-js-core.git",
     "directory": "packages/principal"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
+    "url": "https://github.com/dfinity/icp-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/principal/package.json
+++ b/packages/principal/package.json
@@ -7,11 +7,11 @@
   "homepage": "https://js.icp.build/core/v3.2/libs/principal",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfinity/agent-js.git",
+    "url": "https://github.com/dfinity/icp-sdk-js-core.git",
     "directory": "packages/principal"
   },
   "bugs": {
-    "url": "https://github.com/dfinity/agent-js/issues"
+    "url": "https://github.com/dfinity/icp-sdk-js-core/issues"
   },
   "keywords": [
     "internet computer",

--- a/packages/use-auth-client/package.json
+++ b/packages/use-auth-client/package.json
@@ -39,17 +39,9 @@
     "api",
     "sdk"
   ],
-  "bugs": {
-    "url": "https://github.com/dfinity/agent-js/issues"
-  },
   "author": "DFINITY Stiftung <sdk@dfinity.org>",
   "license": "Apache-2.0",
   "homepage": "https://js.icp.build/core/v3.2/libs/use-auth-client",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/dfinity/agent-js.git",
-    "directory": "packages/use-auth-client"
-  },
   "dependencies": {
     "@dfinity/agent": "workspace:*",
     "@dfinity/auth-client": "workspace:*",


### PR DESCRIPTION
# Description

Remove or replace the occurrences of `agent-js` with `icp-js-core`. Once this is merged and the patch version for the packages is released, I will rename the repo on GitHub.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/agent-js/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
