### PR TITLE
feat: wire the delegation permissions field through Delegation

### DIFF
--- a/packages/core/src/identity/identity/delegation.test.ts
+++ b/packages/core/src/identity/identity/delegation.test.ts
@@ -1,12 +1,14 @@
 import { Principal } from '#principal';
 import {
+  Delegation,
   DelegationChain,
   DelegationIdentity,
   PartialDelegationIdentity,
   type SignedDelegation,
 } from './delegation.ts';
 import { Ed25519KeyIdentity } from './ed25519.ts';
-import { type DerEncodedPublicKey, Ed25519PublicKey } from '#agent';
+import { type DerEncodedPublicKey, Ed25519PublicKey, requestIdOf } from '#agent';
+import { bytesToHex } from '@noble/hashes/utils.js';
 
 function createIdentity(seed: number): Ed25519KeyIdentity {
   const s = new Uint8Array([seed, ...new Array(31).fill(0)]);
@@ -154,6 +156,94 @@ test('Delegation Chain can sign', async () => {
   );
   expect(isValid).toBe(true);
   expect(middle.toJSON()[1].length).toBe(64);
+});
+
+describe('Delegation permissions field', () => {
+  const pubkey = new Uint8Array([1, 2, 3, 4]);
+  const expiration = BigInt(1609459200000) * BigInt(1_000_000);
+
+  it('is exposed on the Delegation instance', () => {
+    const delegation = new Delegation(pubkey, expiration, undefined, 'queries');
+    expect(delegation.permissions).toBe('queries');
+  });
+
+  it('is included in the CBOR value when present', () => {
+    const delegation = new Delegation(pubkey, expiration, undefined, 'queries');
+    expect(delegation.toCborValue()).toMatchObject({ permissions: 'queries' });
+  });
+
+  it('is omitted from the CBOR value when absent (backwards compatible)', () => {
+    const delegation = new Delegation(pubkey, expiration);
+    expect('permissions' in delegation.toCborValue()).toBe(false);
+  });
+
+  it('is included in toJSON as a plain (non-hex) string when present', () => {
+    const delegation = new Delegation(pubkey, expiration, undefined, 'queries');
+    expect(delegation.toJSON().permissions).toBe('queries');
+  });
+
+  it('is omitted from toJSON when absent (backwards compatible)', () => {
+    const delegation = new Delegation(pubkey, expiration);
+    expect('permissions' in delegation.toJSON()).toBe(false);
+  });
+
+  it('round-trips through DelegationChain toJSON/fromJSON', async () => {
+    const root = createIdentity(2);
+    const session = createIdentity(0);
+
+    const chain = await DelegationChain.create(
+      root,
+      session.getPublicKey(),
+      new Date(1609459200000),
+      { permissions: 'queries' },
+    );
+
+    expect(chain.delegations[0].delegation.permissions).toBe('queries');
+    expect(chain.toJSON().delegations[0].delegation.permissions).toBe('queries');
+
+    const restored = DelegationChain.fromJSON(JSON.stringify(chain));
+    expect(restored.delegations[0].delegation.permissions).toBe('queries');
+    expect(restored.toJSON()).toEqual(chain.toJSON());
+  });
+
+  it('throws on a non-string permissions value in fromJSON', () => {
+    expect(() =>
+      DelegationChain.fromJSON({
+        publicKey: '00',
+        delegations: [
+          {
+            signature: '00',
+            delegation: {
+              pubkey: '00'.repeat(32),
+              expiration: '1655f29d787c0000',
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              permissions: 123 as any,
+            },
+          },
+        ],
+      }),
+    ).toThrow('Invalid permissions.');
+  });
+
+  // Cross-implementation reference vector. The Internet Identity canister signs
+  // the representation-independent hash of `{pubkey, expiration, permissions}`
+  // for a queries-only (read-only) delegation. `requestIdOf` must reproduce that
+  // exact hash byte-for-byte, otherwise the canister signature would not verify
+  // once the delegation is forwarded to the relying party. This pins the same
+  // vector asserted by the II backend test `should_pin_queries_permissions_msg`.
+  it('produces the same representation-independent hash as the II canister', () => {
+    const sessionPubkey = new TextEncoder().encode('test session public key');
+    const delegation = new Delegation(
+      sessionPubkey,
+      BigInt('1700000000000000000'),
+      undefined,
+      'queries',
+    );
+
+    const hash = bytesToHex(new Uint8Array(requestIdOf({ ...delegation })));
+
+    expect(hash).toBe('061d792a31da1cedbbb4ed1a4234c12645d021e6a81ef1598bbe27124f33a4c6');
+  });
 });
 
 describe('PartialDelegationIdentity', () => {

--- a/packages/core/src/identity/identity/delegation.ts
+++ b/packages/core/src/identity/identity/delegation.ts
@@ -58,7 +58,7 @@ export class Delegation implements ToCborValue {
       ...(this.targets && {
         targets: this.targets,
       }),
-      ...(this.permissions !== undefined && {
+      ...(this.permissions && {
         permissions: this.permissions,
       }),
     };
@@ -74,7 +74,7 @@ export class Delegation implements ToCborValue {
       expiration: this.expiration.toString(16),
       pubkey: safeBytesToHex(this.pubkey),
       ...(this.targets && { targets: this.targets.map(p => p.toHex()) }),
-      ...(this.permissions !== undefined && { permissions: this.permissions }),
+      ...(this.permissions && { permissions: this.permissions }),
     };
   }
 }
@@ -287,7 +287,7 @@ export class DelegationChain {
             ...(targets && {
               targets: targets.map(t => t.toHex()),
             }),
-            ...(permissions !== undefined && { permissions }),
+            ...(permissions && { permissions }),
           },
           signature: safeBytesToHex(signature),
         };

--- a/packages/core/src/identity/identity/delegation.ts
+++ b/packages/core/src/identity/identity/delegation.ts
@@ -46,6 +46,7 @@ export class Delegation implements ToCborValue {
     pubkey: Uint8Array,
     public readonly expiration: bigint,
     public readonly targets?: Principal[],
+    public readonly permissions?: string,
   ) {
     this.pubkey = pubkey.slice();
   }
@@ -57,6 +58,9 @@ export class Delegation implements ToCborValue {
       ...(this.targets && {
         targets: this.targets,
       }),
+      ...(this.permissions !== undefined && {
+        permissions: this.permissions,
+      }),
     };
   }
 
