### PR TITLE
feat: add optional `onPollingStarted` callback when making update calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Feat
+
+- **agent**: add optional `onPollingStarted` callback when making update calls (#1345)
+
 ## v5.3.1 (2026-04-23)
 
 ### Refactor
@@ -11,7 +17,6 @@
 ### Feat
 
 - **identity**: add AttributesIdentity for sender_info support (#1338)
-- **agent**: add optional `onRequestAccepted` callback when making update calls (#1345)
 
 ## v5.2.1 (2026-04-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Feat
 
 - **identity**: add AttributesIdentity for sender_info support (#1338)
+- **agent**: add optional `onRequestAccepted` callback when making update calls (#1345)
 
 ## v5.2.1 (2026-04-01)
 

--- a/packages/core/src/agent/agent/api.ts
+++ b/packages/core/src/agent/agent/api.ts
@@ -130,14 +130,15 @@ export interface CallOptions {
 
 export interface UpdateOptions extends CallOptions {
   /**
-   * An optional callback that will be invoked once the request is accepted by the IC.
+   * An optional callback that will be invoked once the agent starts polling for the result of the
+   * update call.
    *
-   * If `callSync` is set to false, the callback will be invoked once the request has been accepted
-   * by a single node. If `callSync` is set to true, the IC will first try to process the request
-   * synchronously, but if the synchronous request timeout is exceeded, the IC will reply
-   * indicating the request was accepted, at which point the callback will be invoked.
+   * If `callSync` is set to false, polling will start, and the callback will be invoked, once the
+   * request has been accepted by a single node. If `callSync` is set to true, the IC will first
+   * try to process the request synchronously. But if the synchronous request timeout is exceeded,
+   * the agent will start polling for the result, at which point the callback will be invoked.
    */
-  onRequestAccepted?: () => void;
+  onPollingStarted?: () => void;
 }
 
 export interface ReadStateResponse {

--- a/packages/core/src/agent/agent/api.ts
+++ b/packages/core/src/agent/agent/api.ts
@@ -118,6 +118,11 @@ export interface CallOptions {
   effectiveCanisterId: Principal | string;
 
   /**
+   * Whether to use synchronous call mode. Defaults to true.
+   */
+  callSync?: boolean;
+
+  /**
    * An optional nonce to use for the call, used to prevent replay attacks.
    */
   nonce?: Uint8Array;

--- a/packages/core/src/agent/agent/api.ts
+++ b/packages/core/src/agent/agent/api.ts
@@ -123,6 +123,14 @@ export interface CallOptions {
   nonce?: Uint8Array;
 }
 
+export interface UpdateOptions extends CallOptions {
+  /**
+   * An optional callback that will be invoked once the request is accepted by the IC.
+   * Using this requires `callSync` to be set to false.
+   */
+  onRequestAccepted?: () => void;
+}
+
 export interface ReadStateResponse {
   certificate: Uint8Array;
 }

--- a/packages/core/src/agent/agent/api.ts
+++ b/packages/core/src/agent/agent/api.ts
@@ -131,7 +131,11 @@ export interface CallOptions {
 export interface UpdateOptions extends CallOptions {
   /**
    * An optional callback that will be invoked once the request is accepted by the IC.
-   * Using this requires `callSync` to be set to false.
+   *
+   * If `callSync` is set to false, the callback will be invoked once the request has been accepted
+   * by a single node. If `callSync` is set to true, the IC will first try to process the request
+   * synchronously, but if the synchronous request timeout is exceeded, the IC will reply
+   * indicating the request was accepted, at which point the callback will be invoked.
    */
   onRequestAccepted?: () => void;
 }

--- a/packages/core/src/agent/agent/http/http-update.test.ts
+++ b/packages/core/src/agent/agent/http/http-update.test.ts
@@ -445,10 +445,10 @@ describe('HttpAgent.update', () => {
     });
   });
 
-  it('invokes onRequestAccepted callback', async () => {
+  it('invokes onPollingStarted callback', async () => {
     const agent = createAgentWithCallMock();
     let callbackInvoked = false;
-    await agent.update(canisterId, { ...updateFields, callSync: false, onRequestAccepted: () => callbackInvoked = true });
+    await agent.update(canisterId, { ...updateFields, callSync: false, onPollingStarted: () => callbackInvoked = true });
     expect(callbackInvoked).toBe(true);
   });
 });

--- a/packages/core/src/agent/agent/http/http-update.test.ts
+++ b/packages/core/src/agent/agent/http/http-update.test.ts
@@ -286,15 +286,15 @@ describe('HttpAgent.update', () => {
     });
   });
 
-  describe('v4 sync response handling', () => {
-    function createAgentWithV4Response(overrides: { certificate?: Uint8Array } = {}): HttpAgent {
-      return createAgentWithCallMock({
-        status: 200,
-        statusText: 'OK',
-        body: { certificate: overrides.certificate ?? new Uint8Array([0]) },
-      });
-    }
+  function createAgentWithV4Response(overrides: { certificate?: Uint8Array } = {}): HttpAgent {
+    return createAgentWithCallMock({
+      status: 200,
+      statusText: 'OK',
+      body: { certificate: overrides.certificate ?? new Uint8Array([0]) },
+    });
+  }
 
+  describe('v4 sync response handling', () => {
     it('uses v4 sync response without polling when reply is available', async () => {
       const agent = createAgentWithV4Response();
       replyByRequestKey.set(requestId, new Uint8Array([42]));
@@ -445,10 +445,74 @@ describe('HttpAgent.update', () => {
     });
   });
 
-  it('invokes onPollingStarted callback', async () => {
-    const agent = createAgentWithCallMock();
-    let callbackInvoked = false;
-    await agent.update(canisterId, { ...updateFields, callSync: false, onPollingStarted: () => callbackInvoked = true });
-    expect(callbackInvoked).toBe(true);
-  });
+  describe("onPollingStarted callback", () => {
+    it('invoked upon receiving HTTP response status 202 (ACCEPTED)', async () => {
+      const agent = createAgentWithCallMock();
+      let callbackInvoked = false;
+      await agent.update(canisterId, {
+        ...updateFields,
+        onPollingStarted: () => (callbackInvoked = true),
+      });
+      expect(callbackInvoked).toBe(true);
+    });
+
+    it('invoked when v4 certificate has no request_status entry for the requestId', async () => {
+      const agent = createAgentWithV4Response();
+      replyByRequestKey.set(requestId, new Uint8Array([42]));
+
+      // The v4 certificate will return absent for the request ID.
+      absentStatusRequestIds.add(requestId);
+      const origReadState = agent.readState as jest.Mock;
+      origReadState.mockImplementation(async (...args: unknown[]) => {
+        // Polling gets a fresh certificate where the request is now present
+        absentStatusRequestIds.delete(requestId);
+        return { certificate: new Uint8Array([0]) };
+      });
+
+      let callbackInvoked = false;
+      await agent.update(canisterId, {
+        ...updateFields,
+        onPollingStarted: () => (callbackInvoked = true),
+      });
+      expect(callbackInvoked).toBe(true);
+    });
+
+    it("not invoked if v4 sync response contains reply", async () => {
+      const agent = createAgentWithV4Response();
+      replyByRequestKey.set(requestId, new Uint8Array([42]));
+
+      let callbackInvoked = false;
+      await agent.update(canisterId, {
+        ...updateFields,
+        callSync: true,
+        onPollingStarted: () => (callbackInvoked = true),
+      });
+      expect(callbackInvoked).toBe(false);
+    });
+
+    it('not invoked if request is rejected', async () => {
+      const agent = createAgentWithCallMock({
+        ok: false,
+        status: 200,
+        statusText: 'OK',
+        body: {
+          reject_code: 5,
+          reject_message: 'canister error',
+          error_code: 'IC0503',
+        },
+      });
+
+      let callbackInvoked = false;
+      try {
+        await agent.update(canisterId, {
+          ...updateFields,
+          callSync: true,
+          onPollingStarted: () => (callbackInvoked = true),
+        });
+        fail('Expected update to throw');
+      } catch {
+        expect(callbackInvoked).toBe(false);
+      }
+    });
+  })
 });

--- a/packages/core/src/agent/agent/http/http-update.test.ts
+++ b/packages/core/src/agent/agent/http/http-update.test.ts
@@ -1,6 +1,6 @@
 import { Principal } from '#principal';
-import { HttpAgent } from '../index.ts';
-import type { CallOptions, SubmitResponse } from '../index.ts';
+import { HttpAgent, type UpdateOptions } from '../index.ts';
+import type { SubmitResponse } from '../index.ts';
 import type { RequestId } from '../../request_id.ts';
 import type { LookupPathResultFound, LookupPathStatus } from '../../certificate.ts';
 import { ExternalError, RejectError, UnknownError, UnexpectedV4StatusErrorCode } from '../../errors.ts';
@@ -99,7 +99,7 @@ const mockRequestDetails: CallRequest = {
   ingress_expiry: { toHash: () => new Uint8Array() } as unknown as Expiry,
 };
 
-const callFields: CallOptions = {
+const updateFields: UpdateOptions = {
   methodName: 'test_method',
   arg: new Uint8Array([1]),
   effectiveCanisterId: canisterId,
@@ -151,7 +151,7 @@ describe('HttpAgent.update', () => {
       const expectedReply = new Uint8Array([42]);
       replyByRequestKey.set(requestId, expectedReply);
 
-      const result = await agent.update(canisterId, callFields);
+      const result = await agent.update(canisterId, updateFields);
 
       expect(result.reply).toEqual(expectedReply);
     });
@@ -160,7 +160,7 @@ describe('HttpAgent.update', () => {
       const agent = createAgentWithCallMock();
       replyByRequestKey.set(requestId, new Uint8Array([42]));
 
-      const result = await agent.update(canisterId, callFields);
+      const result = await agent.update(canisterId, updateFields);
 
       expect(result.rawCertificate).toEqual(new Uint8Array([0]));
     });
@@ -170,7 +170,7 @@ describe('HttpAgent.update', () => {
       const expectedReply = new Uint8Array([42]);
       replyByRequestKey.set(requestId, expectedReply);
 
-      const result = await agent.update(canisterId, callFields);
+      const result = await agent.update(canisterId, updateFields);
 
       expect(result.certificate).toBeDefined();
       expect(typeof result.certificate.lookup_path).toBe('function');
@@ -186,7 +186,7 @@ describe('HttpAgent.update', () => {
       const agent = createAgentWithCallMock();
       replyByRequestKey.set(requestId, new Uint8Array([42]));
 
-      const result = await agent.update(canisterId, callFields);
+      const result = await agent.update(canisterId, updateFields);
 
       expect(result.requestDetails).toEqual(mockRequestDetails);
     });
@@ -195,9 +195,9 @@ describe('HttpAgent.update', () => {
       const agent = createAgentWithCallMock();
       replyByRequestKey.set(requestId, new Uint8Array([42]));
 
-      await agent.update(canisterId, callFields);
+      await agent.update(canisterId, updateFields);
 
-      expect(agent.call).toHaveBeenCalledWith(canisterId, callFields);
+      expect(agent.call).toHaveBeenCalledWith(canisterId, updateFields);
     });
 
     it('throws RejectError with reject details when polling encounters a rejection', async () => {
@@ -210,7 +210,7 @@ describe('HttpAgent.update', () => {
       });
 
       try {
-        await agent.update(canisterId, callFields);
+        await agent.update(canisterId, updateFields);
         fail('Expected update to throw');
       } catch (error) {
         expect(error).toBeInstanceOf(RejectError);
@@ -243,10 +243,10 @@ describe('HttpAgent.update', () => {
       const agent = createAgentWithCallMock();
       replyByRequestKey.set(requestId, new Uint8Array([42]));
 
-      const result = await agent.update(canisterId.toText(), callFields);
+      const result = await agent.update(canisterId.toText(), updateFields);
 
       expect(result.reply).toEqual(new Uint8Array([42]));
-      expect(agent.call).toHaveBeenCalledWith(canisterId.toText(), callFields);
+      expect(agent.call).toHaveBeenCalledWith(canisterId.toText(), updateFields);
     });
 
     it('passes nonce through to agent.call', async () => {
@@ -254,7 +254,7 @@ describe('HttpAgent.update', () => {
       replyByRequestKey.set(requestId, new Uint8Array([42]));
       const nonce = new Uint8Array([99, 88, 77]);
 
-      const fieldsWithNonce = { ...callFields, nonce };
+      const fieldsWithNonce = { ...updateFields, nonce };
       await agent.update(canisterId, fieldsWithNonce);
 
       expect(agent.call).toHaveBeenCalledWith(canisterId, fieldsWithNonce);
@@ -264,7 +264,7 @@ describe('HttpAgent.update', () => {
       const agent = createAgentWithCallMock();
       replyByRequestKey.set(requestId, new Uint8Array([42]));
 
-      const result = await agent.update(canisterId, callFields);
+      const result = await agent.update(canisterId, updateFields);
 
       expect(result.callResponse).toEqual({
         ok: true,
@@ -279,7 +279,7 @@ describe('HttpAgent.update', () => {
       const agent = createAgentWithCallMock();
       replyByRequestKey.set(requestId, new Uint8Array([42]));
 
-      const result = await agent.update(canisterId, callFields);
+      const result = await agent.update(canisterId, updateFields);
 
       expect(result.reply).toEqual(new Uint8Array([42]));
       expect(agent.readState).toHaveBeenCalled();
@@ -299,7 +299,7 @@ describe('HttpAgent.update', () => {
       const agent = createAgentWithV4Response();
       replyByRequestKey.set(requestId, new Uint8Array([42]));
 
-      const result = await agent.update(canisterId, callFields);
+      const result = await agent.update(canisterId, updateFields);
 
       expect(result.reply).toEqual(new Uint8Array([42]));
       expect(result.certificate).toBeDefined();
@@ -313,7 +313,7 @@ describe('HttpAgent.update', () => {
       const agent = createAgentWithV4Response({ certificate: certBytes });
       replyByRequestKey.set(requestId, new Uint8Array([42]));
 
-      const result = await agent.update(canisterId, callFields);
+      const result = await agent.update(canisterId, updateFields);
 
       expect(result.rawCertificate).toEqual(certBytes);
     });
@@ -323,7 +323,7 @@ describe('HttpAgent.update', () => {
       Object.defineProperty(agent, 'rootKey', { value: null, writable: true });
       replyByRequestKey.set(requestId, new Uint8Array([42]));
 
-      await expect(agent.update(canisterId, callFields)).rejects.toThrow(ExternalError);
+      await expect(agent.update(canisterId, updateFields)).rejects.toThrow(ExternalError);
     });
 
     it('throws UnknownError with UnexpectedV4StatusErrorCode for unexpected v4 status', async () => {
@@ -332,7 +332,7 @@ describe('HttpAgent.update', () => {
       replyByRequestKey.set(requestId, new Uint8Array([42]));
 
       try {
-        await agent.update(canisterId, callFields);
+        await agent.update(canisterId, updateFields);
         fail('Expected update to throw');
       } catch (error) {
         expect(error).toBeInstanceOf(UnknownError);
@@ -359,7 +359,7 @@ describe('HttpAgent.update', () => {
         return { certificate: new Uint8Array([0]) };
       });
 
-      const result = await agent.update(canisterId, callFields);
+      const result = await agent.update(canisterId, updateFields);
 
       expect(result.reply).toEqual(new Uint8Array([42]));
       expect(agent.readState).toHaveBeenCalled();
@@ -375,7 +375,7 @@ describe('HttpAgent.update', () => {
       });
 
       try {
-        await agent.update(canisterId, callFields);
+        await agent.update(canisterId, updateFields);
         fail('Expected update to throw');
       } catch (error) {
         expect(error).toBeInstanceOf(RejectError);
@@ -399,7 +399,7 @@ describe('HttpAgent.update', () => {
         body: null,
       });
 
-      await expect(agent.update(canisterId, callFields)).rejects.toThrow(UnknownError);
+      await expect(agent.update(canisterId, updateFields)).rejects.toThrow(UnknownError);
       expect(agent.readState).not.toHaveBeenCalled();
     });
 
@@ -411,7 +411,7 @@ describe('HttpAgent.update', () => {
         body: null,
       });
 
-      await expect(agent.update(canisterId, callFields)).rejects.toThrow(UnknownError);
+      await expect(agent.update(canisterId, updateFields)).rejects.toThrow(UnknownError);
       expect(agent.readState).not.toHaveBeenCalled();
     });
   });
@@ -430,7 +430,7 @@ describe('HttpAgent.update', () => {
       });
 
       try {
-        await agent.update(canisterId, callFields);
+        await agent.update(canisterId, updateFields);
         fail('Expected update to throw');
       } catch (error) {
         expect(error).toBeInstanceOf(RejectError);
@@ -443,5 +443,12 @@ describe('HttpAgent.update', () => {
       }
       expect(agent.readState).not.toHaveBeenCalled();
     });
+  });
+
+  it('invokes onRequestAccepted callback', async () => {
+    const agent = createAgentWithCallMock();
+    let callbackInvoked = false;
+    await agent.update(canisterId, { ...updateFields, callSync: false, onRequestAccepted: () => callbackInvoked = true });
+    expect(callbackInvoked).toBe(true);
   });
 });

--- a/packages/core/src/agent/agent/http/index.ts
+++ b/packages/core/src/agent/agent/http/index.ts
@@ -475,23 +475,12 @@ export class HttpAgent implements Agent {
    * Makes a call to a canister method.
    * @param canisterId - The ID of the canister to call. Can be a Principal or a string.
    * @param options - Options for the call.
-   * @param options.methodName - The name of the method to call.
-   * @param options.arg - The argument to pass to the method, as a Uint8Array.
-   * @param options.effectiveCanisterId - (Optional) The effective canister ID, if different from the target canister ID.
-   * @param options.callSync - (Optional) Whether to use synchronous call mode. Defaults to true.
-   * @param options.nonce - (Optional) A unique nonce for the request. If provided, it will override any nonce set by transforms.
    * @param identity - (Optional) The identity to use for the call. If not provided, the agent's current identity will be used.
    * @returns A promise that resolves to the response of the call, including the request ID and response details.
    */
   public async call(
     canisterId: Principal | string,
-    options: {
-      methodName: string;
-      arg: Uint8Array;
-      effectiveCanisterId?: Principal | string;
-      callSync?: boolean;
-      nonce?: Uint8Array | Nonce;
-    },
+    options: CallOptions,
     identity?: Identity | Promise<Identity>,
   ): Promise<SubmitResponse> {
     const callSync = options.callSync ?? true;

--- a/packages/core/src/agent/agent/http/index.ts
+++ b/packages/core/src/agent/agent/http/index.ts
@@ -46,6 +46,7 @@ import {
   type ReadStateOptions,
   type ReadStateResponse,
   type SubmitResponse,
+  type CallOptions,
   type v2ResponseBody,
   type v4ResponseBody,
   isV4ResponseBody,

--- a/packages/core/src/agent/agent/http/index.ts
+++ b/packages/core/src/agent/agent/http/index.ts
@@ -47,11 +47,11 @@ import {
   type ReadStateResponse,
   type SubmitResponse,
   type CallOptions,
+  type UpdateOptions,
   type v2ResponseBody,
   type v4ResponseBody,
   isV4ResponseBody,
   isV2ResponseBody,
-  UpdateOptions,
 } from '../api.ts';
 import { Expiry, httpHeadersTransform, makeNonceTransform } from './transforms.ts';
 import {

--- a/packages/core/src/agent/agent/http/index.ts
+++ b/packages/core/src/agent/agent/http/index.ts
@@ -51,6 +51,7 @@ import {
   type v4ResponseBody,
   isV4ResponseBody,
   isV2ResponseBody,
+  UpdateOptions,
 } from '../api.ts';
 import { Expiry, httpHeadersTransform, makeNonceTransform } from './transforms.ts';
 import {
@@ -656,7 +657,7 @@ export class HttpAgent implements Agent {
    */
   public async update(
     canisterId: Principal | string,
-    fields: CallOptions,
+    fields: UpdateOptions,
     pollingOptions: PollingOptions = {},
   ): Promise<UpdateResult> {
     const effectiveCanisterId = Principal.from(fields.effectiveCanisterId);
@@ -681,6 +682,7 @@ export class HttpAgent implements Agent {
     }
 
     if (response.status === HTTP_STATUS_ACCEPTED) {
+      fields.onRequestAccepted?.();
       const pollResult = await pollForResponse(
         this,
         effectiveCanisterId,

--- a/packages/core/src/agent/agent/http/index.ts
+++ b/packages/core/src/agent/agent/http/index.ts
@@ -663,6 +663,7 @@ export class HttpAgent implements Agent {
         httpDetails,
         requestDetails,
         pollingOptions,
+        fields.onPollingStarted,
       );
     }
 
@@ -671,7 +672,7 @@ export class HttpAgent implements Agent {
     }
 
     if (response.status === HTTP_STATUS_ACCEPTED) {
-      fields.onRequestAccepted?.();
+      fields.onPollingStarted?.();
       const pollResult = await pollForResponse(
         this,
         effectiveCanisterId,
@@ -701,6 +702,7 @@ export class HttpAgent implements Agent {
     httpDetails: HttpDetailsResponse,
     requestDetails: UpdateResult['requestDetails'],
     pollingOptions: PollingOptions,
+    onPollingStarted?: () => void,
   ): Promise<UpdateResult> {
     if (this.rootKey == null) {
       throw ExternalError.fromCode(new MissingRootKeyErrorCode());
@@ -744,6 +746,7 @@ export class HttpAgent implements Agent {
         this.log.warn(
           `v4 sync response certificate does not contain request ID ${bytesToHex(requestId)} status. Falling back to polling.`,
         );
+        onPollingStarted?.();
         const pollResult = await pollForResponse(
           this,
           effectiveCanisterId,

--- a/packages/core/src/agent/agent/http/index.ts
+++ b/packages/core/src/agent/agent/http/index.ts
@@ -46,7 +46,6 @@ import {
   type ReadStateOptions,
   type ReadStateResponse,
   type SubmitResponse,
-  type CallOptions,
   type v2ResponseBody,
   type v4ResponseBody,
   isV4ResponseBody,


### PR DESCRIPTION
# Description

This allows devs to specify an optional callback when submitting update calls, which will be invoked once their request has been accepted by the IC.

We use this within OpenChat to display the first message tick, signalling that the message has made its way to the backend.

# How Has This Been Tested?

I have added tests which cover the various cases where the callback should either be invoked or not, and also we are using this successfully within OpenChat.

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/icp-js-core/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
