### PR TITLE
chore: produce fewer docs files

### DIFF
--- a/docs/scripts/split-index.js
+++ b/docs/scripts/split-index.js
@@ -18,18 +18,26 @@ function extractFrontmatter(content) {
   return match[0];
 }
 
+function resolveApiPath(submodulePath) {
+  const nested = join(submodulePath, 'api', 'index.md');
+  if (existsSync(nested)) return nested;
+  const flat = join(submodulePath, 'api.md');
+  if (existsSync(flat)) return flat;
+  return null;
+}
+
 function processSubmodule(submodulePath) {
   const submoduleName = basename(submodulePath);
-  const apiIndexPath = join(submodulePath, 'api', 'index.md');
+  const apiPath = resolveApiPath(submodulePath);
 
-  if (!existsSync(apiIndexPath)) {
-    console.log(`Skipping ${submoduleName}: no api/index.md found`);
+  if (!apiPath) {
+    console.log(`Skipping ${submoduleName}: no api index found`);
     return;
   }
 
-  console.log(`Processing ${apiIndexPath}`);
+  console.log(`Processing ${apiPath}`);
 
-  const content = readFileSync(apiIndexPath, 'utf-8');
+  const content = readFileSync(apiPath, 'utf-8');
   const splitIndex = content.indexOf(SPLIT_MARKER);
 
   if (splitIndex === -1) {
@@ -42,22 +50,18 @@ function processSubmodule(submodulePath) {
   const firstPart = content.slice(0, splitIndex).trimEnd();
   const secondPart = content.slice(splitIndex + SPLIT_MARKER.length).trimStart();
 
-  // New index.md: first part with title changed to capitalized submodule name
-  // Goes to <submodule>/index.md
   const newIndex = firstPart.replace(
     FRONTMATTER_TITLE,
     `${FRONTMATTER_TITLE_KEY}: ${capitalize(submoduleName)}`,
   );
 
-  // Old index.md: original frontmatter + second part (API reference)
-  // Stays at <submodule>/api/index.md
   const oldIndex = `${frontmatter}\n\n${secondPart}`;
 
   writeFileSync(join(submodulePath, 'index.md'), newIndex + '\n');
-  writeFileSync(apiIndexPath, oldIndex);
+  writeFileSync(apiPath, oldIndex);
 
   console.log(`  Created ${submoduleName}/index.md`);
-  console.log(`  Updated ${submoduleName}/api/index.md`);
+  console.log(`  Updated ${basename(apiPath)}`);
 }
 
 function main() {

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -1,40 +1,49 @@
 {
-    "$schema": "https://typedoc-plugin-markdown.org/schema.json",
-    "entryPoints": [
-      "../packages/core/src/agent/index.ts",
-      "../packages/core/src/agent/canister-env/index.ts",
-      "../packages/core/src/candid/index.ts",
-      "../packages/core/src/identity/index.ts",
-      "../packages/core/src/identity/secp256k1/index.ts",
-      "../packages/core/src/principal/index.ts"
-    ],
-    "tsconfig": "../packages/core/tsconfig.json",
-    "readme": "none",
-    "out": "src/content/tmp",
-    "plugin": [
-      "typedoc-plugin-markdown",
-      "typedoc-plugin-frontmatter",
-      "@dfinity/typedoc-plugin-icp-docs"
-    ],
-    "outputs": [
-      { "name": "markdown", "path": "src/content/tmp" },
-      { "name": "icp-docs", "path": "src/content/docs" }
-    ],
-    "projectDocuments": ["../CHANGELOG.md"],
-    "entryFileName": "index",
-    "hidePageTitle": true,
-    "hideBreadcrumbs": true,
-    "hidePageHeader": true,
-    "frontmatterGlobals": {
-      "editUrl": false,
-      "next": true,
-      "prev": true
+  "$schema": "https://typedoc-plugin-markdown.org/schema.json",
+  "entryPoints": [
+    "../packages/core/src/agent/index.ts",
+    "../packages/core/src/agent/canister-env/index.ts",
+    "../packages/core/src/candid/index.ts",
+    "../packages/core/src/identity/index.ts",
+    "../packages/core/src/identity/secp256k1/index.ts",
+    "../packages/core/src/principal/index.ts"
+  ],
+  "tsconfig": "../packages/core/tsconfig.json",
+  "readme": "none",
+  "out": "src/content/tmp",
+  "plugin": [
+    "typedoc-plugin-markdown",
+    "typedoc-plugin-frontmatter",
+    "@dfinity/typedoc-plugin-icp-docs"
+  ],
+  "outputs": [
+    {
+      "name": "markdown",
+      "path": "src/content/tmp"
     },
-    "readmeFrontmatter": {
-      "editUrl": false,
-      "next": true,
-      "prev": true
-    },
-    "indexFrontmatter": {},
-    "frontmatterNamingConvention": "camelCase"
+    {
+      "name": "icp-docs",
+      "path": "src/content/docs"
+    }
+  ],
+  "projectDocuments": [
+    "../CHANGELOG.md"
+  ],
+  "router": "module",
+  "entryFileName": "index",
+  "hidePageTitle": true,
+  "hideBreadcrumbs": true,
+  "hidePageHeader": true,
+  "frontmatterGlobals": {
+    "editUrl": false,
+    "next": true,
+    "prev": true
+  },
+  "readmeFrontmatter": {
+    "editUrl": false,
+    "next": true,
+    "prev": true
+  },
+  "indexFrontmatter": {},
+  "frontmatterNamingConvention": "camelCase"
 }


### PR DESCRIPTION
Our docs size bloats mostly by file count. With this change, we no longer produce a file per exported symbol, but a file per source file instead. This reduces the file count form 402 to 14.