### PR TITLE
chore(deps): fix npm audit vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@typescript-eslint/eslint-plugin": "^8.57.2",
     "@typescript-eslint/parser": "^8.57.2",
     "dotenv": "^17.3.1",
-    "esbuild": "^0.27.4",
+    "esbuild": "^0.28.1",
     "eslint": "^10.1.0",
     "eslint-plugin-jsdoc": "^62.8.1",
     "jest": "^30.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tsx": "^4.21.0",
     "typedoc": "^0.28.18",
     "typescript": "5.9.3",
-    "vite": "^8.0.9",
+    "vite": "^8.1.0",
     "vitest": "^4.1.3"
   },
   "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,13 @@ settings:
 
 overrides:
   '@babel/core@<=7.29.0': '>=7.29.6'
+  body-parser@>=2.0.0 <2.3.0: '>=2.3.0'
+  brace-expansion: '>=5.0.8'
   esbuild@>=0.27.3 <0.28.1: '>=0.28.1'
-  js-yaml@<3.15.0: '>=3.15.0'
-  linkify-it@<=5.0.0: '>=5.0.1'
+  js-yaml: '>=5.2.2'
+  linkify-it: '>=5.0.2 <6'
   markdown-it@<=14.1.1: '>=14.2.0'
+  postcss@<=8.5.17: '>=8.5.18'
   undici@>=7.0.0 <7.28.0: '>=7.28.0 <8'
   undici@>=7.23.0 <7.28.0: '>=7.28.0 <8'
   vite@>=8.0.0 <=8.0.15: '>=8.0.16'
@@ -49,7 +52,7 @@ importers:
         specifier: ^17.3.1
         version: 17.3.1
       esbuild:
-        specifier: '>=0.28.1'
+        specifier: ^0.28.1
         version: 0.28.1
       eslint:
         specifier: ^10.1.0
@@ -1456,9 +1459,6 @@ packages:
     peerDependencies:
       '@babel/core': '>=7.29.6'
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1478,19 +1478,13 @@ packages:
   bip39@3.1.0:
     resolution: {integrity: sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
-
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1622,9 +1616,6 @@ packages:
     resolution: {integrity: sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==}
     engines: {node: '>= 12.0.0'}
 
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
     engines: {node: '>=18'}
@@ -1632,6 +1623,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2326,8 +2321,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.0:
-    resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsdoc-type-pratt-parser@7.1.1:
@@ -2460,8 +2455,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -2585,8 +2580,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2762,8 +2757,8 @@ packages:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
     engines: {node: '>=12'}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3195,6 +3190,10 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typedoc-plugin-frontmatter@1.3.1:
     resolution: {integrity: sha512-wXKnhpiOuG3lY9GGKiKcXNrhKbPYm/jA5wbzGE/kKdwlSu8++ZbEuKA0K2dvIna3F+5EQrv+3AeObHkS1QP7JA==}
@@ -3939,7 +3938,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 5.2.0
+      js-yaml: 5.2.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -4766,8 +4765,6 @@ snapshots:
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@8.0.1)
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.29: {}
@@ -4782,30 +4779,21 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
       qs: 6.15.2
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.14:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.0:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4931,11 +4919,11 @@ snapshots:
 
   comment-parser@1.4.5: {}
 
-  concat-map@0.0.1: {}
-
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -5202,7 +5190,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -5886,7 +5874,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.0:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -5997,7 +5985,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -6035,7 +6023,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -6082,15 +6070,15 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -6108,7 +6096,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   nanoid@5.1.7: {}
 
@@ -6255,9 +6243,9 @@ snapshots:
     dependencies:
       queue-lit: 1.5.2
 
-  postcss@8.5.16:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6699,6 +6687,12 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typedoc-plugin-frontmatter@1.3.1(typedoc-plugin-markdown@4.11.0(typedoc@0.28.18(typescript@5.9.3))):
     dependencies:
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.18(typescript@5.9.3))
@@ -6784,7 +6778,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.23
       rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: '>=8.0.16'
+        specifier: ^8.1.0
         version: 8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,10 +18,14 @@ onlyBuiltDependencies:
 
 overrides:
   '@babel/core@<=7.29.0': '>=7.29.6'
+  body-parser@>=2.0.0 <2.3.0: '>=2.3.0'
+  brace-expansion: '>=5.0.8'
   esbuild@>=0.27.3 <0.28.1: '>=0.28.1'
-  js-yaml@<3.15.0: '>=3.15.0'
-  linkify-it@<=5.0.0: '>=5.0.1'
+  js-yaml: '>=5.2.2'
+  # linkify-it 6 dropped its default export, which markdown-it 14 imports
+  linkify-it: '>=5.0.2 <6'
   markdown-it@<=14.1.1: '>=14.2.0'
+  postcss@<=8.5.17: '>=8.5.18'
   undici@>=7.0.0 <7.28.0: '>=7.28.0 <8'
   undici@>=7.23.0 <7.28.0: '>=7.28.0 <8'
   vite@>=8.0.0 <=8.0.15: '>=8.0.16'


### PR DESCRIPTION
Supersedes #1379, which left 4 vulnerabilities unfixed and broke the docs build.

## Why #1379 didn't work

`pnpm audit --fix` appends version-keyed overrides like `js-yaml@>=5.0.0 <=5.2.1`, but pnpm matches the key's range against the **declared** dependency spec, not the resolved version. `@istanbuljs/load-nyc-config` declares `js-yaml: ^3.13.1`, so those keys never matched — and the already-locked 5.2.0 still satisfied the pre-existing `js-yaml@<3.15.0: '>=3.15.0'` override, so nothing re-resolved. Same for `brace-expansion`, where 5.0.6 kept satisfying `>=1.1.16` / `>=2.1.2`. #1379's own `audit` job reports `4 vulnerabilities found`.

Dropping the version keys on those three forces re-resolution.

## Why the docs build broke

`linkify-it@<=5.0.1: '>=5.0.2'` resolved to the newest allowed version, 6.1.0, whose ESM build exports only `{ LinkifyIt, REBuilder, linkifyit }`. markdown-it 14.2.0 declares `linkify-it: ^5.0.1` and does `import LinkifyIt from 'linkify-it'`, so typedoc failed with:

```
SyntaxError: The requested module 'linkify-it' does not provide an export named 'default'
```

Pinning to `>=5.0.2 <6` patches the advisory (5.0.2 is the fixed release) and keeps the default export. markdown-it 15 declares `linkify-it: ^6.0.0`, but it is under the 7-day `minimumReleaseAge` gate.

## Also

The esbuild alert is against the root `package.json` declared range (`^0.27.4`), not the lockfile — which already resolved 0.28.1 — so the devDependency is bumped to `^0.28.1`.

## Result

All alerts covered; each package collapses to a single patched version: `brace-expansion 5.0.8`, `js-yaml 5.2.2`, `linkify-it 5.0.2`, `postcss 8.5.23`, `body-parser 2.3.0`, `esbuild 0.28.1`. `brace-expansion 5.0.9` and `js-yaml 5.2.3` exist but are inside the `minimumReleaseAge` window; the ranges will pick them up on a later install.

Verified locally: `pnpm audit` → no known vulnerabilities; `pnpm build` (incl. docs), `pnpm test`, `pnpm typecheck` all pass; `pnpm lint` reports 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coverage check

Verified exhaustively rather than trusting the `pnpm audit` summary:

- **All 9 open Dependabot alerts** semver-checked against the resulting lockfile → 0 remain.
- **All 817 resolved `name@version` pairs** in `pnpm-lock.yaml` queried against the GitHub Advisory Database (`GET /advisories?ecosystem=npm&affects=…`) → 0 advisories. Sanity-checked with a positive control (`brace-expansion@5.0.6` correctly returns GHSA-3jxr and GHSA-mh99).
- **All 44 declared dependency ranges** across every workspace manifest, checked at their range minimum — the form Dependabot used for the esbuild alert → 0 advisories.

That last check surfaced one extra issue beyond the open alerts: the root `vite` devDependency declared `^8.0.9`, inside the vulnerable range of GHSA-fx2h-pf6j-xcff (high) and GHSA-v6wh-96g9-6wx3 (medium), both fixed in 8.0.16. The lockfile already resolved 8.1.0 via an override, so the tree was safe, but the declared range would have drawn a Dependabot alert of the same kind as esbuild's. Bumped to `^8.1.0`; resolution unchanged.

Note that `brace-expansion 5.0.9` and `js-yaml 5.2.3` are newer than the patched versions pinned here but sit inside the 7-day `minimumReleaseAge` window; the ranges will pick them up on a later install. Both currently-pinned versions are fully patched against every published advisory.
