### PR TITLE
ci: allow bots to update pnpm lockfile and workspace

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,7 +1,8 @@
 CHANGELOG.md
 .cz.yaml
 package.json
-package-lock.json
+pnpm-lock.yaml
+pnpm-workspace.yaml
 packages/*/package.json
 demos/*/package.json
 e2e/*/package.json


### PR DESCRIPTION
# Description

Updates the bot file-change allowlist ([.github/repo_policies/BOT_APPROVED_FILES](.github/repo_policies/BOT_APPROVED_FILES)) for pnpm.

## Problem

The `check-repo-policies / Check Bot Policies` check (from `dfinity/ci-tools`) requires every file changed by a **bot-authored** PR to match an entry in `BOT_APPROVED_FILES`. That list was carried over from npm — it allows `package-lock.json` (which this pnpm repo doesn't have) but not the pnpm equivalents.

As a result, the NPM Audit auto-fix workflow's PR (#1370) fails the policy check, because it touches:

- `pnpm-lock.yaml` — every dependency change rewrites it
- `pnpm-workspace.yaml` — pnpm 10 stores `overrides:` here, where `pnpm audit --fix` writes

Release/changelog bot PRs pass today only because a version bump doesn't rewrite the pnpm lockfile — but any *dependency* update does.

## Change

- Replace the obsolete `package-lock.json` entry with `pnpm-lock.yaml` and `pnpm-workspace.yaml`.

This is the durable fix — it unblocks not just #1370 but every future dependency-fix PR, which would otherwise fail identically.

## Security note

`pnpm-workspace.yaml` is more sensitive than a lockfile (it holds `onlyBuiltDependencies` and `overrides`). Widening the allowlist to include it is acceptable because:

- Auto-remediation fundamentally needs to write overrides there.
- Bot PRs still require human approval before merge, so the diff is always reviewed — the policy check is defense-in-depth, not the only gate.

## Checklist:

- [x] My changes follow the guidelines in [CONTRIBUTING.md](https://github.com/dfinity/icp-js-core/blob/main/.github/CONTRIBUTING.md).
- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly. _(CI-only change; changelog is auto-generated from conventional commits.)_
- [ ] I have made corresponding changes to the documentation. _(No user-facing docs affected.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)