@@ -64,10 +68,13 @@ export class Delegation implements ToCborValue {
     // every string should be hex and once-de-hexed,
     // discoverable what it is (e.g. de-hex to get JSON with a 'type' property, or de-hex to DER
     // with an OID). After de-hex, if it's not obvious what it is, it's an ArrayBuffer.
+    // `permissions` is the exception: it is a semantic value (e.g. "queries"),
+    // not opaque binary, so it is kept as a plain string rather than hex-encoded.
     return {
       expiration: this.expiration.toString(16),
       pubkey: safeBytesToHex(this.pubkey),
       ...(this.targets && { targets: this.targets.map(p => p.toHex()) }),
+      ...(this.permissions !== undefined && { permissions: this.permissions }),
     };
   }
 }
@@ -85,6 +92,9 @@ interface JsonnableDelegation {
   pubkey: string;
   // Array of strings, where each string is hex of principal blob (*NOT* textual representation).
   targets?: string[];
+  // The delegation's optional `permissions` field (e.g. "queries"). Unlike the
+  // fields above, this is a plain semantic string, *NOT* hex-encoded.
+  permissions?: string;
 }
 
 /**
@@ -104,17 +114,20 @@ export interface SignedDelegation {
  * @param to The identity that receives the delegation.
  * @param expiration An expiration date for this delegation.
  * @param targets Limit this delegation to the target principals.
+ * @param permissions Restrict the kinds of calls the delegation permits (e.g. "queries").
  */
 async function _createSingleDelegation(
   from: SignIdentity,
   to: PublicKey,
   expiration: Date,
   targets?: Principal[],
+  permissions?: string,
 ): Promise<SignedDelegation> {
   const delegation: Delegation = new Delegation(
     to.toDer(),
     BigInt(+expiration) * BigInt(1000000), // In nanoseconds.
     targets,
+    permissions,
   );
   // The signature is calculated by signing the concatenation of the domain separator
   // and the message.
@@ -141,6 +154,7 @@ export interface JsonnableDelegationChain {
       pubkey: string;
       expiration: string;
       targets?: string[];
+      permissions?: string;
     };
   }>;
 }
@@ -179,6 +193,7 @@ export class DelegationChain {
    * @param options A set of options for this delegation. expiration and previous
    * @param options.previous - Another DelegationChain that this chain should start with.
    * @param options.targets - targets that scope the delegation (e.g. Canister Principals)
+   * @param options.permissions - restricts the kinds of calls the delegation permits (e.g. "queries")
    */
   public static async create(
     from: SignIdentity,
@@ -187,9 +202,16 @@ export class DelegationChain {
     options: {
       previous?: DelegationChain;
       targets?: Principal[];
+      permissions?: string;
     } = {},
   ): Promise<DelegationChain> {
-    const delegation = await _createSingleDelegation(from, to, expiration, options.targets);
+    const delegation = await _createSingleDelegation(
+      from,
+      to,
+      expiration,
+      options.targets,
+      options.permissions,
+    );
     return new DelegationChain(
       [...(options.previous?.delegations || []), delegation],
       options.previous?.publicKey || from.getPublicKey().toDer(),
@@ -208,9 +230,12 @@ export class DelegationChain {
 
     const parsedDelegations: SignedDelegation[] = delegations.map(signedDelegation => {
       const { delegation, signature } = signedDelegation;
-      const { pubkey, expiration, targets } = delegation;
+      const { pubkey, expiration, targets, permissions } = delegation;
       if (targets !== undefined && !Array.isArray(targets)) {
         throw new Error('Invalid targets.');
+      }
+      if (permissions !== undefined && typeof permissions !== 'string') {
+        throw new Error('Invalid permissions.');
       }
 
       return {
@@ -224,6 +249,7 @@ export class DelegationChain {
               }
               return Principal.fromHex(t);
             }),
+          permissions,
         ),
         signature: _parseBlob(signature) as Signature,
       };
@@ -253,7 +279,7 @@ export class DelegationChain {
     return {
       delegations: this.delegations.map(signedDelegation => {
         const { delegation, signature } = signedDelegation;
-        const { targets } = delegation;
+        const { targets, permissions } = delegation;
         return {
           delegation: {
             expiration: delegation.expiration.toString(16),
@@ -261,6 +287,7 @@ export class DelegationChain {
             ...(targets && {
               targets: targets.map(t => t.toHex()),
             }),
+            ...(permissions !== undefined && { permissions }),
           },
           signature: safeBytesToHex(signature),
         };


### PR DESCRIPTION
# Description

The `Delegation` class dropped the optional `permissions` field defined by the IC interface specification. As a result a **restricted (e.g. queries-only / read-only) delegation could not be represented, serialized, or forwarded** to a relying party by `@icp-sdk/core`.

This matters because the canister signature over a delegation **covers** the `permissions` field: the Internet Identity canister folds `permissions: "queries"` into the representation-independent hash it signs. When the agent reconstructs the delegation without that field, it recomputes a different hash, so the signature fails to verify and the delegation is unusable (read-only delegations "fail closed" on the dapp side).

This PR threads `permissions` through the delegation types so the field round-trips end-to-end:

- **`Delegation`** — new optional constructor arg and readonly `permissions` property.
- **`toCborValue`** — includes `permissions` when present, so it appears on the wire in `sender_delegation` and the replica recomputes the signed hash correctly.
- **`toJSON` / `fromJSON`** and the `JsonnableDelegation` / `JsonnableDelegationChain` types — persists and restores the field. It is kept as a plain string (e.g. `"queries"`) rather than hex-encoded, because it is a semantic value, not opaque binary; `fromJSON` validates it is a string.
- **`DelegationChain.create`** — new `permissions` option, for symmetry when minting chains.

All additions are optional and omitted when absent, so existing (unrestricted) delegations serialize **byte-for-byte** as before — no behavioral change for current callers.

### Context

Discovered while investigating why Internet Identity read-only delegations were not honored end-to-end: II already signs and requests `permissions`, but the agent library had nowhere to carry it. This is the library-side prerequisite noted in the II frontend (`@icp-sdk/core` must round-trip the `permissions` field before restricted delegations can verify on the relying-party side).

Fixes # (no issue filed yet)

# How Has This Been Tested?

Added unit tests in `packages/core/src/identity/identity/delegation.test.ts`:

- `permissions` is exposed on the `Delegation` instance.
- Included in `toCborValue` / `toJSON` when present; **omitted when absent** (backwards-compatibility assertions).
- Round-trips through `DelegationChain.create` → `toJSON` → `fromJSON`.
- `fromJSON` throws `Invalid permissions.` on a non-string value.
- **Cross-implementation reference vector**: `requestIdOf({...delegation})` for a queries-only delegation reproduces the exact representation-independent hash (`061d792a…33a4c6`) pinned by the Internet Identity backend test `should_pin_queries_permissions_msg`, guaranteeing the agent recomputes byte-for-byte what the canister signs.

Commands run in `packages/core`:

- `pnpm typecheck` — clean
- `pnpm test` — **42 suites / 638 tests pass** (incl. the pre-existing delegation golden test, confirming no serialization drift)
- `eslint` + `prettier --check` on the changed files — clean

# Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/icp-js-core/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly. _(The changelog is auto-generated from conventional commits per CONTRIBUTING.md — no manual edit.)_
- [ ] I have made corresponding changes to the documentation. _(API docs are generated from the source TSDoc, which is updated here.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRakSoztjTRdffETFZXGjL)_